### PR TITLE
Fix clipboard copy on HTTP (non-HTTPS) environments

### DIFF
--- a/frontend-react/src/components/addInstance/FactoryManager/FactoryManager.jsx
+++ b/frontend-react/src/components/addInstance/FactoryManager/FactoryManager.jsx
@@ -5,6 +5,7 @@ import CodeMirrorEditor from '../../CodeMirrorEditor';
 import { Loader2, File as FileIcon, Maximize, Copy } from 'lucide-react';
 import NewFactoryModal from './NewFactoryModal';
 import FullScreenConfigEditorModal from '../../config/FullScreenConfigEditorModal';
+import { copyToClipboard } from '../../../utils/clipboard';
 
 // Using a simple JSON syntax highlighter might be better if factories are JSON-like,
 // but they are usually JSON-ish or proprietary. Python or just generic config is often fine.
@@ -359,7 +360,7 @@ function FactoryManager({
     const handleCopyContent = () => {
         const content = getCurrentContent();
         if (content) {
-            navigator.clipboard.writeText(content);
+            copyToClipboard(content);
         }
     };
 

--- a/frontend-react/src/components/addInstance/InstanceConfigTabs.jsx
+++ b/frontend-react/src/components/addInstance/InstanceConfigTabs.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Tab } from '@headlessui/react';
 import { Maximize, Copy } from 'lucide-react';
 import { classNames } from '../../utils/uiUtils';
+import { copyToClipboard } from '../../utils/clipboard';
 import CodeMirrorEditor from '../CodeMirrorEditor';
 import FileUploadButton from '../FileUploadButton';
 import { qlcfgLanguage } from '../../codemirror-lang-qlcfg';
@@ -22,7 +23,7 @@ function InstanceConfigTabs({
 }) {
   const handleCopyContent = (fileName) => {
     const content = configContents[fileName] || '';
-    navigator.clipboard.writeText(content);
+    copyToClipboard(content);
   };
 
   return (

--- a/frontend-react/src/components/config/ConfigEditorTabs.jsx
+++ b/frontend-react/src/components/config/ConfigEditorTabs.jsx
@@ -4,6 +4,7 @@ import { Maximize, Copy } from 'lucide-react';
 import CodeMirrorEditor from '../CodeMirrorEditor';
 import FileUploadButton from '../FileUploadButton';
 import { classNames } from '../../utils/uiUtils';
+import { copyToClipboard } from '../../utils/clipboard';
 
 function ConfigEditorTabs({
   configFilesOrder,
@@ -18,7 +19,7 @@ function ConfigEditorTabs({
 }) {
   const handleCopyContent = (fileName) => {
     const content = configs[fileName] || '';
-    navigator.clipboard.writeText(content);
+    copyToClipboard(content);
   };
 
   return (

--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -8,6 +8,7 @@ import StatusIndicator from '../StatusIndicator';
 import { formatDateTime } from '../../utils/uiUtils';
 import { formatVultrRegion, formatVultrPlan } from '../../utils/formatters';
 import { HostStatus, QLFILTER_STATUS } from '../../utils/statusEnums';
+import { copyToClipboard } from '../../utils/clipboard';
 import { validateHostName, HOST_NAME_MAX_LENGTH } from '../../utils/resourceValidation';
 
 export default function HostDetailDrawer({
@@ -82,7 +83,7 @@ export default function HostDetailDrawer({
 
   const handleCopyIp = () => {
     if (internalHost?.ip_address) {
-      navigator.clipboard.writeText(internalHost.ip_address).then(() => {
+      copyToClipboard(internalHost.ip_address).then(() => {
         setIpCopied(true);
         setTimeout(() => setIpCopied(false), 2000);
         addNotification('IP Address copied to clipboard!', 'success');

--- a/frontend-react/src/components/instances/InstanceDetailsModal.jsx
+++ b/frontend-react/src/components/instances/InstanceDetailsModal.jsx
@@ -9,6 +9,7 @@ import StatusIndicator from '../StatusIndicator';
 import QlColorString from '../common/QlColorString';
 import LiveServerStatusModal from './LiveServerStatusModal';
 import { validateInstanceName, INSTANCE_NAME_MAX_LENGTH } from '../../utils/resourceValidation';
+import { copyToClipboard } from '../../utils/clipboard';
 
 const POLLING_INTERVAL = 3000;
 const POLLABLE_STATUSES = ['PENDING', 'DEPLOYING', 'CONFIGURING', 'STARTING', 'STOPPING', 'RESTARTING', 'DELETING'];
@@ -148,7 +149,7 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
 
   const handleCopyIp = (ipAddress) => {
     if (!ipAddress) return;
-    navigator.clipboard.writeText(ipAddress).then(() => {
+    copyToClipboard(ipAddress).then(() => {
       setIpCopied(true); addNotification('IP Address copied to clipboard!', 'success');
       setTimeout(() => setIpCopied(false), 2000);
     }).catch(() => addNotification('Failed to copy IP address.', 'error'));
@@ -156,7 +157,7 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
 
   const handleCopyText = (text, field) => {
     if (!text) return;
-    navigator.clipboard.writeText(text).then(() => {
+    copyToClipboard(text).then(() => {
       setCopiedField(field);
       addNotification('Copied to clipboard!', 'success');
       setTimeout(() => setCopiedField(null), 2000);

--- a/frontend-react/src/components/instances/InstancesTableRow.jsx
+++ b/frontend-react/src/components/instances/InstancesTableRow.jsx
@@ -3,6 +3,7 @@ import { LoaderCircle, AlertTriangle, Zap, Copy, Check } from 'lucide-react'; //
 import { formatStatus } from '../../utils/formatters';
 import InstanceActionsMenu from '../InstanceActionsMenu'; // Path relative to InstancesTableRow.jsx
 import { useNotification } from '../NotificationProvider'; // Added for copy notification
+import { copyToClipboard } from '../../utils/clipboard';
 import InfoTooltip from '../common/InfoTooltip';
 
 function InstancesTableRow({
@@ -23,7 +24,7 @@ function InstancesTableRow({
 
   const handleCopyIp = (ipAddress) => {
     if (!ipAddress) return;
-    navigator.clipboard.writeText(ipAddress).then(() => {
+    copyToClipboard(ipAddress).then(() => {
       setIpCopied(true);
       addNotification('IP Address copied to clipboard!', 'success');
       setTimeout(() => setIpCopied(false), 2000);

--- a/frontend-react/src/hooks/useHosts.js
+++ b/frontend-react/src/hooks/useHosts.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { getHosts, deleteHost } from '../services/api';
 import { useNotification } from '../components/NotificationProvider';
 import { useLoading } from '../contexts/LoadingContext'; // Import useLoading
+import { copyToClipboard as copyTextToClipboard } from '../utils/clipboard';
 
 export const POLLING_INTERVAL = 3000; // 3 seconds
 export const POLLABLE_HOST_STATUSES = ['pending', 'provisioning', 'provisioned_pending_setup', 'deleting', 'rebooting', 'configuring'];
@@ -100,7 +101,7 @@ export function useHosts() {
   };
 
   const copyToClipboard = (text, hostId) => {
-    navigator.clipboard.writeText(text).then(() => {
+    copyTextToClipboard(text).then(() => {
       setCopiedIp(hostId);
       setTimeout(() => setCopiedIp(null), 2000);
     }).catch(err => {

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { copyToClipboard } from '../utils/clipboard';
 import { ChevronDown, ChevronUp, ChevronRight, Plus, Copy, Check, MapPin, GripVertical } from 'lucide-react';
 import { useServers } from '../hooks/useServers';
 import StatusIndicator from '../components/StatusIndicator';
@@ -83,7 +84,7 @@ export default function ServersPage() {
 
     const copyToClipboard = (ip, hostId, e) => {
         e?.stopPropagation();
-        navigator.clipboard.writeText(ip).then(() => {
+        copyToClipboard(ip).then(() => {
             setCopiedIp(hostId);
             addNotification('IP copied to clipboard', 'success');
             setTimeout(() => setCopiedIp(null), 2000);

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { copyToClipboard } from '../utils/clipboard';
+import { copyToClipboard as copyTextToClipboard } from '../utils/clipboard';
 import { ChevronDown, ChevronUp, ChevronRight, Plus, Copy, Check, MapPin, GripVertical } from 'lucide-react';
 import { useServers } from '../hooks/useServers';
 import StatusIndicator from '../components/StatusIndicator';
@@ -84,7 +84,7 @@ export default function ServersPage() {
 
     const copyToClipboard = (ip, hostId, e) => {
         e?.stopPropagation();
-        copyToClipboard(ip).then(() => {
+        copyTextToClipboard(ip).then(() => {
             setCopiedIp(hostId);
             addNotification('IP copied to clipboard', 'success');
             setTimeout(() => setCopiedIp(null), 2000);

--- a/frontend-react/src/pages/SettingsPage.jsx
+++ b/frontend-react/src/pages/SettingsPage.jsx
@@ -4,6 +4,7 @@ import { getApiKey, regenerateApiKey, revokeApiKey } from '../services/api';
 import { useNotification } from '../components/NotificationProvider';
 import ConfirmationModal from '../components/ConfirmationModal';
 import { formatDateTime } from '../utils/uiUtils';
+import { copyToClipboard } from '../utils/clipboard';
 
 function SettingsPage() {
   const [apiKey, setApiKey] = useState(null);
@@ -55,7 +56,7 @@ function SettingsPage() {
 
   const handleCopy = () => {
     if (apiKey?.key) {
-      navigator.clipboard.writeText(apiKey.key);
+      copyToClipboard(apiKey.key);
       showSuccess('API key copied to clipboard.');
     }
   };

--- a/frontend-react/src/utils/clipboard.js
+++ b/frontend-react/src/utils/clipboard.js
@@ -1,0 +1,27 @@
+/**
+ * Copies text to clipboard with a fallback for non-HTTPS environments.
+ * navigator.clipboard is only available in secure contexts (HTTPS/localhost).
+ * The execCommand fallback works on HTTP as well.
+ */
+export function copyToClipboard(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+        return navigator.clipboard.writeText(text);
+    }
+
+    // Fallback for HTTP environments
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    try {
+        document.execCommand('copy');
+        return Promise.resolve();
+    } catch {
+        return Promise.reject(new Error('Copy failed'));
+    } finally {
+        document.body.removeChild(textarea);
+    }
+}

--- a/frontend-react/src/utils/clipboard.js
+++ b/frontend-react/src/utils/clipboard.js
@@ -17,7 +17,7 @@ export function copyToClipboard(text) {
     textarea.focus();
     textarea.select();
     try {
-        document.execCommand('copy');
+        if (!document.execCommand('copy')) throw new Error('Copy failed');
         return Promise.resolve();
     } catch {
         return Promise.reject(new Error('Copy failed'));


### PR DESCRIPTION
## Summary
- Adds `frontend-react/src/utils/clipboard.js` with a `copyToClipboard()` utility
- Falls back to `document.execCommand('copy')` when `navigator.clipboard` is unavailable (HTTP / non-secure context)
- Replaces all direct `navigator.clipboard.writeText()` calls across 9 files

## Root cause
`navigator.clipboard` is only available in secure contexts (HTTPS or localhost). On test/dev servers without TLS, copy buttons silently failed.

## Test plan
- Open the app over HTTP (no certificate) and verify IP copy buttons work
- Verify copy still works on HTTPS production