### PR TITLE
[fix] Improve mobile servers layout

### DIFF
--- a/frontend-react/src/components/instances/InstanceRowContent.jsx
+++ b/frontend-react/src/components/instances/InstanceRowContent.jsx
@@ -23,22 +23,22 @@ export default function InstanceRowContent({
         <>
             <button
                 onClick={() => onOpenDetails(inst.id)}
-                className="text-sm font-medium hover:underline text-left truncate pl-2 text-blue-600 dark:text-blue-400"
+                className="instance-name-cell truncate pl-2 text-left text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
             >
                 {inst.name}
             </button>
             <span
-                className="text-[13px] truncate text-theme-secondary"
+                className="instance-hostname-cell truncate text-[13px] text-theme-secondary"
                 style={{ gridColumn: 'span 2' }}
                 title={inst.hostname}
             >
                 {inst.hostname || '—'}
             </span>
-            <span className="font-mono text-[13px] text-theme-secondary">
+            <span className="instance-port-cell font-mono text-[13px] text-theme-secondary">
                 {inst.port}
             </span>
             <span
-                className={`flex items-center gap-1 text-[12px] font-mono font-semibold ${inst.lan_rate_enabled
+                className={`instance-rate-cell flex items-center gap-1 text-[12px] font-mono font-semibold ${inst.lan_rate_enabled
                     ? 'text-[var(--accent-warning)]'
                     : 'text-theme-muted'
                     }`}
@@ -46,7 +46,7 @@ export default function InstanceRowContent({
                 {inst.lan_rate_enabled && <Zap size={12} />}
                 {inst.lan_rate_enabled ? '99k' : '25k'}
             </span>
-            <span className="flex items-center gap-1.5" title="View live status">
+            <span className="instance-players-cell flex items-center gap-1.5" title="View live status">
                 {serverStatus
                     ? (
                         <button
@@ -63,7 +63,7 @@ export default function InstanceRowContent({
                     : <span className="text-[13px] font-mono text-theme-muted px-2 py-0.5">—</span>
                 }
             </span>
-            <div className="flex items-center gap-4">
+            <div className="instance-status-cell flex items-center gap-4">
                 <StatusIndicator
                     status={inst.status}
                     pollableStatuses={pollableStatuses}
@@ -84,7 +84,7 @@ export default function InstanceRowContent({
                         </a>
                     )}
             </div>
-            <div className="flex justify-end">
+            <div className="instance-actions-cell flex justify-end">
                 <InstanceActionsMenu
                     instance={{
                         ...inst,

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -899,6 +899,130 @@ body {
   border-top-color: var(--surface-border-strong);
 }
 
+@media (max-width: 767px) {
+  .host-header-row,
+  .instances-header-row {
+    display: none;
+  }
+
+  .server-grid {
+    grid-template-columns: 36px minmax(0, 1fr) auto;
+    gap: 8px 12px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .server-grid.host-row,
+  .instance-row-sortable,
+  .instance-row-overlay {
+    align-items: start;
+  }
+
+  .host-row-first-col,
+  .drag-handle {
+    grid-row: 1 / span 3;
+    align-self: start;
+    padding-top: 2px;
+  }
+
+  .host-row > button:nth-child(2) {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 0;
+  }
+
+  .host-row > span:nth-child(3) {
+    grid-column: 2;
+    grid-row: 2;
+    min-width: 0;
+  }
+
+  .host-row > span:nth-child(4) {
+    grid-column: 2;
+    grid-row: 3;
+    min-width: 0;
+  }
+
+  .host-row > div:nth-child(5) {
+    grid-column: 2 / 4 !important;
+    grid-row: 4;
+    min-width: 0;
+    flex-wrap: wrap;
+  }
+
+  .host-row > div:nth-child(6) {
+    grid-column: 3;
+    grid-row: 1;
+    justify-self: end;
+  }
+
+  .host-row > div:nth-child(7) {
+    grid-column: 3;
+    grid-row: 2 / span 2;
+    align-self: start;
+  }
+
+  .instance-name-cell {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 0;
+    padding-left: 0;
+  }
+
+  .instance-status-cell {
+    grid-column: 2;
+    grid-row: 2;
+    min-width: 0;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .instance-hostname-cell {
+    grid-column: 2 / 4;
+    grid-row: 3;
+    min-width: 0;
+  }
+
+  .instance-port-cell,
+  .instance-rate-cell,
+  .instance-players-cell {
+    min-width: 0;
+  }
+
+  .instance-port-cell {
+    grid-column: 2;
+    grid-row: 4;
+  }
+
+  .instance-rate-cell {
+    grid-column: 2;
+    grid-row: 5;
+  }
+
+  .instance-players-cell {
+    grid-column: 3;
+    grid-row: 4 / span 2;
+    justify-self: end;
+    align-self: start;
+  }
+
+  .instance-actions-cell {
+    grid-column: 3;
+    grid-row: 1;
+    justify-self: end;
+    align-self: start;
+  }
+
+  .add-instance-area {
+    padding-inline: 12px;
+  }
+
+  .add-instance-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 .btn-connect:hover .connect-tooltip {
   display: block;
 }

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -899,7 +899,7 @@ body {
   border-top-color: var(--surface-border-strong);
 }
 
-@media (max-width: 767px) {
+@media (max-width: 639px) {
   .host-header-row,
   .instances-header-row {
     display: none;
@@ -925,38 +925,38 @@ body {
     padding-top: 2px;
   }
 
-  .host-row > button:nth-child(2) {
+  .host-name-cell {
     grid-column: 2;
     grid-row: 1;
     min-width: 0;
   }
 
-  .host-row > span:nth-child(3) {
+  .host-provider-cell {
     grid-column: 2;
     grid-row: 2;
     min-width: 0;
   }
 
-  .host-row > span:nth-child(4) {
+  .host-region-cell {
     grid-column: 2;
     grid-row: 3;
     min-width: 0;
   }
 
-  .host-row > div:nth-child(5) {
+  .host-ip-cell {
     grid-column: 2 / 4 !important;
     grid-row: 4;
     min-width: 0;
     flex-wrap: wrap;
   }
 
-  .host-row > div:nth-child(6) {
+  .host-status-cell {
     grid-column: 3;
     grid-row: 1;
     justify-self: end;
   }
 
-  .host-row > div:nth-child(7) {
+  .host-actions-cell {
     grid-column: 3;
     grid-row: 2 / span 2;
     align-self: start;

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -197,22 +197,22 @@ export default function ServersPage() {
                                 </div>
                                 <button
                                     onClick={(e) => { e.stopPropagation(); handleOpenHostDrawer(host.id); }}
-                                    className="text-[15px] font-semibold hover:underline text-left truncate"
+                                    className="host-name-cell text-[15px] font-semibold hover:underline text-left truncate"
                                     style={{ color: 'var(--accent-primary)' }}
                                 >
                                     {host.name}
                                 </button>
-                                <span className="text-[13px] capitalize truncate text-theme-secondary">
+                                <span className="host-provider-cell text-[13px] capitalize truncate text-theme-secondary">
                                     {host.provider || 'standalone'}
                                 </span>
-                                <span className="text-[13px] truncate text-theme-secondary flex items-center gap-1.5">
+                                <span className="host-region-cell text-[13px] truncate text-theme-secondary flex items-center gap-1.5">
                                     <MapPin size={14} className="text-theme-muted flex-shrink-0" />
                                     {host.is_standalone
                                         ? (host.timezone || '—')
                                         : (formatVultrRegion(host.region) || '—')
                                     }
                                 </span>
-                                <div className="flex items-center gap-2 truncate" style={{ gridColumn: 'span 3' }} onClick={(e) => e.stopPropagation()}>
+                                <div className="host-ip-cell flex items-center gap-2 truncate" style={{ gridColumn: 'span 3' }} onClick={(e) => e.stopPropagation()}>
                                     <span className="font-mono text-[13px] text-theme-secondary">{host.ip_address || '—'}</span>
                                     {host.ip_address && (
                                         <button onClick={(e) => copyToClipboard(host.ip_address, host.id, e)} className="p-1 text-theme-muted hover:text-theme-secondary rounded transition-colors hover:bg-black/5 dark:hover:bg-white/5">
@@ -220,13 +220,13 @@ export default function ServersPage() {
                                         </button>
                                     )}
                                 </div>
-                                <div>
+                                <div className="host-status-cell">
                                     {(host.qlfilter_status === 'installing' || host.qlfilter_status === 'uninstalling')
                                         ? <StatusIndicator status="configuring" pollableStatuses={['configuring']} />
                                         : <StatusIndicator status={host.status} pollableStatuses={POLLABLE_HOST_STATUSES} />
                                     }
                                 </div>
-                                <div className="flex justify-end" onClick={(e) => e.stopPropagation()}>
+                                <div className="host-actions-cell flex justify-end" onClick={(e) => e.stopPropagation()}>
                                     <HostActionsMenu host={host} handleDelete={(id, name) => requestDeleteHost(id, name)} onOpenDrawer={handleOpenHostDrawer} POLLABLE_STATUSES={POLLABLE_HOST_STATUSES} onInstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'install')} onUninstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'uninstall')} onRequestRestart={handleRequestHostRestart} onOpenUpdateWorkshop={openWorkshopModal} onOpenAutoRestart={openAutoRestartModal} />
                                 </div>
                             </div>

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -120,12 +120,12 @@ export default function ServersPage() {
     }
 
     return (
-        <div className="max-w-[1280px] mx-auto py-8 px-8">
+        <div className="max-w-[1280px] mx-auto px-4 py-6 sm:px-8 sm:py-8">
             {/* Page Header */}
-            <div className="flex items-end justify-between mb-7">
-                <div>
-                    <h1 className="heading-display text-[32px] text-theme-primary tracking-wider">Servers</h1>
-                    <div className="flex gap-5 mt-3">
+            <div className="mb-7 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                <div className="min-w-0">
+                    <h1 className="heading-display text-[28px] tracking-wider text-theme-primary sm:text-[32px]">Servers</h1>
+                    <div className="mt-3 hidden gap-5 sm:flex">
                         <span className="flex items-center gap-1.5 text-sm font-medium text-theme-secondary">
                             <span className="w-2 h-2 rounded-full bg-blue-500" />
                             {stats.totalHosts} Host{stats.totalHosts !== 1 ? 's' : ''}
@@ -140,12 +140,12 @@ export default function ServersPage() {
                         </span>
                     </div>
                 </div>
-                <div className="flex gap-2.5">
-                    <button onClick={allExpanded ? collapseAll : expandAll} className="btn btn-secondary gap-2">
+                <div className="flex flex-col gap-2.5 sm:flex-row sm:flex-wrap sm:justify-end">
+                    <button onClick={allExpanded ? collapseAll : expandAll} className="btn btn-secondary w-full justify-center gap-2 sm:w-auto">
                         {allExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
                         {allExpanded ? 'Collapse All' : 'Expand All'}
                     </button>
-                    <button onClick={() => setIsAddHostModalOpen(true)} className="btn btn-primary gap-2">
+                    <button onClick={() => setIsAddHostModalOpen(true)} className="btn btn-primary w-full justify-center gap-2 sm:w-auto">
                         <Plus size={14} /> Add New Host
                     </button>
                 </div>


### PR DESCRIPTION
## What changed
- reworked the mobile servers grid into a compact multi-row layout
- made the page header actions wrap cleanly on narrow screens
- hid the mobile host/instance/running counters

## Why
The servers page used fixed-width columns that overflowed common phone widths, and the header actions did not wrap.

## Validation
- pnpm exec eslint src/pages/ServersPage.jsx src/components/instances/InstanceRowContent.jsx
- pnpm lint still fails on pre-existing unrelated project issues