### PR TITLE
[fix] Remove mobile navbar overflow

### DIFF
--- a/frontend-react/src/App.jsx
+++ b/frontend-react/src/App.jsx
@@ -19,9 +19,9 @@ function App() {
       <LoadingProvider>
         <NotificationProvider>
           {/* Main container uses CSS variable-based theme class */}
-          <div className="flex flex-col min-h-screen bg-theme-base text-theme-primary">
+          <div className="app-shell flex flex-col min-h-screen bg-theme-base text-theme-primary">
             <Navbar />
-            <main className="flex-grow relative z-0 main-grid-bg">
+            <main className="main-shell flex-grow relative z-0 main-grid-bg">
               <Routes>
                 <Route path="/login" element={<LoginPage />} />
                 <Route element={<ProtectedRoute />}>

--- a/frontend-react/src/components/Navbar.jsx
+++ b/frontend-react/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { Menu, Transition } from '@headlessui/react';
 import ThemeToggleButton from './ThemeToggleButton';
 import { useAuth } from '../contexts/AuthContext';
-import { Settings, Users, ChevronDown, Terminal, LogOut, Server, SlidersHorizontal } from 'lucide-react';
+import { Settings, Users, ChevronDown, Terminal, LogOut, Server, SlidersHorizontal, Menu as MenuIcon } from 'lucide-react';
 
 function Navbar() {
   const navigate = useNavigate();
@@ -112,6 +112,75 @@ function Navbar() {
 
         {/* Right section: Auth + Theme */}
         <div className="navbar-section-right">
+          {isAuthenticated && !passwordChangeRequired && (
+            <Menu as="div" className="navbar-mobile-menu-wrapper">
+              <Menu.Button className="navbar-mobile-menu-trigger" aria-label="Open navigation menu">
+                <MenuIcon size={18} strokeWidth={2.2} />
+              </Menu.Button>
+
+              <Transition
+                as={Fragment}
+                enter="navbar-dropdown-enter"
+                enterFrom="navbar-dropdown-enter-from"
+                enterTo="navbar-dropdown-enter-to"
+                leave="navbar-dropdown-leave"
+                leaveFrom="navbar-dropdown-leave-from"
+                leaveTo="navbar-dropdown-leave-to"
+              >
+                <Menu.Items className="navbar-mobile-menu-panel">
+                  <div className="navbar-dropdown-accent" />
+                  <div className="navbar-dropdown-content">
+                    <Menu.Item>
+                      {({ active }) => (
+                        <Link
+                          to="/servers"
+                          className={`navbar-dropdown-item ${active || isActive('servers') ? 'navbar-dropdown-item-active' : ''}`}
+                        >
+                          <Server size={16} strokeWidth={2} />
+                          <span>Servers</span>
+                        </Link>
+                      )}
+                    </Menu.Item>
+                    <Menu.Item>
+                      {({ active }) => (
+                        <Link
+                          to="/settings/users"
+                          className={`navbar-dropdown-item ${active || location.pathname === '/settings/users' ? 'navbar-dropdown-item-active' : ''}`}
+                        >
+                          <Users size={16} strokeWidth={2} />
+                          <span>User Management</span>
+                        </Link>
+                      )}
+                    </Menu.Item>
+                    <Menu.Item>
+                      {({ active }) => (
+                        <Link
+                          to="/settings"
+                          className={`navbar-dropdown-item ${active || location.pathname === '/settings' ? 'navbar-dropdown-item-active' : ''}`}
+                        >
+                          <SlidersHorizontal size={16} strokeWidth={2} />
+                          <span>API Settings</span>
+                        </Link>
+                      )}
+                    </Menu.Item>
+                    <Menu.Item>
+                      {({ active }) => (
+                        <button
+                          type="button"
+                          onClick={handleLogout}
+                          className={`navbar-dropdown-item navbar-mobile-logout ${active ? 'navbar-dropdown-item-active' : ''}`}
+                        >
+                          <LogOut size={16} strokeWidth={2} />
+                          <span>Logout</span>
+                        </button>
+                      )}
+                    </Menu.Item>
+                  </div>
+                </Menu.Items>
+              </Transition>
+            </Menu>
+          )}
+
           {isAuthenticated ? (
             <button onClick={handleLogout} className="navbar-logout-btn">
               <LogOut size={16} strokeWidth={2} />

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -73,6 +73,8 @@
    ============================================ */
 html {
   scroll-behavior: smooth;
+  width: 100%;
+  overflow-x: clip;
 }
 
 /* Noise texture overlay */
@@ -89,6 +91,15 @@ body {
   font-family: 'Exo 2', system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  width: 100%;
+  overflow-x: clip;
+}
+
+#root,
+.app-shell,
+.main-shell {
+  width: 100%;
+  overflow-x: clip;
 }
 
 /* ============================================
@@ -1341,6 +1352,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 32px;
+  min-width: 0;
   animation: navbar-content-reveal 0.6s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -1361,6 +1373,7 @@ body {
   display: flex;
   align-items: center;
   gap: 20px;
+  min-width: 0;
   animation: navbar-fade-in 0.4s ease-out 0.1s backwards;
 }
 
@@ -1386,6 +1399,7 @@ body {
   text-decoration: none;
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   position: relative;
+  min-width: 0;
 }
 
 .navbar-brand-link::before {
@@ -1495,6 +1509,7 @@ body {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   line-height: 1;
+  min-width: 0;
 }
 
 .navbar-brand-text {
@@ -1879,7 +1894,37 @@ body {
   display: flex;
   align-items: center;
   gap: 12px;
+  min-width: 0;
   animation: navbar-fade-in 0.4s ease-out 0.3s backwards;
+}
+
+.navbar-mobile-menu-wrapper {
+  display: none;
+  position: relative;
+}
+
+.navbar-mobile-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.navbar-mobile-menu-trigger:hover {
+  color: var(--text-primary);
+  background: var(--surface-elevated);
+}
+
+.navbar-mobile-menu-trigger:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }
 
 /* Logout button */
@@ -2016,6 +2061,31 @@ body {
 .navbar-theme-wrapper {
   display: flex;
   align-items: center;
+  min-width: 0;
+}
+
+.navbar-mobile-menu-panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: min(260px, calc(100vw - 24px));
+  background: var(--surface-raised);
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.25),
+    0 0 0 1px var(--surface-border);
+  outline: none;
+  z-index: 70;
+}
+
+.navbar-mobile-logout {
+  width: 100%;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
 }
 
 /* ===== NEUMORPHIC THEME TOGGLE ===== */
@@ -2324,8 +2394,8 @@ body {
     padding: 0 16px;
   }
 
-  .navbar-brand-text-wrapper {
-    font-size: 18px;
+  .navbar-brand-link {
+    padding-right: 0;
   }
 
   .navbar-brand-subtext {
@@ -2336,8 +2406,11 @@ body {
     display: none;
   }
 
-  .navbar-logout-btn span,
-  .navbar-login-btn span {
+  .navbar-brand-text {
+    font-size: 18px;
+  }
+
+  .navbar-logout-btn span {
     display: none;
   }
 
@@ -2345,11 +2418,25 @@ body {
   .navbar-login-btn {
     padding: 8px 12px;
   }
+
+  .navbar-logout-btn,
+  .navbar-divider {
+    display: none;
+  }
+
+  .navbar-mobile-menu-wrapper {
+    display: block;
+  }
 }
 
 @media (max-width: 480px) {
   .navbar-container {
     height: 56px;
+  }
+
+  .navbar-content {
+    gap: 10px;
+    padding: 0 10px;
   }
 
   .navbar-brand-icon-wrapper {
@@ -2363,7 +2450,22 @@ body {
   }
 
   .navbar-section-left {
-    gap: 12px;
+    gap: 8px;
+    flex: 1 1 auto;
+  }
+
+  .navbar-section-right {
+    flex: 0 0 auto;
+    gap: 8px;
+  }
+
+  .navbar-brand-link {
+    gap: 10px;
+  }
+
+  .navbar-brand-text {
+    font-size: 16px;
+    letter-spacing: 0.08em;
   }
 }
 


### PR DESCRIPTION
## What changed
- converted the narrow-screen navbar into a compact mobile header with a menu trigger
- moved authenticated mobile navigation and logout into a dropdown menu
- added app-shell overflow clipping and navbar min-width guards to stop viewport stretching

## Why
On iPhone-sized screens the layout still required horizontal scrolling even when the server list itself no longer needed it. The remaining overflow came from the navbar and shell-level layout behavior.

## Validation
- pnpm exec eslint src/components/Navbar.jsx src/App.jsx src/pages/ServersPage.jsx