### PR TITLE
Feature: Auto-open Add Host modal after first password change

### DIFF
--- a/frontend-react/src/pages/ChangePasswordPage.jsx
+++ b/frontend-react/src/pages/ChangePasswordPage.jsx
@@ -24,7 +24,7 @@ function ChangePasswordPage() {
       await changePassword(password, confirmPassword);
       clearPasswordChangeRequired();
       showSuccess('Password updated successfully.');
-      navigate('/servers', { replace: true });
+      navigate('/servers', { replace: true, state: { openAddHost: true } });
     } catch (err) {
       setError(err.error?.message || err.message || 'Failed to change password.');
     } finally {

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { copyToClipboard as copyTextToClipboard } from '../utils/clipboard';
 import { ChevronDown, ChevronUp, ChevronRight, Plus, Copy, Check, MapPin, GripVertical } from 'lucide-react';
 import { useServers } from '../hooks/useServers';
@@ -37,6 +38,7 @@ import { useServerStatus } from '../hooks/useServerStatus';
 
 export default function ServersPage() {
     const { addNotification, showSuccess, showError } = useNotification();
+
     const {
         serversData, stats, loading, error,
         toggleExpand, expandAll, collapseAll, refreshData,
@@ -79,6 +81,29 @@ export default function ServersPage() {
         const inst = host.instances.find(i => i.id === rconKey.instanceId);
         return inst ? { ...inst, host_id: host.id, host_ip: host.ip_address } : null;
     }, [serversData, rconKey]);
+
+    const location = useLocation();
+    const navigate = useNavigate();
+    const autoOpenRef = useRef(location.state?.openAddHost === true);
+
+    // Clear route state on mount so a page refresh doesn't re-trigger
+    useEffect(() => {
+        if (autoOpenRef.current) {
+            navigate(
+                { pathname: location.pathname, search: location.search, hash: location.hash },
+                { replace: true, state: null }
+            );
+        }
+    }, [location.hash, location.pathname, location.search, navigate]);
+
+    // Auto-open Add Host modal when redirected from change-password with no hosts
+    useEffect(() => {
+        if (!autoOpenRef.current || loading) return;
+        autoOpenRef.current = false; // always disarm after loading resolves
+        if (serversData.length === 0) {
+            setIsAddHostModalOpen(true);
+        }
+    }, [loading, serversData]);
 
     const allExpanded = useMemo(() => serversData.length > 0 && serversData.every(h => h.expanded), [serversData]);
 

--- a/frontend-react/src/pages/__tests__/ChangePasswordPage.test.jsx
+++ b/frontend-react/src/pages/__tests__/ChangePasswordPage.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ChangePasswordPage from '../ChangePasswordPage';
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  clearPasswordChangeRequired: vi.fn(),
+  showSuccess: vi.fn(),
+  changePassword: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ clearPasswordChangeRequired: mocks.clearPasswordChangeRequired }),
+}));
+
+vi.mock('../../components/NotificationProvider', () => ({
+  useNotification: () => ({ showSuccess: mocks.showSuccess }),
+}));
+
+vi.mock('../../services/auth', () => ({
+  changePassword: mocks.changePassword,
+}));
+
+describe('ChangePasswordPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.changePassword.mockResolvedValue({});
+  });
+
+  it('navigates to /servers with openAddHost state on success', async () => {
+    render(<ChangePasswordPage />);
+
+    fireEvent.change(screen.getByLabelText(/new password/i), {
+      target: { value: 'newpassword123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'newpassword123' },
+    });
+    fireEvent.submit(screen.getByRole('button', { name: /save password/i }));
+
+    await waitFor(() => {
+      expect(mocks.navigate).toHaveBeenCalledWith('/servers', {
+        replace: true,
+        state: { openAddHost: true },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What changed

  - pass `state: { openAddHost: true }` when redirecting from `ChangePasswordPage` to `/servers`
  - read and consume that flag in `ServersPage`
  - auto-open the Add Host modal once loading completes and the user has zero hosts
  - clear the route state with React Router `replace` navigation so it does not re-trigger on refresh and does not clobber
  router history state
  - add a test covering the redirect state from `ChangePasswordPage`

  ## Why

  On a fresh deployment, the user is forced through a password change before any hosts exist. After that redirect, they
  landed on an empty Servers page and still had to manually click `Add New Host`.

  This change makes onboarding continue directly into the host creation flow.

  ## Impact

  - affects only the post-password-change onboarding path
  - users with zero hosts get the Add Host modal automatically once
  - users with existing hosts see no behavior change