### PR TITLE
[codex] Sync GitHub Pages landing page with README

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>QLSM — Quake Live Server Management</title>
-<meta name="description" content="Web UI for managing Quake Live dedicated servers via Terraform and Ansible. Flask + React + SQLite + Redis. Deploy instances, edit configs, restart servers from a browser.">
+<meta name="description" content="QLSM — Quake Live Server Management. Web UI for managing Quake Live dedicated servers with self-deployment, standalone remote servers, and VULTR provisioning.">
 <style>
   body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 800px; margin: 40px auto; padding: 0 20px; color: #24292e; line-height: 1.6; }
   h1 { font-size: 2em; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; }
@@ -14,6 +14,8 @@
   pre code { background: none; padding: 0; }
   a { color: #0366d6; }
   ul { padding-left: 1.5em; }
+  li { margin: 0.35em 0; }
+  img { max-width: 100%; height: auto; border-radius: 8px; border: 1px solid #eaecef; margin: 16px 0; }
   .github-link { display: inline-block; margin: 10px 0 20px; padding: 8px 16px; background: #24292e; color: #fff; border-radius: 6px; text-decoration: none; font-weight: bold; }
   .github-link:hover { background: #444; color: #fff; }
 </style>
@@ -24,9 +26,43 @@
 
 <a class="github-link" href="https://github.com/dngrtech/qlsm">View on GitHub</a>
 
-<p>I built this because managing Quake Live dedicated servers without tooling means a lot of SSH sessions, manual config edits, and copy-pasting commands. QLSM wraps that into a web UI — deploy instances, edit configs, restart servers, monitor status, all from a browser.</p>
+<h2>Features</h2>
 
-<p>Bring your own VPS. If you want to provision new hosts on Vultr, there's Terraform for that. Everything else runs over SSH via Ansible.</p>
+<ul>
+  <li>Three deployment modes (Debian 12 and Ubuntu 22 are tested and recommended):
+    <ul>
+      <li>QLSM self-deployment: run QLDS instances on the same machine as QLSM</li>
+      <li>Standalone remote server</li>
+      <li>VULTR cloud provisioning via Terraform</li>
+    </ul>
+  </li>
+  <li>Optional 99k LAN rate mode. Only Debian 12 supports this feature</li>
+  <li>Optional <code>QLFilter</code> deployment for supported hosts (anti-DDOS protection)</li>
+  <li>Per-instance RCON console with command line and live feed of all server events</li>
+  <li>Live server status with current map, gametype, mode/factory, match timer, player list, and scores</li>
+  <li>Syntax-aware editors (CodeMirror) for <code>server.cfg</code>, <code>mappool.txt</code>, <code>access.txt</code>, and <code>workshop.txt</code>, featuring a Python linter for minqlx plugin's code validation. The editor includes search and replace functionality for easy editing</li>
+  <li>Upload common config files, factories, custom minqlx plugins, or <code>*.so</code> binary files</li>
+  <li>Preset manager to load/save/update/delete qlds presets. Each preset includes custom <code>server.cfg</code>, <code>access.cfg</code>, <code>mappool.cfg</code>, <code>workshop.txt</code>, set of minqlx-plugins and <code>*.factories</code> files
+    <ul>
+      <li>Minqlx plugins can be enabled in the UI by selecting checkboxes. This eliminates the need to manually edit the <code>qlx_plugins</code> cvar, as QLSM handles it automatically.</li>
+      <li>UI-driven Factory Management: Enable factories directly via checkboxes</li>
+    </ul>
+  </li>
+  <li>Chat logs (including rotated archived chat log files) and server logs retrieval with convenient search capability</li>
+  <li>Daily/weekly/monthly host auto-restart scheduling; scheduled restarts trigger workshop refresh across deployed instances</li>
+  <li>Manual workshop item update by Steam Workshop ID, with optional restart of selected instances</li>
+  <li>ZMQ RCON Port, ZMQ RCON Password, ZMQ Stats Port, ZMQ Stats Password - all these cvars are auto-generated and shown in the UI</li>
+  <li>User management: create users, delete users, and reset passwords</li>
+  <li>External API key management for service-to-service access</li>
+  <li>External REST API for authenticated instance inventory lookups</li>
+  <li>Per-user host/instance ordering and expanded-state preferences stored in browser local storage</li>
+</ul>
+
+<p>Everything runs over SSH via Ansible.</p>
+
+<img width="1428" height="993" alt="servers_page" src="https://github.com/user-attachments/assets/11894a0e-19df-492e-8da7-d69b5ff01d8a">
+
+<img width="1258" height="1218" alt="edit_config" src="https://github.com/user-attachments/assets/23cbf0dd-b291-46af-941b-74ad802c746b">
 
 <h2>Stack</h2>
 
@@ -34,24 +70,26 @@
 
 <h2>Requirements</h2>
 
-<p>You need a Linux VPS (Ubuntu 22.04 or newer recommended) with:</p>
+<p>Ubuntu 22.04 or newer recommended:</p>
 <ul>
   <li><strong>Docker</strong> — <a href="https://docs.docker.com/engine/install/ubuntu/">install guide</a></li>
   <li><strong>Docker Compose</strong> (usually included with Docker)</li>
   <li>A user with <code>sudo</code> access</li>
 </ul>
 
+<p>Redis, Caddy, the app itself run inside Docker.</p>
+
 <p>To install Docker on a fresh Ubuntu server:</p>
 <pre><code>curl -fsSL https://get.docker.com | sh
 sudo usermod -aG docker $USER
 newgrp docker</code></pre>
 
-<h2>Quick start (production)</h2>
+<h2>Quick start</h2>
 
-<h3>Option 1 — one-liner (recommended)</h3>
+<h3>Option 1 — one-liner</h3>
 <pre><code>curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-install.sh | bash</code></pre>
 
-<p>With a domain (enables HTTPS via Caddy):</p>
+<p>With a custom domain (enables HTTPS via Caddy):</p>
 <pre><code>SITE_ADDRESS=qlds.example.com bash &lt;(curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-install.sh)</code></pre>
 
 <h3>Option 2 — git clone</h3>
@@ -67,11 +105,17 @@ docker compose up -d</code></pre>
 
 <p>Downloads the latest <code>docker-compose.yml</code>, pulls the new image, and restarts. Your <code>.env</code> and data are untouched.</p>
 
+<p>Full setup guide: <a href="https://github.com/dngrtech/qlsm/blob/main/docs/setup.md">docs/setup.md</a></p>
+
 <h2>Development</h2>
 <pre><code>cp .env.example .env
 ./run-dev.sh</code></pre>
 
 <p>That starts Flask, Vite, an RQ worker, the RCON service, and a status poller together. Flask ends up on <code>:5001</code>, frontend on <code>:5173</code>.</p>
+
+<p>Redis needs to be running locally for dev (it's included automatically in the Docker stack for production):</p>
+<pre><code># Ubuntu/Debian
+sudo apt install redis-server && sudo systemctl enable --now redis</code></pre>
 
 <pre><code>pytest tests/</code></pre>
 


### PR DESCRIPTION
## Summary
- update `index.html` so the GitHub Pages site reflects the current README content
- add the current feature list, screenshots, and refreshed install/update/development copy to the landing page
- keep the static page aligned with the repository front page instead of the older marketing copy

## Why
The GitHub Pages site at `https://dngrtech.github.io/qlsm/` was still serving older content and no longer matched the current README.

## Impact
- visitors to the GitHub Pages site now see the same top-level product and setup information as the repository landing page
- the static page includes the newer features section and screenshots

## Validation
- reviewed the rendered HTML diff for `index.html`
- verified the page content now matches the current README sections that should appear on the landing page

## Notes
- no code or runtime behavior changed; this is a static content update only