### PR TITLE
[codex] Simplify empty-state Add Host CTA

### DIFF
--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -167,15 +167,17 @@ export default function ServersPage() {
                         </span>
                     </div>
                 </div>
-                <div className="flex flex-col gap-2.5 sm:flex-row sm:flex-wrap sm:justify-end">
-                    <button onClick={allExpanded ? collapseAll : expandAll} className="btn btn-secondary w-full justify-center gap-2 sm:w-auto">
-                        {allExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-                        {allExpanded ? 'Collapse All' : 'Expand All'}
-                    </button>
-                    <button onClick={() => setIsAddHostModalOpen(true)} className="btn btn-primary w-full justify-center gap-2 sm:w-auto">
-                        <Plus size={14} /> Add New Host
-                    </button>
-                </div>
+                {serversData.length > 0 && (
+                    <div className="flex flex-col gap-2.5 sm:flex-row sm:flex-wrap sm:justify-end">
+                        <button onClick={allExpanded ? collapseAll : expandAll} className="btn btn-secondary w-full justify-center gap-2 sm:w-auto">
+                            {allExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                            {allExpanded ? 'Collapse All' : 'Expand All'}
+                        </button>
+                        <button onClick={() => setIsAddHostModalOpen(true)} className="btn btn-primary w-full justify-center gap-2 sm:w-auto">
+                            <Plus size={14} /> Add New Host
+                        </button>
+                    </div>
+                )}
             </div>
 
             {/* Content */}


### PR DESCRIPTION
## Summary
- hide the header action group when the Servers page has no hosts
- keep the empty state as the single place to start adding a host
- preserve the existing header controls once hosts exist

## Why
The empty Servers screen showed two separate `Add New Host` buttons at the same time, which made the page feel visually duplicated and less intentional.

## Impact
Users landing on an empty install now see one clear call to action instead of two competing controls.

## Validation
- linted `frontend-react/src/pages/ServersPage.jsx`
- manually reviewed the one-file diff