### PR TITLE
Fix expanded config editor theme and add expand button for plugin files

### DIFF
--- a/frontend-react/src/components/ExpandedEditorModal.jsx
+++ b/frontend-react/src/components/ExpandedEditorModal.jsx
@@ -12,10 +12,6 @@ function ExpandedEditorModal({
   language,
   linterSource,
 }) {
-  const handleContentChangeInternal = (newContent) => {
-    onContentChange(newContent);
-  };
-
   return (
     <Transition appear show={isOpen} as={Fragment}>
       <Dialog as="div" className="relative z-[70]" onClose={onClose}>
@@ -65,7 +61,7 @@ function ExpandedEditorModal({
                 <div className="relative z-10 flex-grow overflow-hidden min-h-0 p-1">
                   <CodeMirrorEditor
                     value={fileContent}
-                    onChange={handleContentChangeInternal}
+                    onChange={onContentChange}
                     language={language}
                     linterSource={linterSource}
                     isActiveTab={true}

--- a/frontend-react/src/components/ExpandedEditorModal.jsx
+++ b/frontend-react/src/components/ExpandedEditorModal.jsx
@@ -1,103 +1,93 @@
-import React, { Fragment } from 'react'; // Removed useState, useEffect
+import React, { Fragment } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import CodeMirrorEditor from './CodeMirrorEditor';
-// ConfirmationModal no longer needed here
 import { X } from 'lucide-react';
 
 function ExpandedEditorModal({
   isOpen,
-  onClose, // This will now be called directly
+  onClose,
   fileName,
   fileContent,
-  onContentChange, // Content changes are propagated up
+  onContentChange,
   language,
   linterSource,
 }) {
-  // Unsaved changes logic (isDirty, showCloseConfirmExpanded, initialContent, related functions) removed.
-  // The parent modal (EditInstanceConfigModal) will handle unsaved changes for the overall configuration.
-
-  // When CodeMirror content changes, just propagate it.
   const handleContentChangeInternal = (newContent) => {
     onContentChange(newContent);
   };
 
-  // All close actions (backdrop, Esc, X button, Done button) will directly call the onClose prop.
   return (
-    <>
-      <Transition appear show={isOpen} as={Fragment}>
-        <Dialog as="div" className="relative z-[70]" onClose={onClose}>
-          <Transition.Child
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="fixed inset-0 bg-black/30 dark:bg-black/50" />
-          </Transition.Child>
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-[70]" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="modal-backdrop fixed inset-0" aria-hidden="true" />
+        </Transition.Child>
 
-          <div className="fixed inset-0 overflow-y-auto">
-            <div className="flex min-h-full items-center justify-center p-4 text-center">
-              <Transition.Child
-                as={Fragment}
-                enter="ease-out duration-300"
-                enterFrom="opacity-0 scale-95"
-                enterTo="opacity-100 scale-100"
-                leave="ease-in duration-200"
-                leaveFrom="opacity-100 scale-100"
-                leaveTo="opacity-0 scale-95"
-              >
-                {/* Changed sizing and structure to match FullScreenConfigEditorModal */}
-                <Dialog.Panel className="flex flex-col w-[95vw] h-[95vh] transform overflow-hidden rounded-lg bg-white dark:bg-slate-800 text-left align-middle shadow-xl transition-all">
-                  <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-slate-700">
-                    <Dialog.Title
-                      as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900 dark:text-slate-100"
-                    >
-                      Editing: {fileName}
-                    </Dialog.Title>
-                    <button
-                      type="button"
-                      className="p-1 rounded-md text-gray-400 hover:text-gray-500 dark:text-slate-400 dark:hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-600"
-                      onClick={onClose} // Directly call onClose
-                      aria-label="Close editor"
-                    >
-                      <X size={24} />
-                    </button>
-                  </div>
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="modal-panel flex flex-col w-[95vw] h-[95vh] transform overflow-hidden text-left align-middle transition-all">
+                <div className="accent-line-top" />
 
-                  {/* Editor takes remaining space */}
-                  <div className="flex-grow overflow-hidden min-h-0 p-1"> {/* Added p-1 for slight padding around editor */}
-                    <CodeMirrorEditor
-                      value={fileContent}
-                      onChange={handleContentChangeInternal}
-                      language={language}
-                      linterSource={linterSource}
-                      isActiveTab={true}
-                      height="100%" // Ensure CodeMirror takes full height of this div
-                    />
-                  </div>
+                <div className="relative z-10 flex items-center justify-between p-4 border-b border-[var(--surface-border)]">
+                  <Dialog.Title
+                    as="h3"
+                    className="font-display text-lg font-semibold tracking-wider uppercase text-theme-primary"
+                  >
+                    Editing: {fileName}
+                  </Dialog.Title>
+                  <button
+                    type="button"
+                    className="logs-modal-close-btn"
+                    onClick={onClose}
+                    aria-label="Close editor"
+                  >
+                    <X size={16} />
+                  </button>
+                </div>
 
-                  {/* Footer with Done button */}
-                  <div className="flex justify-end items-center p-4 border-t border-gray-200 dark:border-slate-700">
-                    <button
-                      type="button"
-                      className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:bg-indigo-500 dark:hover:bg-indigo-600"
-                      onClick={onClose} // Directly call onClose
-                    >
-                      Done
-                    </button>
-                  </div>
-                </Dialog.Panel>
-              </Transition.Child>
-            </div>
+                <div className="relative z-10 flex-grow overflow-hidden min-h-0 p-1">
+                  <CodeMirrorEditor
+                    value={fileContent}
+                    onChange={handleContentChangeInternal}
+                    language={language}
+                    linterSource={linterSource}
+                    isActiveTab={true}
+                    height="100%"
+                  />
+                </div>
+
+                <div className="relative z-10 flex justify-end items-center p-4 border-t border-[var(--surface-border)]">
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={onClose}
+                  >
+                    Done
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
           </div>
-        </Dialog>
-      </Transition>
-      {/* ConfirmationModal removed from here */}
-    </>
+        </div>
+      </Dialog>
+    </Transition>
   );
 }
 

--- a/frontend-react/src/components/addInstance/ScriptManager/ScriptManager.jsx
+++ b/frontend-react/src/components/addInstance/ScriptManager/ScriptManager.jsx
@@ -36,6 +36,7 @@ const ScriptManager = forwardRef(function ScriptManager({
   onCheck,
   loading,
   error,
+  onExpandEditor,
 }, ref) {
   const [selectedFile, setSelectedFile] = useState(null);
   const [currentContent, setCurrentContent] = useState('');
@@ -53,7 +54,14 @@ const ScriptManager = forwardRef(function ScriptManager({
     setEditedContent({});
   }, [editedContent, writeContent]);
 
-  useImperativeHandle(ref, () => ({ flushEdits }), [flushEdits]);
+  const updateContent = useCallback((path, content) => {
+    setEditedContent(prev => ({ ...prev, [path]: content }));
+    if (selectedFile?.path === path) {
+      setCurrentContent(content);
+    }
+  }, [selectedFile]);
+
+  useImperativeHandle(ref, () => ({ flushEdits, updateContent }), [flushEdits, updateContent]);
 
   const handleSelectFile = useCallback(async (item) => {
     if (item.type === 'folder') return;
@@ -227,6 +235,7 @@ const ScriptManager = forwardRef(function ScriptManager({
             onChange={handleContentChange}
             isDirty={isDirty}
             isLoading={contentLoading}
+            onExpand={onExpandEditor ? () => onExpandEditor(selectedFile, currentContent) : undefined}
           />
         )}
       </div>

--- a/frontend-react/src/components/addInstance/ScriptManager/TextFileEditor.jsx
+++ b/frontend-react/src/components/addInstance/ScriptManager/TextFileEditor.jsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { CheckCircle, XCircle, RefreshCw } from 'lucide-react';
+import { CheckCircle, XCircle, RefreshCw, Maximize } from 'lucide-react';
 import CodeMirrorEditor from '../../CodeMirrorEditor';
 import { python } from '@codemirror/lang-python';
 import { validateScript } from '../../../services/api';
@@ -11,7 +11,7 @@ function getFileType(path) {
 }
 
 export default function TextFileEditor({
-  filePath, content, onChange, isDirty, isLoading,
+  filePath, content, onChange, isDirty, isLoading, onExpand,
 }) {
   const [lintStatus, setLintStatus] = useState(null);
   const [lintErrors, setLintErrors] = useState([]);
@@ -68,6 +68,16 @@ export default function TextFileEditor({
                 Validate
               </button>
             </>
+          )}
+          {onExpand && (
+            <button
+              type="button"
+              onClick={onExpand}
+              className="p-1 hover:bg-[var(--surface-base)] rounded transition-colors text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              title="Expand editor"
+            >
+              <Maximize size={14} />
+            </button>
           )}
         </div>
       </div>

--- a/frontend-react/src/components/addInstance/ScriptManager/TextFileEditor.jsx
+++ b/frontend-react/src/components/addInstance/ScriptManager/TextFileEditor.jsx
@@ -75,6 +75,7 @@ export default function TextFileEditor({
               onClick={onExpand}
               className="p-1 hover:bg-[var(--surface-base)] rounded transition-colors text-[var(--text-muted)] hover:text-[var(--text-primary)]"
               title="Expand editor"
+              aria-label="Expand editor"
             >
               <Maximize size={14} />
             </button>

--- a/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
+++ b/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, Fragment, useCallback } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { X, LoaderCircle, Zap, AlertTriangle, Settings, Code2, LayoutGrid, Save, FolderOpen } from 'lucide-react';
+import { python } from '@codemirror/lang-python';
 import { getInstanceConfig, updateInstanceConfig, getInstanceById, getPresets, getPresetById, createPreset, updateInstance } from '../../services/api';
 import { useDraftWorkspace } from '../../hooks/useDraftWorkspace';
 import ConfigEditorTabs from '../config/ConfigEditorTabs';
@@ -80,6 +81,7 @@ function EditInstanceConfigModal({
   const [expandedFileContent, setExpandedFileContent] = useState('');
   const [expandedFileLanguage, setExpandedFileLanguage] = useState(null);
   const [expandedFileLinterSource, setExpandedFileLinterSource] = useState(null);
+  const [expandedPluginPath, setExpandedPluginPath] = useState(null);
 
   // State for preset modals
   const [isLoadPresetModalOpen, setIsLoadPresetModalOpen] = useState(false);
@@ -425,6 +427,7 @@ function EditInstanceConfigModal({
   };
 
   const handleExpandEditor = (fileNameToExpand) => {
+    setExpandedPluginPath(null);
     setExpandedFileName(fileNameToExpand);
     setExpandedFileContent(configs[fileNameToExpand] || '');
     setExpandedFileLanguage(getLanguageForFile(fileNameToExpand));
@@ -432,10 +435,25 @@ function EditInstanceConfigModal({
     setIsExpandedEditorOpen(true);
   };
 
+  const handleExpandPluginEditor = useCallback((selectedFile, content) => {
+    setExpandedPluginPath(selectedFile.path);
+    setExpandedFileName(selectedFile.name);
+    setExpandedFileContent(content);
+    setExpandedFileLanguage(selectedFile.name.endsWith('.py') ? python() : null);
+    setExpandedFileLinterSource(null);
+    setIsExpandedEditorOpen(true);
+  }, []);
+
   const handleExpandedEditorContentChange = (newContent) => {
-    setExpandedFileContent(newContent); // Update content for the expanded editor
-    setConfigs(prev => ({ ...prev, [expandedFileName]: newContent })); // Update main configs state
-    setIsDirty(true); // Mark main modal as dirty due to changes from expanded editor
+    setExpandedFileContent(newContent);
+    if (expandedPluginPath) {
+      if (scriptManagerRef.current?.updateContent) {
+        scriptManagerRef.current.updateContent(expandedPluginPath, newContent);
+      }
+    } else {
+      setConfigs(prev => ({ ...prev, [expandedFileName]: newContent }));
+    }
+    setIsDirty(true);
   };
 
   const handleCloseExpandedEditor = () => {
@@ -694,6 +712,7 @@ function EditInstanceConfigModal({
                               onCheck={togglePluginSelection}
                               loading={draft.loading}
                               error={draft.error}
+                              onExpandEditor={handleExpandPluginEditor}
                             />
                           ) : (
                             <FactoryManager


### PR DESCRIPTION
## Summary
- Expanded editor now matches the parent Edit Config modal's dark theme (uses `modal-panel`/`modal-backdrop` design system) instead of blueish `slate` Tailwind colors
- Plugins tab's `TextFileEditor` gains a Maximize button that opens the same expanded editor with Python syntax highlighting; edits sync back via a new `updateContent` imperative handle on `ScriptManager`

## Test plan
- [ ] Open Edit Configuration modal for an instance → colors match previous dark theme
- [ ] Press Expand in a config tab → expanded editor background is dark, not blueish
- [ ] Switch to Plugins tab, select a `.py` file → Maximize button appears in editor header
- [ ] Click Maximize → expanded editor opens with Python highlighting
- [ ] Edit in expanded editor → changes persist after closing (saved with config)