### PR TITLE
Fix Validate button truncation in plugin file editor

### DIFF
--- a/frontend-react/src/components/addInstance/ScriptManager/TextFileEditor.jsx
+++ b/frontend-react/src/components/addInstance/ScriptManager/TextFileEditor.jsx
@@ -46,11 +46,11 @@ export default function TextFileEditor({
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center justify-between px-3 py-2 border-b border-gray-700">
-        <div className="flex items-center gap-2 text-sm text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-gray-400 min-w-0 flex-1">
           <span className="truncate">{filePath}</span>
-          {isDirty && <span className="text-yellow-500 text-xs">(modified)</span>}
+          {isDirty && <span className="text-yellow-500 text-xs flex-shrink-0">(modified)</span>}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-shrink-0">
           {isPython && (
             <>
               {lintStatus === 'valid' && (


### PR DESCRIPTION
## Summary
- Add `min-w-0 flex-1` to the filename container so it truncates properly instead of squishing adjacent buttons
- Add `flex-shrink-0` to the buttons container so Validate/Expand are never clipped
- Add `flex-shrink-0` to the "(modified)" indicator for the same reason

## Test plan
- [ ] Open the Plugins tab and select a `.py` file with a long filename — Validate button should be fully visible
- [ ] Confirm Validate button appears consistently across all `.py` files
- [ ] Confirm the expand icon is always visible