### PR TITLE
Fix editor panel stretching when plugin files have long lines

### DIFF
--- a/frontend-react/src/components/addInstance/ScriptManager/ScriptManager.jsx
+++ b/frontend-react/src/components/addInstance/ScriptManager/ScriptManager.jsx
@@ -213,7 +213,7 @@ const ScriptManager = forwardRef(function ScriptManager({
           onCheck={onCheck}
         />
       </div>
-      <div className="flex-1 bg-[var(--surface-base)]">
+      <div className="flex-1 min-w-0 bg-[var(--surface-base)]">
         {!selectedFile ? (
           <div className="flex items-center justify-center h-full text-gray-500 text-sm">
             Select a file to view or edit


### PR DESCRIPTION
## Summary
- PR #13 fixed truncation of the Validate button inside the header, but didn't address the root cause: the right-pane flex container lacked `min-w-0`, so long CodeMirror lines (e.g. in `mydiscordbot.py`) grew the panel wider than the modal
- The outer modal has `overflow-hidden`, which then clipped the header entirely — Validate button vanished on some files, was partially visible on others
- Adding `min-w-0` to the `flex-1` right pane in `ScriptManager.jsx` lets the flex child respect the parent's width; CodeMirror's own horizontal scroll handles long lines

## Test plan
- [ ] Open Plugins tab, click through files with long lines (`mydiscordbot.py`, `commands.py`) — Validate button stays fully visible
- [ ] Confirm code view scrolls horizontally within the editor pane rather than pushing the header off-screen
- [ ] Confirm other files (`log.py`, `essentials.py`) still render correctly