### PR TITLE
Document cron-based auto-update in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ INSTALL_DIR=/opt/qlsm bash <(curl -fsSL https://raw.githubusercontent.com/dngrte
 
 Downloads the latest `docker-compose.yml`, pulls the new image, and restarts. Your `.env` and data are untouched.
 
+### Auto-update via cron
+
+To run the updater automatically (daily at 9 AM local time):
+
+```bash
+# Default install (~/qlsm):
+(crontab -l 2>/dev/null; echo "0 9 * * * curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-install.sh | bash -s -- --update >> \$HOME/qlsm-update.log 2>&1") | crontab -
+
+# Vultr / system install (/opt/qlsm) — install under root:
+sudo bash -c '(crontab -l 2>/dev/null; echo "0 9 * * * INSTALL_DIR=/opt/qlsm bash <(curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-install.sh) --update >> /var/log/qlsm-update.log 2>&1") | crontab -'
+```
+
+Adjust `0 9 * * *` to change the schedule (minute hour day month weekday). Review `crontab -l` to verify.
+
 Full setup guide: [docs/setup.md](docs/setup.md)
 
 ## Development


### PR DESCRIPTION
## Summary
- Add an "Auto-update via cron" subsection under the Updating section of README
- Provide two ready-to-paste one-liners: one for default (`~/qlsm`) installs and one for root-managed (`/opt/qlsm`) Vultr installs, both scheduled daily at 09:00 local time
- Logs written to `~/qlsm-update.log` (user) or `/var/log/qlsm-update.log` (system)

## Test plan
- [ ] Render README on GitHub — verify new subsection appears under Updating
- [ ] Paste the user-install one-liner on a test box and confirm `crontab -l` shows the entry