### PR TITLE
Fix drawer button hierarchy and color consistency

### DIFF
--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -303,12 +303,12 @@ export default function HostDetailDrawer({
                         ? <><LoaderCircle size={14} className="animate-spin" /> Rebooting...</>
                         : <><PowerIcon size={14} /> Restart</>}
                     </button>
-                    <button type="button" onClick={handleDeleteClick} disabled={internalHost?.status === 'deleting'} className="btn btn-danger gap-1.5">
-                      {internalHost?.is_standalone ? 'Remove' : 'Delete'}
-                    </button>
                     <button type="button" onClick={() => qlBtn.action?.()} disabled={qlBtn.disabled}
                       className={`btn ${qlBtn.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} gap-1.5`}>
                       <qlBtn.Icon size={14} className={qlBtn.loading ? 'animate-spin' : ''} /> {qlBtn.text}
+                    </button>
+                    <button type="button" onClick={handleDeleteClick} disabled={internalHost?.status === 'deleting'} className="btn btn-danger gap-1.5">
+                      {internalHost?.is_standalone ? 'Remove' : 'Delete'}
                     </button>
                   </div>
                 )}

--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -296,21 +296,20 @@ export default function HostDetailDrawer({
                 {/* Footer Actions */}
                 {internalHost && !loading && !error && (
                   <div className="drawer-footer">
+                    <button type="button" onClick={onClose} className="btn btn-ghost">Close</button>
                     <button type="button" onClick={() => internalHost && onRequestRestart?.(internalHost)} disabled={isRestartDisabled}
-                      className="btn btn-secondary gap-1.5" style={!isRestartDisabled ? { borderColor: 'var(--accent-warning)', color: 'var(--accent-warning)' } : {}}>
+                      className="btn btn-secondary gap-1.5">
                       {internalHost?.status?.toLowerCase() === HostStatus.REBOOTING.toLowerCase()
                         ? <><LoaderCircle size={14} className="animate-spin" /> Rebooting...</>
                         : <><PowerIcon size={14} /> Restart</>}
                     </button>
-                    <button type="button" onClick={() => qlBtn.action?.()} disabled={qlBtn.disabled}
-                      className={`btn ${qlBtn.variant === 'primary' ? 'btn-primary' : qlBtn.variant === 'warning' ? 'btn-secondary' : 'btn-secondary'} gap-1.5`}
-                      style={qlBtn.variant === 'warning' && !qlBtn.disabled ? { borderColor: '#f59e0b', color: '#f59e0b' } : {}}>
-                      <qlBtn.Icon size={14} className={qlBtn.loading ? 'animate-spin' : ''} /> {qlBtn.text}
-                    </button>
                     <button type="button" onClick={handleDeleteClick} disabled={internalHost?.status === 'deleting'} className="btn btn-danger gap-1.5">
                       {internalHost?.is_standalone ? 'Remove' : 'Delete'}
                     </button>
-                    <button type="button" onClick={onClose} className="btn btn-secondary">Close</button>
+                    <button type="button" onClick={() => qlBtn.action?.()} disabled={qlBtn.disabled}
+                      className={`btn ${qlBtn.variant === 'primary' ? 'btn-primary' : 'btn-secondary'} gap-1.5`}>
+                      <qlBtn.Icon size={14} className={qlBtn.loading ? 'animate-spin' : ''} /> {qlBtn.text}
+                    </button>
                   </div>
                 )}
               </div>

--- a/frontend-react/src/components/instances/InstanceDetailsModal.jsx
+++ b/frontend-react/src/components/instances/InstanceDetailsModal.jsx
@@ -426,15 +426,15 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
                       <RefreshCw size={14} className={actionLoading && statusUpper === 'RESTARTING' ? 'animate-spin' : ''} />
                       {actionLoading && statusUpper === 'RESTARTING' ? 'Restarting...' : 'Restart'}
                     </button>
-                    <button type="button" onClick={() => setIsDeleteModalOpen(true)}
-                      disabled={actionLoading || ['DELETING', 'DEPLOYING', 'CONFIGURING'].includes(statusUpper)}
-                      className="btn btn-danger gap-1.5">
-                      <Trash2 size={14} /> {actionLoading && statusUpper === 'DELETING' ? 'Deleting...' : 'Delete'}
-                    </button>
                     <button type="button" onClick={() => { if (instance) onOpenEditConfig(instance); onClose(); }}
                       disabled={actionLoading || ['DEPLOYING', 'CONFIGURING'].includes(statusUpper)}
                       className="btn btn-primary gap-1.5">
                       <Edit3 size={14} /> Edit Config
+                    </button>
+                    <button type="button" onClick={() => setIsDeleteModalOpen(true)}
+                      disabled={actionLoading || ['DELETING', 'DEPLOYING', 'CONFIGURING'].includes(statusUpper)}
+                      className="btn btn-danger gap-1.5">
+                      <Trash2 size={14} /> {actionLoading && statusUpper === 'DELETING' ? 'Deleting...' : 'Delete'}
                     </button>
                   </div>
                 )}

--- a/frontend-react/src/components/instances/InstanceDetailsModal.jsx
+++ b/frontend-react/src/components/instances/InstanceDetailsModal.jsx
@@ -412,22 +412,17 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
                 {/* Footer Actions */}
                 {instance && !loading && !error && (
                   <div className="drawer-footer">
-                    <button type="button" onClick={() => { if (instance) onOpenEditConfig(instance); onClose(); }}
-                      disabled={actionLoading || ['DEPLOYING', 'CONFIGURING'].includes(statusUpper)}
-                      className="btn btn-secondary gap-1.5" style={{ borderColor: '#3b82f6', color: '#3b82f6' }}>
-                      <Edit3 size={14} /> Edit Config
-                    </button>
+                    <button type="button" onClick={onClose} className="btn btn-ghost">Close</button>
                     <button type="button" onClick={handleStopStart}
                       disabled={actionLoading || isBusyStatus || statusUpper === 'IDLE'}
-                      className="btn btn-secondary gap-1.5"
-                      style={statusUpper === 'STOPPED' ? { borderColor: 'var(--accent-primary)', color: 'var(--accent-primary)' } : isActionableStatus ? { borderColor: 'var(--accent-warning)', color: 'var(--accent-warning)' } : {}}>
+                      className="btn btn-secondary gap-1.5">
                       {statusUpper === 'STOPPED'
                         ? <><Play size={14} /> {actionLoading && statusUpper === 'STARTING' ? 'Starting...' : 'Start'}</>
                         : <><Square size={14} /> {actionLoading && statusUpper === 'STOPPING' ? 'Stopping...' : 'Stop'}</>
                       }
                     </button>
                     <button type="button" onClick={handleRestart} disabled={actionLoading || !isActionableStatus}
-                      className="btn btn-secondary gap-1.5" style={isActionableStatus ? { borderColor: 'var(--accent-warning)', color: 'var(--accent-warning)' } : {}}>
+                      className="btn btn-secondary gap-1.5">
                       <RefreshCw size={14} className={actionLoading && statusUpper === 'RESTARTING' ? 'animate-spin' : ''} />
                       {actionLoading && statusUpper === 'RESTARTING' ? 'Restarting...' : 'Restart'}
                     </button>
@@ -436,7 +431,11 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
                       className="btn btn-danger gap-1.5">
                       <Trash2 size={14} /> {actionLoading && statusUpper === 'DELETING' ? 'Deleting...' : 'Delete'}
                     </button>
-                    <button type="button" onClick={onClose} className="btn btn-secondary">Close</button>
+                    <button type="button" onClick={() => { if (instance) onOpenEditConfig(instance); onClose(); }}
+                      disabled={actionLoading || ['DEPLOYING', 'CONFIGURING'].includes(statusUpper)}
+                      className="btn btn-primary gap-1.5">
+                      <Edit3 size={14} /> Edit Config
+                    </button>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- Simplify button styling in `HostDetailDrawer` and `InstanceDetailsModal` footers.
- Replace ad-hoc inline `borderColor`/`color` overrides (blue, amber, warning) with the existing `btn-primary` / `btn-secondary` / `btn-danger` / `btn-ghost` hierarchy.
- `Edit Config` (instance) and `Install QLFilter` (host) now clearly read as primary actions; `Stop`/`Restart`/`Uninstall` settle into neutral secondary; `Close` uses `btn-ghost` so it no longer competes with operational buttons.
- Establishes a shared button ordering convention across both drawers: Close on the left, destructive (Delete/Remove) distinguished by color rather than position, primary rightmost.

## Motivation
The previous footer had four visually competing buttons with mixed blue/amber/green/red hues, no clear primary action, and inconsistent conventions between the two drawers. This change keeps contrast within theme tokens and reduces color noise.

## Test plan
- [ ] Open an instance drawer; confirm Edit Config stands out as primary, Stop/Restart are neutral, Delete is red, Close reads as dismiss.
- [ ] Open a host drawer with QLFilter not installed; confirm Install QLFilter is primary.
- [ ] Open a host drawer with QLFilter installed; confirm Uninstall QLFilter is neutral (btn-secondary).
- [ ] Verify disabled states and loading spinners still render correctly.