### PR TITLE
Remove redundant Close button from drawer footers

### DIFF
--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -296,7 +296,6 @@ export default function HostDetailDrawer({
                 {/* Footer Actions */}
                 {internalHost && !loading && !error && (
                   <div className="drawer-footer">
-                    <button type="button" onClick={onClose} className="btn btn-ghost">Close</button>
                     <button type="button" onClick={() => internalHost && onRequestRestart?.(internalHost)} disabled={isRestartDisabled}
                       className="btn btn-secondary gap-1.5">
                       {internalHost?.status?.toLowerCase() === HostStatus.REBOOTING.toLowerCase()

--- a/frontend-react/src/components/instances/InstanceDetailsModal.jsx
+++ b/frontend-react/src/components/instances/InstanceDetailsModal.jsx
@@ -412,7 +412,6 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
                 {/* Footer Actions */}
                 {instance && !loading && !error && (
                   <div className="drawer-footer">
-                    <button type="button" onClick={onClose} className="btn btn-ghost">Close</button>
                     <button type="button" onClick={handleStopStart}
                       disabled={actionLoading || isBusyStatus || statusUpper === 'IDLE'}
                       className="btn btn-secondary gap-1.5">


### PR DESCRIPTION
## Summary
- Fixes a visual bug where the instance drawer footer wrapped the Delete button onto a second row that rendered behind the page's bottom bar.
- The drawer header already has an X close button (ESC and outside-click also dismiss), so the footer Close was duplicative.
- With Close gone, Instance drawer = 4 buttons (Stop, Restart, Edit Config, Delete) and Host drawer = 3 buttons (Restart, QLFilter, Delete) fit on a single row at 500px/420px widths respectively.

## Test plan
- [ ] Open instance drawer; all 4 buttons fit one row and are fully visible.
- [ ] Open host drawer; all 3 buttons fit one row.
- [ ] ESC, header X, and clicking outside still close the drawer.