### PR TITLE
Keep host/instance drawers above the footer

### DIFF
--- a/frontend-react/src/App.jsx
+++ b/frontend-react/src/App.jsx
@@ -36,7 +36,10 @@ function App() {
                 </Route>
               </Routes>
             </main>
-            <footer className="relative z-10 bg-theme-raised border-t border-theme p-4 text-center text-sm text-theme-secondary">
+            <footer
+              className="relative z-10 bg-theme-raised border-t border-theme flex items-center justify-center text-sm text-theme-secondary shrink-0"
+              style={{ height: 'var(--footer-height)' }}
+            >
               <span className="font-mono text-xs tracking-wide">
                 QLSM — Quake Live Server Management
               </span>

--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -173,8 +173,14 @@ export default function HostDetailDrawer({
   return (
     <>
       <Transition.Root show={open} as={Fragment}>
-        <div className="fixed inset-0 z-40 overflow-hidden pointer-events-none">
-          <div className="fixed inset-y-0 right-0 flex max-w-full pointer-events-none">
+        <div
+          className="fixed inset-x-0 top-0 z-40 overflow-hidden pointer-events-none"
+          style={{ bottom: 'var(--footer-height)' }}
+        >
+          <div
+            className="fixed top-0 right-0 flex max-w-full pointer-events-none"
+            style={{ bottom: 'var(--footer-height)' }}
+          >
             <Transition.Child as={Fragment} enter="transform transition ease-out duration-300" enterFrom="translate-x-full" enterTo="translate-x-0" leave="transform transition ease-in duration-200" leaveFrom="translate-x-0" leaveTo="translate-x-full">
               <div ref={panelRef} className="drawer-panel w-[420px] pointer-events-auto">
                 {/* Header */}

--- a/frontend-react/src/components/instances/InstanceDetailsModal.jsx
+++ b/frontend-react/src/components/instances/InstanceDetailsModal.jsx
@@ -231,8 +231,14 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
   return (
     <>
       <Transition.Root show={isOpen} as={Fragment}>
-        <div className="fixed inset-0 z-40 overflow-hidden pointer-events-none">
-          <div className="fixed inset-y-0 right-0 flex max-w-full pointer-events-none">
+        <div
+          className="fixed inset-x-0 top-0 z-40 overflow-hidden pointer-events-none"
+          style={{ bottom: 'var(--footer-height)' }}
+        >
+          <div
+            className="fixed top-0 right-0 flex max-w-full pointer-events-none"
+            style={{ bottom: 'var(--footer-height)' }}
+          >
             <Transition.Child as={Fragment} enter="transform transition ease-out duration-300" enterFrom="translate-x-full" enterTo="translate-x-0" leave="transform transition ease-in duration-200" leaveFrom="translate-x-0" leaveTo="translate-x-full">
               <div ref={panelRef} className="drawer-panel w-[500px] pointer-events-auto">
                 {/* Header */}

--- a/frontend-react/src/components/instances/LiveServerStatusModal.jsx
+++ b/frontend-react/src/components/instances/LiveServerStatusModal.jsx
@@ -212,8 +212,14 @@ export default function LiveServerStatusModal({ isOpen, onClose, instance, serve
 
     return (
         <Transition.Root show={isOpen} as={Fragment}>
-            <div className="fixed inset-0 z-40 overflow-hidden pointer-events-none">
-                <div className="fixed inset-y-0 right-0 flex max-w-full pointer-events-none">
+            <div
+                className="fixed inset-x-0 top-0 z-40 overflow-hidden pointer-events-none"
+                style={{ bottom: 'var(--footer-height)' }}
+            >
+                <div
+                    className="fixed top-0 right-0 flex max-w-full pointer-events-none"
+                    style={{ bottom: 'var(--footer-height)' }}
+                >
                     <Transition.Child
                         as={Fragment}
                         enter="transform transition ease-out duration-300"

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -10,6 +10,9 @@
    CSS Custom Properties - Light Theme (default)
    ============================================ */
 :root {
+  /* Layout */
+  --footer-height: 53px;
+
   /* Accent Colors */
   --accent-primary: #0D9668;
   --accent-primary-dim: #087A53;


### PR DESCRIPTION
## Summary
- Side drawers used `fixed inset-y-0`, so their panels extended behind the footer bar and their action buttons ended up lower than the `QLSM — …` footer line.
- Added a `--footer-height` CSS variable (53px), pinned the footer to that height, and offset the three drawers (`HostDetailDrawer`, `InstanceDetailsModal`, `LiveServerStatusModal`) so their bottom edge aligns with the footer top.

## Test plan
- [ ] Open a host drawer and confirm its bottom action row sits flush with the top of the footer (not below it).
- [ ] Repeat for the instance details drawer and the live server status drawer.
- [ ] Resize the viewport vertically and confirm the drawer stays anchored above the footer without overlap.