### PR TITLE
Layer footer over drawer instead of shrinking drawer bounds

### DIFF
--- a/frontend-react/src/App.jsx
+++ b/frontend-react/src/App.jsx
@@ -37,7 +37,7 @@ function App() {
               </Routes>
             </main>
             <footer
-              className="relative z-10 bg-theme-raised border-t border-theme flex items-center justify-center text-sm text-theme-secondary shrink-0"
+              className="sticky bottom-0 z-50 bg-theme-raised border-t border-theme flex items-center justify-center text-sm text-theme-secondary shrink-0"
               style={{ height: 'var(--footer-height)' }}
             >
               <span className="font-mono text-xs tracking-wide">

--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -173,14 +173,8 @@ export default function HostDetailDrawer({
   return (
     <>
       <Transition.Root show={open} as={Fragment}>
-        <div
-          className="fixed inset-x-0 top-0 z-40 overflow-hidden pointer-events-none"
-          style={{ bottom: 'var(--footer-height)' }}
-        >
-          <div
-            className="fixed top-0 right-0 flex max-w-full pointer-events-none"
-            style={{ bottom: 'var(--footer-height)' }}
-          >
+        <div className="fixed inset-0 z-40 overflow-hidden pointer-events-none">
+          <div className="fixed inset-y-0 right-0 flex max-w-full pointer-events-none">
             <Transition.Child as={Fragment} enter="transform transition ease-out duration-300" enterFrom="translate-x-full" enterTo="translate-x-0" leave="transform transition ease-in duration-200" leaveFrom="translate-x-0" leaveTo="translate-x-full">
               <div ref={panelRef} className="drawer-panel w-[420px] pointer-events-auto">
                 {/* Header */}

--- a/frontend-react/src/components/instances/InstanceDetailsModal.jsx
+++ b/frontend-react/src/components/instances/InstanceDetailsModal.jsx
@@ -231,14 +231,8 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
   return (
     <>
       <Transition.Root show={isOpen} as={Fragment}>
-        <div
-          className="fixed inset-x-0 top-0 z-40 overflow-hidden pointer-events-none"
-          style={{ bottom: 'var(--footer-height)' }}
-        >
-          <div
-            className="fixed top-0 right-0 flex max-w-full pointer-events-none"
-            style={{ bottom: 'var(--footer-height)' }}
-          >
+        <div className="fixed inset-0 z-40 overflow-hidden pointer-events-none">
+          <div className="fixed inset-y-0 right-0 flex max-w-full pointer-events-none">
             <Transition.Child as={Fragment} enter="transform transition ease-out duration-300" enterFrom="translate-x-full" enterTo="translate-x-0" leave="transform transition ease-in duration-200" leaveFrom="translate-x-0" leaveTo="translate-x-full">
               <div ref={panelRef} className="drawer-panel w-[500px] pointer-events-auto">
                 {/* Header */}

--- a/frontend-react/src/components/instances/LiveServerStatusModal.jsx
+++ b/frontend-react/src/components/instances/LiveServerStatusModal.jsx
@@ -212,14 +212,8 @@ export default function LiveServerStatusModal({ isOpen, onClose, instance, serve
 
     return (
         <Transition.Root show={isOpen} as={Fragment}>
-            <div
-                className="fixed inset-x-0 top-0 z-40 overflow-hidden pointer-events-none"
-                style={{ bottom: 'var(--footer-height)' }}
-            >
-                <div
-                    className="fixed top-0 right-0 flex max-w-full pointer-events-none"
-                    style={{ bottom: 'var(--footer-height)' }}
-                >
+            <div className="fixed inset-0 z-40 overflow-hidden pointer-events-none">
+                <div className="fixed inset-y-0 right-0 flex max-w-full pointer-events-none">
                     <Transition.Child
                         as={Fragment}
                         enter="transform transition ease-out duration-300"

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1152,6 +1152,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
+  padding-bottom: var(--footer-height);
   background: var(--surface-overlay);
   border-left: 1px solid var(--surface-border);
   box-shadow: -10px 0 40px rgba(15, 23, 42, 0.1);


### PR DESCRIPTION
## Summary
- Previous fix (#18) shortened the drawer's fixed container to stop above the footer. That created a visible gap in the bottom-right strip where the page content leaked through because the drawer stopped covering the host list there.
- Revert the drawer containers to `fixed inset-0` / `fixed inset-y-0`, promote the footer to `sticky bottom-0 z-50` so it overlays the drawer, and add `padding-bottom: var(--footer-height)` to `.drawer-panel` so the drawer's action buttons render above the footer bar instead of behind it.

## Test plan
- [ ] Open the host drawer: action buttons (Configure / Delete / etc.) sit flush above the footer bar; no page content leaks below the drawer.
- [ ] Repeat for the instance details drawer and the live server status drawer.
- [ ] Footer remains a continuous bar across the full viewport width, including the region occupied by the drawer.