### PR TITLE
[codex] Guard Vultr add-host flow when API key is missing

### DIFF
--- a/frontend-react/src/components/hosts/AddHostFormFields.jsx
+++ b/frontend-react/src/components/hosts/AddHostFormFields.jsx
@@ -19,6 +19,8 @@ function AddHostFormFields({
   provider,
   providerListOptions,
   onProviderChange,
+  vultrConfigured,
+  vultrUnavailableMessage,
   selectedContinent,
   onContinentChange,
   vultrContinentOptions,
@@ -48,6 +50,7 @@ function AddHostFormFields({
 }) {
   const isStandalone = provider === 'standalone';
   const isSelf = provider === 'self';
+  const isVultrUnavailable = provider === 'vultr' && !vultrConfigured;
 
   return (
     <>
@@ -90,13 +93,29 @@ function AddHostFormFields({
 
       {/* Cloud provider fields */}
       {!isStandalone && !isSelf && (
-        <>
+        <div
+          data-testid="vultr-cloud-fields"
+          className={`space-y-5 transition-opacity ${isVultrUnavailable ? 'opacity-50' : 'opacity-100'}`}
+        >
+          {isVultrUnavailable && (
+            <div
+              className="rounded-lg px-3.5 py-3 text-sm"
+              style={{
+                background: 'rgba(255, 51, 102, 0.08)',
+                border: '1px solid rgba(255, 51, 102, 0.2)',
+                color: 'var(--accent-danger)',
+              }}
+            >
+              {vultrUnavailableMessage}
+            </div>
+          )}
           {provider === 'vultr' && (
             <FloatingListbox
               label="Continent"
               value={selectedContinent}
               onChange={onContinentChange}
               options={vultrContinentOptions}
+              disabled={isVultrUnavailable}
               getOptionKey={(opt) => opt.id}
               getOptionValue={(opt) => opt.name}
               getOptionDisplay={(opt) => opt.name}
@@ -113,7 +132,7 @@ function AddHostFormFields({
             value={region}
             onChange={onRegionChange}
             options={provider === 'vultr' ? vultrFilteredRegions : (providerOptions[provider]?.regions || [])}
-            disabled={(provider === 'vultr' && !selectedContinent) || (provider !== 'vultr' && (providerOptions[provider]?.regions?.length || 0) === 0)}
+            disabled={isVultrUnavailable || (provider === 'vultr' && !selectedContinent) || (provider !== 'vultr' && (providerOptions[provider]?.regions?.length || 0) === 0)}
             getOptionKey={(opt) => opt.id}
             getOptionDisplay={(opt) => provider === 'vultr' ? `${opt.city} (${opt.country})` : opt.name}
             getSelectedDisplay={(val, opts) => {
@@ -134,7 +153,7 @@ function AddHostFormFields({
             value={machineSize}
             onChange={onMachineSizeChange}
             options={currentSizes}
-            disabled={!provider || currentSizes.length === 0}
+            disabled={isVultrUnavailable || !provider || currentSizes.length === 0}
             getOptionKey={(opt) => opt.id}
             getOptionDisplay={(opt) => opt.name}
             getSelectedDisplay={(val, opts) => {
@@ -144,7 +163,7 @@ function AddHostFormFields({
             }}
             noOptionsMessage="No sizes available for this provider."
           />
-        </>
+        </div>
       )}
 
       {isSelf && (

--- a/frontend-react/src/components/hosts/AddHostModal.jsx
+++ b/frontend-react/src/components/hosts/AddHostModal.jsx
@@ -14,6 +14,18 @@ const PROVIDER_LIST_OPTIONS = [
   { id: 'vultr', name: 'VULTR' },
 ];
 
+const DEFAULT_SELF_HOST_DEFAULTS = {
+  ssh_user: 'root',
+  host_ip: null,
+  provider_capabilities: {
+    vultr: {
+      configured: true,
+    },
+  },
+};
+
+const VULTR_UNAVAILABLE_MESSAGE = 'Vultr deployment is unavailable until VULTR_API_KEY is added to the environment.';
+
 function AddHostModal({ isOpen, onClose, onHostAdded }) {
   const [name, setName] = useState('');
   const [nameError, setNameError] = useState(null);
@@ -27,6 +39,8 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const { showSuccess, showError } = useNotification();
+  const [selfHostDefaults, setSelfHostDefaults] = useState(DEFAULT_SELF_HOST_DEFAULTS);
+  const [vultrConfigured, setVultrConfigured] = useState(true);
 
   // Standalone-specific state
   const [ipAddress, setIpAddress] = useState('');
@@ -44,26 +58,39 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   const availableProviderOptions = PROVIDER_LIST_OPTIONS.filter(
     (option) => option.id !== 'self' || !selfHostExists
   );
+  const isVultrUnavailable = provider === 'vultr' && !vultrConfigured;
 
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
     setProviderOptionsReady(false);
 
-    getHosts()
-      .then((hosts) => {
+    Promise.allSettled([getHosts(), getSelfHostDefaults()])
+      .then(([hostsResult, defaultsResult]) => {
         if (cancelled) return;
-        const hasSelfHost = hosts.some((host) => host.provider === 'self');
-        setSelfHostExists(hasSelfHost);
-        setProvider(hasSelfHost ? 'standalone' : 'self');
-        setProviderOptionsReady(true);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        const message = err.error?.message || err.message || 'Failed to load host options.';
-        showError(message);
-        setSelfHostExists(false);
-        setProvider('self');
+
+        if (hostsResult.status === 'fulfilled') {
+          const hasSelfHost = hostsResult.value.some((host) => host.provider === 'self');
+          setSelfHostExists(hasSelfHost);
+          setProvider(hasSelfHost ? 'standalone' : 'self');
+        } else {
+          const message = hostsResult.reason?.error?.message || hostsResult.reason?.message || 'Failed to load host options.';
+          showError(message);
+          setSelfHostExists(false);
+          setProvider('self');
+        }
+
+        if (defaultsResult.status === 'fulfilled') {
+          const defaults = defaultsResult.value || DEFAULT_SELF_HOST_DEFAULTS;
+          setSelfHostDefaults(defaults);
+          setVultrConfigured(defaults.provider_capabilities?.vultr?.configured ?? true);
+        } else {
+          const message = defaultsResult.reason?.error?.message || defaultsResult.reason?.message || 'Failed to load self-host defaults.';
+          showError(message);
+          setSelfHostDefaults(DEFAULT_SELF_HOST_DEFAULTS);
+          setVultrConfigured(true);
+        }
+
         setProviderOptionsReady(true);
       });
 
@@ -86,23 +113,9 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
 
   useEffect(() => {
     if (!isOpen || !providerOptionsReady || provider !== 'self') return;
-    let cancelled = false;
-
-    getSelfHostDefaults()
-      .then((defaults) => {
-        if (cancelled) return;
-        if (defaults?.ssh_user) setSshUser(defaults.ssh_user);
-        if (defaults?.host_ip) setIpAddress(defaults.host_ip);
-      })
-      .catch((err) => {
-        const message = err.error?.message || err.message || 'Failed to load self-host defaults.';
-        showError(message);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, provider, providerOptionsReady, showError]);
+    setSshUser(selfHostDefaults?.ssh_user || 'root');
+    setIpAddress(selfHostDefaults?.host_ip || '');
+  }, [isOpen, provider, providerOptionsReady, selfHostDefaults]);
 
   const resetForm = () => {
     setName('');
@@ -122,6 +135,8 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
     setTimezone('');
     setConnectionTestStatus('idle');
     setConnectionTestMessage('');
+    setSelfHostDefaults(DEFAULT_SELF_HOST_DEFAULTS);
+    setVultrConfigured(true);
     setProviderOptionsReady(false);
   };
 
@@ -183,6 +198,10 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError(null);
+
+    if (isVultrUnavailable) {
+      return;
+    }
 
     const validationError = validateHostName(name);
     if (validationError) {
@@ -354,8 +373,11 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
                         providerListOptions={availableProviderOptions}
                         onProviderChange={(value) => {
                           setProvider(value);
+                          setError(null);
                           resetConnectionTest();
                         }}
+                        vultrConfigured={vultrConfigured}
+                        vultrUnavailableMessage={VULTR_UNAVAILABLE_MESSAGE}
                         selectedContinent={selectedContinent}
                         onContinentChange={setSelectedContinent}
                         vultrContinentOptions={vultrContinentOptions}
@@ -417,7 +439,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
                     </button>
                     <button
                       type="submit"
-                      disabled={loading || !providerOptionsReady || (provider === 'standalone' && connectionTestStatus !== 'success')}
+                      disabled={loading || !providerOptionsReady || isVultrUnavailable || (provider === 'standalone' && connectionTestStatus !== 'success')}
                       className="px-5 py-2 rounded-lg text-sm font-semibold transition-all disabled:opacity-40 disabled:cursor-not-allowed text-white dark:text-[#0A0E14]"
                       style={{
                         background: 'var(--accent-primary)',

--- a/frontend-react/src/components/hosts/AddHostModal.jsx
+++ b/frontend-react/src/components/hosts/AddHostModal.jsx
@@ -19,7 +19,7 @@ const DEFAULT_SELF_HOST_DEFAULTS = {
   host_ip: null,
   provider_capabilities: {
     vultr: {
-      configured: true,
+      configured: false,
     },
   },
 };
@@ -40,7 +40,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   const [loading, setLoading] = useState(false);
   const { showSuccess, showError } = useNotification();
   const [selfHostDefaults, setSelfHostDefaults] = useState(DEFAULT_SELF_HOST_DEFAULTS);
-  const [vultrConfigured, setVultrConfigured] = useState(true);
+  const [vultrConfigured, setVultrConfigured] = useState(false);
 
   // Standalone-specific state
   const [ipAddress, setIpAddress] = useState('');
@@ -88,7 +88,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
           const message = defaultsResult.reason?.error?.message || defaultsResult.reason?.message || 'Failed to load self-host defaults.';
           showError(message);
           setSelfHostDefaults(DEFAULT_SELF_HOST_DEFAULTS);
-          setVultrConfigured(true);
+          setVultrConfigured(false);
         }
 
         setProviderOptionsReady(true);
@@ -136,7 +136,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
     setConnectionTestStatus('idle');
     setConnectionTestMessage('');
     setSelfHostDefaults(DEFAULT_SELF_HOST_DEFAULTS);
-    setVultrConfigured(true);
+    setVultrConfigured(false);
     setProviderOptionsReady(false);
   };
 

--- a/frontend-react/src/components/hosts/__tests__/AddHostFormFields.test.jsx
+++ b/frontend-react/src/components/hosts/__tests__/AddHostFormFields.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AddHostFormFields from '../AddHostFormFields';
+
+vi.mock('../../common/FloatingListbox', () => ({
+  default: ({ label, disabled = false }) => (
+    <div
+      data-testid={`listbox-${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}
+      data-disabled={disabled ? 'true' : 'false'}
+    >
+      {label}
+    </div>
+  ),
+}));
+
+function renderFields(props = {}) {
+  return render(
+    <AddHostFormFields
+      name="cloud-host"
+      onNameChange={vi.fn()}
+      nameError={null}
+      onNameBlur={vi.fn()}
+      provider="vultr"
+      providerListOptions={[
+        { id: 'self', name: 'QLSM Host (self-deployment)' },
+        { id: 'standalone', name: 'Standalone' },
+        { id: 'vultr', name: 'VULTR' },
+      ]}
+      onProviderChange={vi.fn()}
+      vultrConfigured={false}
+      vultrUnavailableMessage="Vultr deployment is unavailable until VULTR_API_KEY is added to the environment."
+      selectedContinent="North America"
+      onContinentChange={vi.fn()}
+      vultrContinentOptions={[{ id: 'north-america', name: 'North America' }]}
+      region=""
+      onRegionChange={vi.fn()}
+      vultrFilteredRegions={[{ id: 'ewr', city: 'New Jersey', country: 'US' }]}
+      machineSize=""
+      onMachineSizeChange={vi.fn()}
+      currentSizes={[{ id: 'vc2-1c-1gb', name: 'vc2-1c-1gb' }]}
+      ipAddress=""
+      onIpAddressChange={vi.fn()}
+      sshPort={22}
+      onSshPortChange={vi.fn()}
+      sshUser="root"
+      onSshUserChange={vi.fn()}
+      standaloneAuthMethod="key"
+      onStandaloneAuthMethodChange={vi.fn()}
+      sshKey=""
+      onSshKeyChange={vi.fn()}
+      sshPassword=""
+      onSshPasswordChange={vi.fn()}
+      timezone=""
+      onTimezoneChange={vi.fn()}
+      connectionTestStatus="idle"
+      connectionTestMessage=""
+      onTestConnection={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+describe('AddHostFormFields', () => {
+  it('shows the Vultr env warning and disables cloud controls when Vultr is unavailable', () => {
+    renderFields();
+
+    expect(screen.getByText(/Vultr deployment is unavailable until VULTR_API_KEY is added to the environment\./i)).toBeInTheDocument();
+    expect(screen.getByTestId('vultr-cloud-fields')).toHaveClass('opacity-50');
+    expect(screen.getByTestId('listbox-provider')).toHaveAttribute('data-disabled', 'false');
+    expect(screen.getByTestId('listbox-continent')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByTestId('listbox-region')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByTestId('listbox-machine-size-plan')).toHaveAttribute('data-disabled', 'true');
+  });
+});

--- a/frontend-react/src/components/hosts/__tests__/AddHostModal.test.jsx
+++ b/frontend-react/src/components/hosts/__tests__/AddHostModal.test.jsx
@@ -32,6 +32,7 @@ vi.mock('../AddHostFormFields', () => ({
     <div>
       <div data-testid="provider-value">{props.provider}</div>
       <div data-testid="auth-method-value">{props.standaloneAuthMethod || ''}</div>
+      <div data-testid="vultr-configured">{String(props.vultrConfigured)}</div>
       {(props.providerListOptions || []).map((option) => (
         <div key={option.id}>{option.name}</div>
       ))}
@@ -41,6 +42,9 @@ vi.mock('../AddHostFormFields', () => ({
       )}
       {(props.providerListOptions || []).some((option) => option.id === 'standalone') && (
         <button type="button" onClick={() => props.onProviderChange('standalone')}>Choose standalone</button>
+      )}
+      {(props.providerListOptions || []).some((option) => option.id === 'vultr') && (
+        <button type="button" onClick={() => props.onProviderChange('vultr')}>Choose vultr</button>
       )}
       <button type="button" onClick={() => props.onTimezoneChange('UTC')}>Set timezone</button>
       <input aria-label="Server address" value={props.ipAddress || ''} onChange={props.onIpAddressChange} />
@@ -60,7 +64,11 @@ describe('AddHostModal self provider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getHosts.mockResolvedValue([]);
-    mocks.getSelfHostDefaults.mockResolvedValue({ ssh_user: 'rage', host_ip: '203.0.113.10' });
+    mocks.getSelfHostDefaults.mockResolvedValue({
+      ssh_user: 'rage',
+      host_ip: '203.0.113.10',
+      provider_capabilities: { vultr: { configured: true } },
+    });
   });
 
   it('defaults to self when no self host exists and omits linode', async () => {
@@ -97,12 +105,12 @@ describe('AddHostModal self provider', () => {
     render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
 
     await waitFor(() => expect(mocks.getHosts).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mocks.getSelfHostDefaults).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.getByTestId('provider-value')).toHaveTextContent('standalone'));
     expect(screen.queryByText('QLSM Host (self-deployment)')).not.toBeInTheDocument();
     expect(screen.getByText('Standalone')).toBeInTheDocument();
     expect(screen.getByText('VULTR')).toBeInTheDocument();
     expect(screen.queryByText(/linode/i)).not.toBeInTheDocument();
-    expect(mocks.getSelfHostDefaults).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: /choose self/i })).not.toBeInTheDocument();
   });
 
@@ -158,5 +166,25 @@ describe('AddHostModal self provider', () => {
       ssh_password: 'bootstrap-secret',
       timezone: 'UTC',
     }));
+  });
+
+  it('disables Vultr submission when the env-backed capability is unavailable', async () => {
+    mocks.getSelfHostDefaults.mockResolvedValue({
+      ssh_user: 'rage',
+      host_ip: '203.0.113.10',
+      provider_capabilities: { vultr: { configured: false } },
+    });
+
+    render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
+
+    await waitFor(() => expect(mocks.getSelfHostDefaults).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: /choose vultr/i }));
+
+    await waitFor(() => expect(screen.getByTestId('provider-value')).toHaveTextContent('vultr'));
+    expect(screen.getByTestId('vultr-configured')).toHaveTextContent('false');
+    expect(screen.getByRole('button', { name: /add host/i })).toBeDisabled();
+
+    fireEvent.submit(screen.getByRole('button', { name: /add host/i }).closest('form'));
+    expect(mocks.createHost).not.toHaveBeenCalled();
   });
 });

--- a/frontend-react/src/services/__tests__/api.test.js
+++ b/frontend-react/src/services/__tests__/api.test.js
@@ -30,12 +30,19 @@ describe('getSelfHostDefaults', () => {
 
   it('fetches self-host defaults', async () => {
     mocks.get.mockResolvedValue({
-      data: { data: { ssh_user: 'rage', host_ip: '203.0.113.10' } },
+      data: {
+        data: {
+          ssh_user: 'rage',
+          host_ip: '203.0.113.10',
+          provider_capabilities: { vultr: { configured: false } },
+        },
+      },
     });
 
     await expect(getSelfHostDefaults()).resolves.toEqual({
       ssh_user: 'rage',
       host_ip: '203.0.113.10',
+      provider_capabilities: { vultr: { configured: false } },
     });
     expect(mocks.get).toHaveBeenCalledWith('/hosts/self/defaults');
   });

--- a/tests/test_host_api_routes.py
+++ b/tests/test_host_api_routes.py
@@ -154,6 +154,20 @@ def test_create_host_cloud_missing_region(client, app):
     assert response.status_code == 400
 
 
+def test_create_vultr_host_requires_configured_api_key(client, app, monkeypatch):
+    """Vultr host creation is blocked when the runtime API key is missing."""
+    monkeypatch.delenv('VULTR_API_KEY', raising=False)
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.post('/api/hosts/', headers=headers, json={
+        'name': 'missing-vultr-key',
+        'provider': 'vultr',
+        'region': 'ewr',
+        'machine_size': 'vc2-1c-1gb'
+    })
+    assert response.status_code == 400
+    assert 'VULTR_API_KEY' in response.get_json()['error']['message']
+
+
 def test_create_host_unauthenticated(client, app):
     """Unauthenticated request returns 401."""
     response = client.post('/api/hosts/', json={
@@ -415,25 +429,30 @@ def test_create_standalone_host_rejects_unsafe_ssh_user(client, app):
 
 
 @patch('ui.routes.host_routes.detect_default_self_ssh_user', return_value='rage')
-def test_get_self_host_defaults_no_env(mock_user, client, app):
+def test_get_self_host_defaults_no_env(mock_user, client, app, monkeypatch):
     """Without QLSM_HOST_IP env var, host_ip is None."""
+    monkeypatch.delenv('QLSM_HOST_IP', raising=False)
+    monkeypatch.delenv('VULTR_API_KEY', raising=False)
     headers = auth_headers(app, DEFAULT_USER)
     response = client.get('/api/hosts/self/defaults', headers=headers)
     assert response.status_code == 200
     data = response.get_json()['data']
     assert data['ssh_user'] == 'rage'
     assert data['host_ip'] is None
+    assert data['provider_capabilities']['vultr']['configured'] is False
 
 
 @patch('ui.routes.host_routes.detect_default_self_ssh_user', return_value='rage')
 def test_get_self_host_defaults_with_env(mock_user, client, app, monkeypatch):
     """QLSM_HOST_IP env var is returned as host_ip."""
     monkeypatch.setenv('QLSM_HOST_IP', '203.0.113.10')
+    monkeypatch.setenv('VULTR_API_KEY', 'test-vultr-key')
     headers = auth_headers(app, DEFAULT_USER)
     response = client.get('/api/hosts/self/defaults', headers=headers)
     assert response.status_code == 200
     data = response.get_json()['data']
     assert data['host_ip'] == '203.0.113.10'
+    assert data['provider_capabilities']['vultr']['configured'] is True
 
 
 @patch('ui.routes.host_routes.enqueue_task')

--- a/ui/routes/host_routes.py
+++ b/ui/routes/host_routes.py
@@ -72,6 +72,10 @@ VALID_TIMEZONES = {
     'Pacific/Auckland', 'Pacific/Honolulu', 'UTC',
 }
 
+
+def is_vultr_configured():
+    return bool(os.environ.get('VULTR_API_KEY', '').strip())
+
 # Import task functions
 from ui.tasks import provision_host, destroy_host, \
     install_qlfilter_task, uninstall_qlfilter_task, check_qlfilter_status_task, \
@@ -135,6 +139,13 @@ def _handle_cloud_host_creation(name, provider, data):
     region = data.get('region')
     machine_size = data.get('machine_size')
     timezone = data.get('timezone')
+
+    if provider == 'vultr' and not is_vultr_configured():
+        return jsonify({
+            "error": {
+                "message": "Vultr deployment is unavailable until VULTR_API_KEY is added to the environment."
+            }
+        }), 400
 
     if not region or not machine_size:
         return jsonify({"error": {"message": "Region and Machine Size are required for cloud providers."}}), 400
@@ -556,7 +567,17 @@ def _handle_standalone_host_creation(name, data):
 def get_self_host_defaults_api():
     ssh_user = detect_default_self_ssh_user()
     host_ip = os.environ.get('QLSM_HOST_IP', '').strip() or None
-    return jsonify({"data": {"ssh_user": ssh_user, "host_ip": host_ip}})
+    return jsonify({
+        "data": {
+            "ssh_user": ssh_user,
+            "host_ip": host_ip,
+            "provider_capabilities": {
+                "vultr": {
+                    "configured": is_vultr_configured(),
+                }
+            },
+        }
+    })
 
 
 def _validate_self_ssh_user(value):


### PR DESCRIPTION
## Summary
- expose a backend capability flag for whether Vultr is configured in the runtime environment
- block Vultr host creation when `VULTR_API_KEY` is missing
- show an inline warning in the Add Host modal, dim/disable Vultr deployment controls, and disable the Add Host button when Vultr is unavailable
- add focused backend and frontend tests for the guarded flow

## Validation
- `pytest tests/test_host_api_routes.py -k "vultr or self_host_defaults"`
- `pnpm exec vitest run src/components/hosts/__tests__/AddHostModal.test.jsx src/components/hosts/__tests__/AddHostFormFields.test.jsx src/services/__tests__/api.test.js`
- `pnpm exec eslint src/components/hosts/AddHostModal.jsx src/components/hosts/AddHostFormFields.jsx src/components/hosts/__tests__/AddHostModal.test.jsx src/components/hosts/__tests__/AddHostFormFields.test.jsx src/services/__tests__/api.test.js`