### PR TITLE
Self-host OS auto-detect with Ubuntu warning

### DIFF
--- a/frontend-react/src/components/hosts/AddHostFormFields.jsx
+++ b/frontend-react/src/components/hosts/AddHostFormFields.jsx
@@ -47,6 +47,7 @@ function AddHostFormFields({
   connectionTestStatus,
   connectionTestMessage,
   onTestConnection,
+  osInfo,
 }) {
   const isStandalone = provider === 'standalone';
   const isSelf = provider === 'self';
@@ -184,6 +185,7 @@ function AddHostFormFields({
             onSshUserChange={onSshUserChange}
             timezone={timezone}
             onTimezoneChange={onTimezoneChange}
+            osInfo={osInfo}
           />
         </>
       )}

--- a/frontend-react/src/components/hosts/AddHostModal.jsx
+++ b/frontend-react/src/components/hosts/AddHostModal.jsx
@@ -41,6 +41,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   const { showSuccess, showError } = useNotification();
   const [selfHostDefaults, setSelfHostDefaults] = useState(DEFAULT_SELF_HOST_DEFAULTS);
   const [vultrConfigured, setVultrConfigured] = useState(false);
+  const [selfHostOsInfo, setSelfHostOsInfo] = useState(null);
 
   // Standalone-specific state
   const [ipAddress, setIpAddress] = useState('');
@@ -83,6 +84,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
         if (defaultsResult.status === 'fulfilled') {
           const defaults = defaultsResult.value || DEFAULT_SELF_HOST_DEFAULTS;
           setSelfHostDefaults(defaults);
+          setSelfHostOsInfo(defaults.os_info || null);
           setVultrConfigured(defaults.provider_capabilities?.vultr?.configured ?? true);
         } else {
           const message = defaultsResult.reason?.error?.message || defaultsResult.reason?.message || 'Failed to load self-host defaults.';
@@ -136,6 +138,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
     setConnectionTestStatus('idle');
     setConnectionTestMessage('');
     setSelfHostDefaults(DEFAULT_SELF_HOST_DEFAULTS);
+    setSelfHostOsInfo(null);
     setVultrConfigured(false);
     setProviderOptionsReady(false);
   };
@@ -404,6 +407,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
                         connectionTestStatus={connectionTestStatus}
                         connectionTestMessage={connectionTestMessage}
                         onTestConnection={handleTestConnection}
+                        osInfo={selfHostOsInfo}
                       />
                     ) : (
                       <div className="text-sm text-theme-muted">Loading host options...</div>

--- a/frontend-react/src/components/hosts/SelfHostFields.jsx
+++ b/frontend-react/src/components/hosts/SelfHostFields.jsx
@@ -8,9 +8,24 @@ const inputFocusRing = 'focus:ring-[var(--accent-primary)] focus:border-[var(--a
 const inputStyle = { background: 'var(--surface-elevated)', border: '1px solid var(--surface-border)' };
 const labelClass = 'block text-sm font-medium text-theme-secondary';
 
-function SelfHostFields({ ipAddress, onIpAddressChange, sshUser, onSshUserChange, timezone, onTimezoneChange }) {
+function SelfHostFields({ ipAddress, onIpAddressChange, sshUser, onSshUserChange, timezone, onTimezoneChange, osInfo }) {
   return (
     <>
+      {osInfo && (
+        <p className="text-xs text-theme-secondary">
+          Detected OS: {osInfo.pretty_name}
+        </p>
+      )}
+
+      {osInfo?.os_type === 'ubuntu' && (
+        <p
+          className="text-xs font-medium"
+          style={{ color: 'var(--accent-danger)' }}
+        >
+          Warning: 99k LAN rate is not compatible with Ubuntu.
+        </p>
+      )}
+
       <div>
         <label htmlFor="modal-self-ip" className={labelClass}>
           <span className="inline-flex items-center gap-1.5">

--- a/tests/test_host_api_routes.py
+++ b/tests/test_host_api_routes.py
@@ -428,8 +428,9 @@ def test_create_standalone_host_rejects_unsafe_ssh_user(client, app):
     assert 'SSH username contains invalid characters' in response.get_json()['error']['message']
 
 
+@patch('ui.routes.host_routes.detect_local_os', return_value=None)
 @patch('ui.routes.host_routes.detect_default_self_ssh_user', return_value='rage')
-def test_get_self_host_defaults_no_env(mock_user, client, app, monkeypatch):
+def test_get_self_host_defaults_no_env(mock_user, mock_os, client, app, monkeypatch):
     """Without QLSM_HOST_IP env var, host_ip is None."""
     monkeypatch.delenv('QLSM_HOST_IP', raising=False)
     monkeypatch.delenv('VULTR_API_KEY', raising=False)
@@ -442,8 +443,9 @@ def test_get_self_host_defaults_no_env(mock_user, client, app, monkeypatch):
     assert data['provider_capabilities']['vultr']['configured'] is False
 
 
+@patch('ui.routes.host_routes.detect_local_os', return_value=None)
 @patch('ui.routes.host_routes.detect_default_self_ssh_user', return_value='rage')
-def test_get_self_host_defaults_with_env(mock_user, client, app, monkeypatch):
+def test_get_self_host_defaults_with_env(mock_user, mock_os, client, app, monkeypatch):
     """QLSM_HOST_IP env var is returned as host_ip."""
     monkeypatch.setenv('QLSM_HOST_IP', '203.0.113.10')
     monkeypatch.setenv('VULTR_API_KEY', 'test-vultr-key')
@@ -453,6 +455,36 @@ def test_get_self_host_defaults_with_env(mock_user, client, app, monkeypatch):
     data = response.get_json()['data']
     assert data['host_ip'] == '203.0.113.10'
     assert data['provider_capabilities']['vultr']['configured'] is True
+
+
+@patch('ui.routes.host_routes.detect_local_os', return_value={
+    'pretty_name': 'Debian GNU/Linux 12 (bookworm)',
+    'os_type': 'debian',
+})
+@patch('ui.routes.host_routes.detect_default_self_ssh_user', return_value='rage')
+def test_get_self_host_defaults_includes_os_info(mock_user, mock_os, client, app, monkeypatch):
+    """os_info is returned when local OS detection succeeds."""
+    monkeypatch.delenv('QLSM_HOST_IP', raising=False)
+    monkeypatch.delenv('VULTR_API_KEY', raising=False)
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.get('/api/hosts/self/defaults', headers=headers)
+    assert response.status_code == 200
+    data = response.get_json()['data']
+    assert data['os_info']['pretty_name'] == 'Debian GNU/Linux 12 (bookworm)'
+    assert data['os_info']['os_type'] == 'debian'
+
+
+@patch('ui.routes.host_routes.detect_local_os', return_value=None)
+@patch('ui.routes.host_routes.detect_default_self_ssh_user', return_value='rage')
+def test_get_self_host_defaults_os_info_none_when_detection_fails(mock_user, mock_os, client, app, monkeypatch):
+    """os_info is None when local OS detection fails."""
+    monkeypatch.delenv('QLSM_HOST_IP', raising=False)
+    monkeypatch.delenv('VULTR_API_KEY', raising=False)
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.get('/api/hosts/self/defaults', headers=headers)
+    assert response.status_code == 200
+    data = response.get_json()['data']
+    assert data['os_info'] is None
 
 
 @patch('ui.routes.host_routes.enqueue_task')

--- a/tests/test_standalone_ssh.py
+++ b/tests/test_standalone_ssh.py
@@ -221,7 +221,7 @@ def test_detect_remote_os_marks_unsupported_release(mock_client_cls):
     )
 
     assert detected["pretty_name"] == "Ubuntu 18.04.6 LTS"
-    assert detected["os_type"] is None
+    assert detected["os_type"] == "ubuntu"
 
 
 @patch("ui.standalone_ssh.paramiko.SSHClient")

--- a/tests/test_standalone_ssh.py
+++ b/tests/test_standalone_ssh.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 from unittest.mock import MagicMock
+from unittest.mock import mock_open
 from unittest.mock import patch
 
 import paramiko
 import pytest
 
 from ui.standalone_ssh import _AuditedAutoAddPolicy
+from ui.standalone_ssh import detect_local_os
 from ui.standalone_ssh import _format_host_key_fingerprint
 from ui.standalone_ssh import StandaloneSSHError
 from ui.standalone_ssh import bootstrap_managed_key
@@ -229,3 +231,25 @@ def test_bootstrap_managed_key_fails_when_password_login_rejected(mock_client_cl
     with patch("ui.standalone_ssh.verify_password_login", return_value=False):
         with pytest.raises(StandaloneSSHError, match="Password authentication failed"):
             bootstrap_managed_key("203.0.113.10", 22, "ansible", "secret", "/tmp/host_id_rsa")
+
+
+def test_detect_local_os_debian():
+    os_release = 'ID=debian\nVERSION_ID="12"\nPRETTY_NAME="Debian GNU/Linux 12 (bookworm)"\n'
+    with patch("builtins.open", mock_open(read_data=os_release)):
+        result = detect_local_os()
+    assert result["pretty_name"] == "Debian GNU/Linux 12 (bookworm)"
+    assert result["os_type"] == "debian"
+
+
+def test_detect_local_os_ubuntu():
+    os_release = 'ID=ubuntu\nVERSION_ID="22.04"\nPRETTY_NAME="Ubuntu 22.04.4 LTS"\n'
+    with patch("builtins.open", mock_open(read_data=os_release)):
+        result = detect_local_os()
+    assert result["pretty_name"] == "Ubuntu 22.04.4 LTS"
+    assert result["os_type"] == "ubuntu"
+
+
+def test_detect_local_os_returns_none_on_missing_file():
+    with patch("builtins.open", side_effect=OSError("no such file")):
+        result = detect_local_os()
+    assert result is None

--- a/ui/routes/host_routes.py
+++ b/ui/routes/host_routes.py
@@ -91,7 +91,7 @@ from ui.routes.self_host_helpers import (
     generate_self_host_keys,
 )
 from ui.standalone_ssh import StandaloneSSHError, bootstrap_managed_key
-from ui.standalone_ssh import detect_remote_os
+from ui.standalone_ssh import detect_local_os, detect_remote_os
 from ui.standalone_ssh import remove_managed_key
 from ui.standalone_ssh import verify_password_login, verify_passwordless_sudo
 from flask_jwt_extended import jwt_required # Import the decorator from Flask-JWT-Extended
@@ -567,10 +567,12 @@ def _handle_standalone_host_creation(name, data):
 def get_self_host_defaults_api():
     ssh_user = detect_default_self_ssh_user()
     host_ip = os.environ.get('QLSM_HOST_IP', '').strip() or None
+    os_info = detect_local_os()
     return jsonify({
         "data": {
             "ssh_user": ssh_user,
             "host_ip": host_ip,
+            "os_info": os_info,
             "provider_capabilities": {
                 "vultr": {
                     "configured": is_vultr_configured(),

--- a/ui/standalone_ssh.py
+++ b/ui/standalone_ssh.py
@@ -119,15 +119,10 @@ def _parse_os_release(os_release_text):
 
 def _detect_supported_os_type(os_release_values):
     distro_id = os_release_values.get("ID", "").strip().lower()
-    version_id = os_release_values.get("VERSION_ID", "").strip()
 
     if distro_id == "debian":
         return "debian"
-    if distro_id == "ubuntu" and version_id.startswith("20."):
-        return "ubuntu"
-    if distro_id == "ubuntu" and version_id.startswith("22."):
-        return "ubuntu"
-    if distro_id == "ubuntu" and version_id.startswith("24."):
+    if distro_id == "ubuntu":
         return "ubuntu"
     return None
 

--- a/ui/standalone_ssh.py
+++ b/ui/standalone_ssh.py
@@ -187,6 +187,25 @@ def detect_remote_os(*, host, port, username, timeout=30, password=None, key_fil
     }
 
 
+def detect_local_os(path="/etc/os-release"):
+    """Read /etc/os-release on the local machine and return OS info dict, or None on failure."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except OSError:
+        return None
+
+    os_release_values = _parse_os_release(content)
+    detected_name = _format_detected_os_name(os_release_values)
+    if not detected_name:
+        return None
+
+    return {
+        "pretty_name": detected_name,
+        "os_type": _detect_supported_os_type(os_release_values),
+    }
+
+
 def verify_password_login(host, port, username, password, timeout=30):
     """Check whether the supplied password can open an SSH session."""
     try:


### PR DESCRIPTION
## Summary
- Auto-detects local OS when the Add Host modal opens with self-hosted selected
- Shows detected OS name (e.g. "Detected OS: Debian GNU/Linux 12") in the form
- Shows red Ubuntu warning if OS type is Ubuntu (matching existing standalone behavior)

## Changes
- `ui/standalone_ssh.py` — new `detect_local_os()` reads `/etc/os-release` locally
- `ui/routes/host_routes.py` — `/api/hosts/self/defaults` now returns `os_info`
- `SelfHostFields.jsx` — renders OS name + Ubuntu warning from `osInfo` prop
- `AddHostFormFields.jsx` / `AddHostModal.jsx` — thread `osInfo` from defaults response

## Test Plan
- [ ] Backend: `pytest tests/test_standalone_ssh.py` and `pytest tests/test_host_api_routes.py` pass
- [ ] Open Add Host modal → select "QLSM Host (self-deployment)" → OS version appears automatically
- [ ] If running on Ubuntu, red warning "99k LAN rate is not compatible with Ubuntu." appears
- [ ] If detection fails (no `/etc/os-release`), no OS line shown, no crash