### PR TITLE
fix: allow deletion of hosts stuck in PROVISIONING after task crash

### DIFF
--- a/ui/routes/host_routes.py
+++ b/ui/routes/host_routes.py
@@ -6,11 +6,25 @@ from ui.database import (
 )
 import re
 import os
+import datetime
 import ipaddress
 import subprocess
 import tempfile
 import uuid
 from ui.task_lock import acquire_lock, release_lock, force_release_lock
+
+# Stale-lock detection constants for delete_host_api.
+# Threshold is intentionally below the minimum host lock TTL (1260s for standalone
+# setup, 1500s for provisioning) so force_release_lock fires while the Redis key
+# may still be alive. DELETING is excluded: its TTL is only 240s, so the lock
+# auto-expires long before any reasonable retry.
+_STALE_LOCK_THRESHOLD_SECONDS = 1200
+_STALE_TRANSITIONAL_STATUSES = {
+    HostStatus.PROVISIONING,
+    HostStatus.PROVISIONED_PENDING_SETUP,
+    HostStatus.CONFIGURING,
+    HostStatus.REBOOTING,
+}
 
 # Host name validation constants
 HOST_NAME_MAX_LENGTH = 20
@@ -725,26 +739,18 @@ def delete_host_api(host_id): # Renamed function
     host_name = host.name
     is_standalone = host.is_standalone
 
-    # Stale-lock detection: if the host has been in a transitional state with
-    # no DB activity for longer than the max provisioning lock TTL (1500s), the
-    # task that holds the lock is almost certainly dead (worker crash, OOM kill).
-    # Force-release the stale lock so the delete can proceed.
-    STALE_LOCK_THRESHOLD_SECONDS = 1800
-    STALE_TRANSITIONAL_STATUSES = {
-        HostStatus.PROVISIONING,
-        HostStatus.PROVISIONED_PENDING_SETUP,
-        HostStatus.CONFIGURING,
-        HostStatus.REBOOTING,
-    }
-    import datetime as _dt
+    # If the host has been stuck in a transitional state with no DB activity for
+    # longer than _STALE_LOCK_THRESHOLD_SECONDS, the task that held the lock is
+    # almost certainly dead (worker crash, OOM kill). Force-release the stale
+    # lock so the delete can proceed.
     if (
-        host.status in STALE_TRANSITIONAL_STATUSES
+        host.status in _STALE_TRANSITIONAL_STATUSES
         and host.last_updated is not None
-        and (_dt.datetime.utcnow() - host.last_updated).total_seconds() > STALE_LOCK_THRESHOLD_SECONDS
+        and (datetime.datetime.utcnow() - host.last_updated).total_seconds() > _STALE_LOCK_THRESHOLD_SECONDS
     ):
         current_app.logger.warning(
             f'Host "{host_name}" ({host_id}) has been in {host.status.value} for '
-            f'>{STALE_LOCK_THRESHOLD_SECONDS}s with no activity. Force-releasing stale lock.'
+            f'>{_STALE_LOCK_THRESHOLD_SECONDS}s with no activity. Force-releasing stale lock.'
         )
         force_release_lock('host', host.id)
 

--- a/ui/routes/host_routes.py
+++ b/ui/routes/host_routes.py
@@ -10,7 +10,7 @@ import ipaddress
 import subprocess
 import tempfile
 import uuid
-from ui.task_lock import acquire_lock, release_lock
+from ui.task_lock import acquire_lock, release_lock, force_release_lock
 
 # Host name validation constants
 HOST_NAME_MAX_LENGTH = 20
@@ -724,6 +724,29 @@ def delete_host_api(host_id): # Renamed function
 
     host_name = host.name
     is_standalone = host.is_standalone
+
+    # Stale-lock detection: if the host has been in a transitional state with
+    # no DB activity for longer than the max provisioning lock TTL (1500s), the
+    # task that holds the lock is almost certainly dead (worker crash, OOM kill).
+    # Force-release the stale lock so the delete can proceed.
+    STALE_LOCK_THRESHOLD_SECONDS = 1800
+    STALE_TRANSITIONAL_STATUSES = {
+        HostStatus.PROVISIONING,
+        HostStatus.PROVISIONED_PENDING_SETUP,
+        HostStatus.CONFIGURING,
+        HostStatus.REBOOTING,
+    }
+    import datetime as _dt
+    if (
+        host.status in STALE_TRANSITIONAL_STATUSES
+        and host.last_updated is not None
+        and (_dt.datetime.utcnow() - host.last_updated).total_seconds() > STALE_LOCK_THRESHOLD_SECONDS
+    ):
+        current_app.logger.warning(
+            f'Host "{host_name}" ({host_id}) has been in {host.status.value} for '
+            f'>{STALE_LOCK_THRESHOLD_SECONDS}s with no activity. Force-releasing stale lock.'
+        )
+        force_release_lock('host', host.id)
 
     lock_token = str(uuid.uuid4())
     if not acquire_lock('host', host.id, lock_token, ttl=240):

--- a/ui/task_lock.py
+++ b/ui/task_lock.py
@@ -70,3 +70,18 @@ def release_lock(entity_type, entity_id, token):
     else:
         log.debug(f"Lock not released (not owner or expired): {key}")
     return bool(result)
+
+
+def force_release_lock(entity_type, entity_id):
+    """Unconditionally delete a stale lock regardless of owner.
+
+    Only call this when the lock is known to be stale (e.g. the task that
+    held it crashed without releasing it and its TTL has long since expired).
+    Returns True if a key was deleted, False if there was nothing to delete.
+    """
+    redis_client = _get_redis()
+    key = f"task_lock:{entity_type}:{entity_id}"
+    result = redis_client.delete(key)
+    if result:
+        log.warning(f"Stale lock force-released: {key}")
+    return bool(result)


### PR DESCRIPTION
## Problem

When an RQ worker is killed hard (SIGKILL, OOM, system crash), the `host_job_failure_handler` never runs. The host stays in `PROVISIONING` indefinitely — the Redis lock expires after 25 min but the status never changes, making the host permanently undeletable through the UI.

## Fix

Before acquiring the deletion lock in `delete_host_api`, check if the host has been in a transitional state (`PROVISIONING`, `PROVISIONED_PENDING_SETUP`, `CONFIGURING`, `REBOOTING`) with no DB activity for >1800s (safely beyond the 1500s provisioning lock TTL). If so, the task is provably dead — force-release the stale Redis lock so deletion can proceed.

`last_updated` is the staleness signal: tasks continuously write logs via `append_log` → `db.session.commit()`, so a stale `last_updated` means the task stopped doing anything.

`force_release_lock()` added to `task_lock.py` for unconditional lock deletion (no owner token required).

## Test plan
- [ ] Host stuck in PROVISIONING for >30 min → delete succeeds
- [ ] Host in PROVISIONING for <30 min with active task → delete still blocked (409)
- [ ] Normal ACTIVE host deletion → unaffected