### PR TITLE
chore: add .claude/rules/ with modular project rules

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - "ui/**/*"
+  - "ansible/**/*"
+  - "terraform/**/*"
+---
+
+# Backend & Infrastructure Rules
+
+## Ansible
+
+- Always quote Jinja variables in YAML: `port: "{{ ssh_port }}"` not `port: {{ ssh_port }}`
+- Variable names in templates must match `--extra-vars` passed from Python
+- Use `--extra-vars` in JSON format for complex values
+
+## Systemd templates
+
+Wrap `ExecStart` in double quotes when args contain spaces:
+```
+ExecStart="/path/script.sh {{ qlds_args }}"
+```
+
+## Task status flow
+
+Set transitional status → Execute operation → Set final status → Commit
+
+Status enums are in `ui/models.py`:
+- `HostStatus`: PENDING, PROVISIONING, PROVISIONED_PENDING_SETUP, ACTIVE, CONFIGURING, DELETING, REBOOTING, ERROR, UNKNOWN
+- `InstanceStatus`: IDLE, DEPLOYING, DELETING, RUNNING, STOPPING, STOPPED, STARTING, RESTARTING, CONFIGURING, UPDATED, ERROR, UNKNOWN
+- `QLFilterStatus`: NOT_INSTALLED, INSTALLING, ACTIVE, INACTIVE, UNINSTALLING, ERROR, UNKNOWN
+
+## Deployment
+
+Always run `flask db upgrade` as part of production deployments when database migrations are involved.
+
+## System administration
+
+Use `sudo` when reading system journals or logs on remote servers.

--- a/.claude/rules/behavior.md
+++ b/.claude/rules/behavior.md
@@ -1,0 +1,14 @@
+# General Behavior
+
+## Pace and scope
+
+- For quick tasks: be concise and fast. Don't over-explore or brainstorm unless asked.
+- If the user interrupts mid-task: treat it as a signal to simplify immediately.
+
+## PR reviews
+
+Always confirm the correct PR number before starting work. Double-check the number the user specified.
+
+## Committing and git operations
+
+When asked to commit, merge, or do simple git operations, do it immediately without running extra checks unless explicitly asked.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,40 @@
+# Code Style & Patterns
+
+## File size limits
+
+- Hard limit: 300 lines of code per source file (excluding comments/blanks)
+- Never exceed 500 lines — flag for refactor when approaching
+- Split by functionality, not arbitrarily
+
+## API response format
+
+```python
+# Success
+{"data": {...}, "message": "optional"}
+
+# Error
+{"error": {"message": "description"}}
+```
+
+## Backend validation order
+
+1. Type check → 2. Normalize (`.strip()`) → 3. Empty check → 4. Length check → 5. Pattern check → 6. Uniqueness check
+
+## Route protection
+
+All protected routes use `@jwt_required()` from `flask_jwt_extended` — parentheses required.
+
+## Background task error handling
+
+- Set status to ERROR on failure
+- Use `append_log(instance, "message")` from `task_logic/common.py`
+- Always commit status changes
+- Return boolean or error string — never raise exceptions to RQ
+
+## Documentation
+
+After any significant change (new feature, route change, model change, new playbook, new service), update whichever of these apply:
+- `docs/architecture.md`
+- `docs/technical.md`
+- `docs/api_reference.md`
+- `docs/development_guidelines.md`

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "frontend-react/**/*"
+---
+
+# Frontend Rules
+
+## React state for real-time updates
+
+Parent components manage item IDs, not full objects. Re-derive objects from the master data list on each render — this ensures child components receive fresh data after polling updates.
+
+## CSS/UI fixes
+
+- Verify the change visually makes sense before committing
+- Never regress from a previously working state
+- If a fix doesn't work on first attempt, stop and re-examine — don't iterate blindly

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -7,7 +7,9 @@ branch creation → implementation → commit → PR → review → (wait for us
 
 Never edit files directly on `main`.
 
-## NEVER close or merge a PR without explicit user instruction
+## NEVER open, close, or merge a PR without explicit user instruction
+
+Never open a PR — even after committing and pushing a branch. Stop after the push and wait for the user to say "create a PR" or "open a PR".
 
 Never close a PR for any reason (stale, duplicate, already merged, etc.) unless the user explicitly says to close it.
 

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,36 @@
+# Git & GitHub Workflow
+
+## Always use the /github skill for feature work
+
+Use `/github` when implementing features or making code changes. It handles:
+branch creation → implementation → commit → PR → review → (wait for user approval) → merge
+
+Never edit files directly on `main`.
+
+## NEVER merge a PR without explicit user instruction
+
+This is a hard rule. After creating a PR:
+1. Stop and show the user the PR URL
+2. Wait for the user to explicitly say to merge (e.g. "merge it", "go ahead and merge")
+3. Only then run the merge command
+
+**"fix the review findings"** is NOT permission to merge.
+**"resume"** is NOT permission to merge.
+**A passing review** is NOT permission to merge.
+Skills do not override this rule. The user's explicit instruction is required every time.
+
+After merging: always `git checkout main && git pull`. Never stay on the feature branch.
+
+## GitHub CLI workarounds (this repo)
+
+- Repo owner is `dngrtech` — use `gh api repos/dngrtech/qlsm/...`. Never use `rage` as owner.
+- `gh pr view <N>` fails (GraphQL deprecation) — use `gh api repos/dngrtech/qlsm/pulls/<N>`
+- `gh pr edit --body` fails — use the REST API with a temp file:
+  ```bash
+  cat <<'EOF' > /tmp/pr_body.md
+  ...body...
+  EOF
+  python3 -c "import json,sys; json.dump({'body': open('/tmp/pr_body.md').read()}, sys.stdout)" > /tmp/pr_payload.json
+  gh api repos/dngrtech/qlsm/pulls/<N> -X PATCH --input /tmp/pr_payload.json
+  ```
+- `jq` is not installed — use `python3 -c "import json..."` for JSON manipulation

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -7,6 +7,10 @@ branch creation → implementation → commit → PR → review → (wait for us
 
 Never edit files directly on `main`.
 
+## NEVER close or merge a PR without explicit user instruction
+
+Never close a PR for any reason (stale, duplicate, already merged, etc.) unless the user explicitly says to close it.
+
 ## NEVER merge a PR without explicit user instruction
 
 This is a hard rule. After creating a PR:

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,11 @@ logging-stack/*
 !logging-stack/promtail/
 !logging-stack/promtail/**
 
+# ── Claude Code rules ─────────────────────────────────────────────────────────
+!.claude/
+!.claude/rules/
+!.claude/rules/**
+
 # ── Docs (selected only) ──────────────────────────────────────────────────────
 !docs/
 docs/*

--- a/frontend-react/public/docs/index.json
+++ b/frontend-react/public/docs/index.json
@@ -3,14 +3,19 @@
     "category": "Getting Started",
     "articles": [
       {
+        "id": "introduction",
+        "title": "What Is QLSM?",
+        "path": "/docs/getting-started/introduction.md"
+      },
+      {
+        "id": "installation",
+        "title": "Install QLSM",
+        "path": "/docs/getting-started/installation.md"
+      },
+      {
         "id": "add-host",
         "title": "Add A Host (Cloud Or Standalone)",
         "path": "/docs/getting-started/add-host.md"
-      },
-      {
-        "id": "auto-restart",
-        "title": "Configure Auto-Restart",
-        "path": "/docs/operations/auto-restart.md"
       },
       {
         "id": "deploy-instance",
@@ -21,6 +26,11 @@
         "id": "presets-overview",
         "title": "Presets And Default Config",
         "path": "/docs/presets/overview.md"
+      },
+      {
+        "id": "auto-restart",
+        "title": "Configure Auto-Restart",
+        "path": "/docs/operations/auto-restart.md"
       }
     ]
   },
@@ -43,9 +53,9 @@
         "path": "/docs/operations/manage-instance.md"
       },
       {
-        "id": "logs-chat",
-        "title": "Use Logs And Chat Logs",
-        "path": "/docs/operations/logs-and-chat.md"
+        "id": "rcon-basics",
+        "title": "RCON Basics",
+        "path": "/docs/operations/rcon-basics.md"
       },
       {
         "id": "server-logs",
@@ -56,11 +66,31 @@
         "id": "chat-logs",
         "title": "Chat Logs",
         "path": "/docs/operations/chat-logs.md"
+      }
+    ]
+  },
+  {
+    "category": "Features",
+    "articles": [
+      {
+        "id": "qlfilter",
+        "title": "QLFilter",
+        "path": "/docs/features/qlfilter.md"
       },
       {
-        "id": "rcon-basics",
-        "title": "RCON Basics",
-        "path": "/docs/operations/rcon-basics.md"
+        "id": "99k-lan-rate",
+        "title": "99k LAN Rate",
+        "path": "/docs/features/99k-lan-rate.md"
+      }
+    ]
+  },
+  {
+    "category": "Administration",
+    "articles": [
+      {
+        "id": "user-management",
+        "title": "User Management & API Keys",
+        "path": "/docs/administration/user-management.md"
       }
     ]
   },

--- a/frontend-react/public/docs/operations/instance-actions-menu.md
+++ b/frontend-react/public/docs/operations/instance-actions-menu.md
@@ -54,6 +54,18 @@ Open from instance row **Actions** in the Servers page.
 Config edits from this menu are instance-local.
 Changes do not modify other instances and do not modify default preset files.
 
+## File Upload In Edit Config
+
+Each config tab (server.cfg, mappool.txt, access.txt, workshop.txt) has an **Upload** button. Use it to drop in a file from your machine instead of typing or pasting.
+
+You can also upload:
+
+- **Plugin files** — `.py` files for custom minqlx plugins, uploaded via the Plugins tab
+- **Factory files** — `.factories` files, uploaded via the Factories tab
+- **Plugin binaries** — `.so` shared library files for native minqlx extensions
+
+This makes it easy to migrate an existing server setup: if you already have a working config and plugin pack, upload everything through the UI rather than manually copying files over SSH.
+
 ## Related Pages
 
 - [Deploy A New Instance](/docs/getting-started/deploy-new-instance)

--- a/frontend-react/public/docs/operations/rcon-basics.md
+++ b/frontend-react/public/docs/operations/rcon-basics.md
@@ -16,6 +16,17 @@ Action reference: [Instance Actions Menu](/docs/operations/instance-actions-menu
 2. Press **Send**.
 3. Read output in the console panel.
 
+## Live Event Stream
+
+The RCON console shows more than just command responses. As long as the console is open, you see a live stream of server events alongside your commands:
+
+- Player connects / disconnects
+- Match state changes (warmup → countdown → in-progress → ended)
+- Kill feed entries
+- Chat messages
+
+This means you can watch what's happening on the server in real time without running a separate tool.
+
 ## Quality-of-Life
 
 - Use Up/Down arrow keys to reuse recent commands.


### PR DESCRIPTION
## Summary
- Allowlists `.claude/rules/` in `.gitignore` so Claude Code rule files are tracked
- Adds five scoped rule files extracted/organized from CLAUDE.md:
  - `git-workflow.md` — hard rule: NEVER merge without explicit user instruction (with examples of what does NOT count as permission)
  - `code-style.md` — file size limits, API patterns, validation order, docs update rule
  - `frontend.md` — path-scoped to `frontend-react/**/*`: React state patterns, CSS/UI fix approach
  - `backend.md` — path-scoped to `ui/**/*`, `ansible/**/*`, `terraform/**/*`: Ansible quoting, status enums, deployment
  - `behavior.md` — pace/scope, PR review, git operations
- Removes duplicate Ansible variable quoting rule from `frontend.md` (already in `backend.md`)

## Test plan
- [ ] Verify `.claude/rules/` files appear in `git ls-files .claude/`
- [ ] Open any frontend file — Claude Code should load `frontend.md` rules
- [ ] Open any backend file — Claude Code should load `backend.md` rules

---
Generated with [Claude Code](https://claude.com/claude-code)