### PR TITLE
fix: hide connect buttons on mobile

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1046,6 +1046,10 @@ body {
     align-self: start;
   }
 
+  .btn-connect {
+    display: none;
+  }
+
   .add-instance-area {
     padding-inline: 12px;
   }


### PR DESCRIPTION
## Summary
- Hides `.btn-connect` (Steam connect links) on screens ≤639px via the existing mobile media query
- Connect buttons are desktop-only functionality; they add clutter on the compact mobile grid layout

## Test plan
- [ ] View ServersPage on a mobile-width screen (< 640px) — connect buttons should not appear
- [ ] View ServersPage on desktop — connect buttons should still appear as normal