### PR TITLE
fix: align mobile host metadata

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -821,6 +821,10 @@ body {
   background: rgba(255, 255, 255, 0.015);
 }
 
+.host-region-mobile-provider {
+  display: none;
+}
+
 /* Drag handle for sortable instance rows */
 .drag-handle {
   display: flex;
@@ -965,20 +969,28 @@ body {
   }
 
   .host-provider-cell {
+    display: none;
+  }
+
+  .host-region-cell {
     grid-column: 2;
     grid-row: 2;
     min-width: 0;
   }
 
-  .host-region-cell {
-    grid-column: 2;
-    grid-row: 3;
-    min-width: 0;
+  .host-region-mobile-provider {
+    display: inline;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
+  .host-region-icon {
+    display: none;
   }
 
   .host-ip-cell {
     grid-column: 2 / 4 !important;
-    grid-row: 4;
+    grid-row: 3;
     min-width: 0;
     flex-wrap: wrap;
   }

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -235,7 +235,8 @@ export default function ServersPage() {
                                     {host.provider || 'standalone'}
                                 </span>
                                 <span className="host-region-cell text-[13px] truncate text-theme-secondary flex items-center gap-1.5">
-                                    <MapPin size={14} className="text-theme-muted flex-shrink-0" />
+                                    <span className="host-region-mobile-provider capitalize">{host.provider || 'standalone'}</span>
+                                    <MapPin size={14} className="host-region-icon text-theme-muted flex-shrink-0" />
                                     {host.is_standalone
                                         ? (host.timezone || '—')
                                         : (formatVultrRegion(host.region) || '—')

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -235,7 +235,7 @@ export default function ServersPage() {
                                     {host.provider || 'standalone'}
                                 </span>
                                 <span className="host-region-cell text-[13px] truncate text-theme-secondary flex items-center gap-1.5">
-                                    <span className="host-region-mobile-provider capitalize">{host.provider || 'standalone'}</span>
+                                    <span className="host-region-mobile-provider capitalize" aria-hidden="true">{host.provider || 'standalone'}</span>
                                     <MapPin size={14} className="host-region-icon text-theme-muted flex-shrink-0" />
                                     {host.is_standalone
                                         ? (host.timezone || '—')


### PR DESCRIPTION
## Summary
- Combine host deployment type with region/timezone on mobile host cards.
- Keep the existing desktop provider and region columns unchanged.

## Validation
- `pnpm exec eslint src/pages/ServersPage.jsx`
- `pnpm build`

## Notes
- Full `pnpm lint` still fails on pre-existing issues outside this change.