### PR TITLE
fix: QLFilter host card indicator and mobile UI fixes

### DIFF
--- a/frontend-react/src/components/HostActionsMenu.jsx
+++ b/frontend-react/src/components/HostActionsMenu.jsx
@@ -8,7 +8,6 @@ function HostActionsMenu({
   host,
   handleDelete,
   onOpenDrawer,
-  POLLABLE_STATUSES,
   onInstallQlfilter,
   onUninstallQlfilter,
   onRequestRestart,
@@ -38,12 +37,13 @@ function HostActionsMenu({
           <div>
             <Menu.Button
               ref={refs.setReference}
-              className={`inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md text-theme-muted hover:text-theme-secondary hover:bg-black/[0.04] dark:hover:bg-white/[0.04] focus:outline-none transition-all ${open ? 'bg-black/[0.04] dark:bg-white/[0.04] text-theme-secondary' : ''
+              className={`host-actions-trigger inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md text-theme-muted hover:text-theme-secondary hover:bg-black/[0.04] dark:hover:bg-white/[0.04] focus:outline-none transition-all ${open ? 'bg-black/[0.04] dark:bg-white/[0.04] text-theme-secondary' : ''
                 }`}
               title="Host Settings"
+              aria-label="Host actions"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="1" /><circle cx="12" cy="5" r="1" /><circle cx="12" cy="19" r="1" /></svg>
-              Actions
+              <span className="host-actions-label">Actions</span>
             </Menu.Button>
           </div>
           <Portal>

--- a/frontend-react/src/components/InstanceActionsMenu.jsx
+++ b/frontend-react/src/components/InstanceActionsMenu.jsx
@@ -53,12 +53,12 @@ function InstanceActionsMenu({ instance, handleRestart, handleDelete, handleStop
           <div>
             <Menu.Button
               ref={refs.setReference}
-              className={`inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md text-theme-muted hover:text-theme-secondary hover:bg-black/[0.04] dark:hover:bg-white/[0.04] focus:outline-none transition-all ${open ? 'bg-black/[0.04] dark:bg-white/[0.04] text-theme-secondary' : ''
+              className={`instance-actions-trigger inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md text-theme-muted hover:text-theme-secondary hover:bg-black/[0.04] dark:hover:bg-white/[0.04] focus:outline-none transition-all ${open ? 'bg-black/[0.04] dark:bg-white/[0.04] text-theme-secondary' : ''
                 }`}
               title="Instance Settings"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="1" /><circle cx="12" cy="5" r="1" /><circle cx="12" cy="19" r="1" /></svg>
-              Actions
+              <span className="instance-actions-label">Actions</span>
             </Menu.Button>
           </div>
           <Portal>

--- a/frontend-react/src/components/InstanceActionsMenu.jsx
+++ b/frontend-react/src/components/InstanceActionsMenu.jsx
@@ -56,6 +56,7 @@ function InstanceActionsMenu({ instance, handleRestart, handleDelete, handleStop
               className={`instance-actions-trigger inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md text-theme-muted hover:text-theme-secondary hover:bg-black/[0.04] dark:hover:bg-white/[0.04] focus:outline-none transition-all ${open ? 'bg-black/[0.04] dark:bg-white/[0.04] text-theme-secondary' : ''
                 }`}
               title="Instance Settings"
+              aria-label="Instance actions"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="1" /><circle cx="12" cy="5" r="1" /><circle cx="12" cy="19" r="1" /></svg>
               <span className="instance-actions-label">Actions</span>

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -757,7 +757,8 @@ body {
 
 .server-grid.host-header-row,
 .server-grid.host-row {
-  grid-template-columns: 56px 1.2fr 1fr 1.25fr 70px 60px 70px 150px 86px 80px;
+  column-gap: 12px;
+  grid-template-columns: 48px minmax(0, 1.2fr) minmax(0, 0.95fr) minmax(0, 1.1fr) 64px 54px 64px 124px 60px 80px;
 }
 
 /* Expand/collapse animation */
@@ -954,6 +955,23 @@ body {
   transform: translateX(-50%);
   border: 5px solid transparent;
   border-top-color: var(--surface-border-strong);
+}
+
+@media (min-width: 640px) and (max-width: 900px) {
+  .server-grid.host-header-row,
+  .server-grid.host-row {
+    column-gap: 14px;
+    grid-template-columns: 48px minmax(0, 1fr) minmax(0, 0.9fr) minmax(0, 1fr) 58px 48px 58px 112px 54px 32px;
+  }
+
+  .host-actions-trigger {
+    gap: 0;
+    padding: 6px;
+  }
+
+  .host-actions-label {
+    display: none;
+  }
 }
 
 @media (max-width: 639px) {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -841,6 +841,10 @@ body {
   display: none;
 }
 
+.host-provider-icon {
+  color: var(--text-muted);
+}
+
 /* Drag handle for sortable instance rows */
 .drag-handle {
   display: flex;
@@ -996,7 +1000,9 @@ body {
   }
 
   .host-region-mobile-provider {
-    display: inline;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     font-weight: 600;
     color: var(--text-secondary);
   }

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -755,6 +755,11 @@ body {
   padding-right: 20px;
 }
 
+.server-grid.host-header-row,
+.server-grid.host-row {
+  grid-template-columns: 56px 1.2fr 1fr 1.25fr 70px 60px 70px 150px 86px 80px;
+}
+
 /* Expand/collapse animation */
 .expand-icon {
   transition: transform 0.25s ease;
@@ -792,6 +797,17 @@ body {
 /* Host column header row */
 .host-header-row {
   border-bottom: 1px solid var(--surface-border);
+}
+
+.host-qlfilter-header,
+.host-qlfilter-cell {
+  justify-self: center;
+}
+
+.host-qlfilter-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Instance row border */
@@ -1001,9 +1017,15 @@ body {
     justify-self: end;
   }
 
+  .host-qlfilter-cell {
+    grid-column: 3;
+    grid-row: 2;
+    justify-self: end;
+  }
+
   .host-actions-cell {
     grid-column: 3;
-    grid-row: 2 / span 2;
+    grid-row: 3;
     align-self: start;
   }
 

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1016,7 +1016,7 @@ body {
     grid-column: 3;
     grid-row: 1;
     justify-self: end;
-    padding-right: 28px;
+    padding-right: 64px;
   }
 
   .host-qlfilter-cell {
@@ -1028,8 +1028,19 @@ body {
 
   .host-actions-cell {
     grid-column: 3;
-    grid-row: 2 / span 2;
-    align-self: start;
+    grid-row: 1;
+    align-self: center;
+    justify-self: end;
+    padding-right: 28px;
+  }
+
+  .host-actions-trigger {
+    gap: 0;
+    padding: 6px;
+  }
+
+  .host-actions-label {
+    display: none;
   }
 
   .instance-name-cell {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -749,16 +749,11 @@ body {
 
 .server-grid {
   display: grid;
-  grid-template-columns: 56px 1.2fr 1fr 1.25fr 70px 60px 70px 220px 80px;
+  column-gap: 12px;
+  grid-template-columns: 56px minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1.25fr) 70px 60px 70px 220px 60px 80px;
   align-items: center;
   padding-left: 20px;
   padding-right: 20px;
-}
-
-.server-grid.host-header-row,
-.server-grid.host-row {
-  column-gap: 12px;
-  grid-template-columns: 48px minmax(0, 1.2fr) minmax(0, 0.95fr) minmax(0, 1.1fr) 64px 54px 64px 124px 60px 80px;
 }
 
 /* Expand/collapse animation */
@@ -809,6 +804,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.instance-actions-cell {
+  grid-column: 10;
 }
 
 /* Instance row border */
@@ -880,7 +879,8 @@ body {
 /* DragOverlay floating row */
 .instance-row-overlay {
   display: grid;
-  grid-template-columns: 40px 1.2fr 1fr 1.25fr 70px 60px 70px 220px 80px;
+  column-gap: 12px;
+  grid-template-columns: 56px minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1.25fr) 70px 60px 70px 220px 60px 80px;
   align-items: center;
   padding: 14px 20px;
   background: var(--surface-raised);
@@ -958,10 +958,10 @@ body {
 }
 
 @media (min-width: 640px) and (max-width: 900px) {
-  .server-grid.host-header-row,
-  .server-grid.host-row {
+  .server-grid,
+  .instance-row-overlay {
     column-gap: 14px;
-    grid-template-columns: 48px minmax(0, 1fr) minmax(0, 0.9fr) minmax(0, 1fr) 58px 48px 58px 112px 54px 32px;
+    grid-template-columns: 48px minmax(0, 1fr) minmax(0, 0.9fr) minmax(0, 1fr) 58px 48px 58px 112px 44px 32px;
   }
 
   .host-actions-trigger {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1007,10 +1007,6 @@ body {
     color: var(--text-secondary);
   }
 
-  .host-region-icon {
-    display: none;
-  }
-
   .host-ip-cell {
     grid-column: 2 / 4 !important;
     grid-row: 3;

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -958,7 +958,8 @@ body {
     display: none;
   }
 
-  .server-grid {
+  .server-grid,
+  .server-grid.host-row {
     grid-template-columns: 36px minmax(0, 1fr) auto;
     gap: 8px 12px;
     padding-left: 12px;
@@ -1015,17 +1016,19 @@ body {
     grid-column: 3;
     grid-row: 1;
     justify-self: end;
+    padding-right: 28px;
   }
 
   .host-qlfilter-cell {
     grid-column: 3;
-    grid-row: 2;
+    grid-row: 1;
+    align-self: center;
     justify-self: end;
   }
 
   .host-actions-cell {
     grid-column: 3;
-    grid-row: 3;
+    grid-row: 2 / span 2;
     align-self: start;
   }
 

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1024,6 +1024,7 @@ body {
     grid-row: 1;
     align-self: center;
     justify-self: end;
+    padding-right: 28px;
   }
 
   .host-actions-cell {
@@ -1031,7 +1032,6 @@ body {
     grid-row: 1;
     align-self: center;
     justify-self: end;
-    padding-right: 28px;
   }
 
   .host-actions-trigger {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -973,7 +973,8 @@ body {
     padding: 6px;
   }
 
-  .host-actions-label {
+  .host-actions-label,
+  .instance-actions-label {
     display: none;
   }
 }

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1067,6 +1067,15 @@ body {
     display: none;
   }
 
+  .instance-actions-trigger {
+    gap: 0;
+    padding: 6px;
+  }
+
+  .instance-actions-label {
+    display: none;
+  }
+
   .instance-name-cell {
     grid-column: 2;
     grid-row: 1;

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -750,7 +750,7 @@ body {
 .server-grid {
   display: grid;
   column-gap: 12px;
-  grid-template-columns: 56px minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1.25fr) 70px 60px 70px 220px 60px 80px;
+  grid-template-columns: 56px minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1.25fr) 70px 60px 70px 220px 60px 90px;
   align-items: center;
   padding-left: 20px;
   padding-right: 20px;
@@ -798,6 +798,10 @@ body {
 .host-qlfilter-header,
 .host-qlfilter-cell {
   justify-self: center;
+}
+
+.host-qlfilter-header {
+  white-space: nowrap;
 }
 
 .host-qlfilter-cell {
@@ -880,7 +884,7 @@ body {
 .instance-row-overlay {
   display: grid;
   column-gap: 12px;
-  grid-template-columns: 56px minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1.25fr) 70px 60px 70px 220px 60px 80px;
+  grid-template-columns: 56px minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1.25fr) 70px 60px 70px 220px 60px 90px;
   align-items: center;
   padding: 14px 20px;
   background: var(--surface-raised);

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -4,6 +4,7 @@ import { copyToClipboard as copyTextToClipboard } from '../utils/clipboard';
 import { ChevronDown, ChevronUp, ChevronRight, Plus, Copy, Check, MapPin, GripVertical } from 'lucide-react';
 import { useServers } from '../hooks/useServers';
 import StatusIndicator from '../components/StatusIndicator';
+import QLFilterIndicator from '../components/hosts/QLFilterIndicator';
 import ConfirmationModal from '../components/ConfirmationModal';
 import HostDetailDrawer from '../components/hosts/HostDetailDrawer';
 import AddHostModal from '../components/hosts/AddHostModal';
@@ -206,6 +207,7 @@ export default function ServersPage() {
                                 <span className="col-label">Region</span>
                                 <span className="col-label" style={{ gridColumn: 'span 3' }}>IP Address</span>
                                 <span className="col-label">Status</span>
+                                <span className="col-label host-qlfilter-header">QL-Filter</span>
                                 <span />
                             </div>
 
@@ -255,6 +257,9 @@ export default function ServersPage() {
                                         ? <StatusIndicator status="configuring" pollableStatuses={['configuring']} />
                                         : <StatusIndicator status={host.status} pollableStatuses={POLLABLE_HOST_STATUSES} />
                                     }
+                                </div>
+                                <div className="host-qlfilter-cell" onClick={(e) => e.stopPropagation()}>
+                                    <QLFilterIndicator qlfilterStatus={host.qlfilter_status} />
                                 </div>
                                 <div className="host-actions-cell flex justify-end" onClick={(e) => e.stopPropagation()}>
                                     <HostActionsMenu host={host} handleDelete={(id, name) => requestDeleteHost(id, name)} onOpenDrawer={handleOpenHostDrawer} POLLABLE_STATUSES={POLLABLE_HOST_STATUSES} onInstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'install')} onUninstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'uninstall')} onRequestRestart={handleRequestHostRestart} onOpenUpdateWorkshop={openWorkshopModal} onOpenAutoRestart={openAutoRestartModal} />

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -228,28 +228,30 @@ export default function ServersPage() {
                                 </div>
                                 <button
                                     onClick={(e) => { e.stopPropagation(); handleOpenHostDrawer(host.id); }}
-                                    className="host-name-cell text-[15px] font-semibold hover:underline text-left truncate"
+                                    className="host-name-cell text-[15px] font-semibold hover:underline text-left truncate min-w-0"
                                     style={{ color: 'var(--accent-primary)' }}
                                 >
                                     {host.name}
                                 </button>
-                                <span className="host-provider-cell text-[13px] capitalize truncate text-theme-secondary flex items-center gap-1.5">
+                                <span className="host-provider-cell text-[13px] capitalize truncate text-theme-secondary flex items-center gap-1.5 min-w-0">
                                     <Globe size={14} className="host-provider-icon text-theme-muted flex-shrink-0" aria-hidden="true" />
                                     <span className="truncate">{host.provider || 'standalone'}</span>
                                 </span>
-                                <span className="host-region-cell text-[13px] truncate text-theme-secondary flex items-center gap-1.5">
+                                <span className="host-region-cell text-[13px] truncate text-theme-secondary flex items-center gap-1.5 min-w-0">
                                     <span className="host-region-mobile-provider capitalize">
                                         <Globe size={14} className="host-provider-icon text-theme-muted flex-shrink-0" aria-hidden="true" />
                                         {host.provider || 'standalone'}
                                     </span>
                                     <MapPin size={14} className="host-region-icon text-theme-muted flex-shrink-0" />
-                                    {host.is_standalone
-                                        ? (host.timezone || '—')
-                                        : (formatVultrRegion(host.region) || '—')
-                                    }
+                                    <span className="truncate">
+                                        {host.is_standalone
+                                            ? (host.timezone || '—')
+                                            : (formatVultrRegion(host.region) || '—')
+                                        }
+                                    </span>
                                 </span>
-                                <div className="host-ip-cell flex items-center gap-2 truncate" style={{ gridColumn: 'span 3' }} onClick={(e) => e.stopPropagation()}>
-                                    <span className="font-mono text-[13px] text-theme-secondary">{host.ip_address || '—'}</span>
+                                <div className="host-ip-cell flex items-center gap-2 truncate min-w-0" style={{ gridColumn: 'span 3' }} onClick={(e) => e.stopPropagation()}>
+                                    <span className="font-mono text-[13px] text-theme-secondary truncate">{host.ip_address || '—'}</span>
                                     {host.ip_address && (
                                         <button onClick={(e) => copyToClipboard(host.ip_address, host.id, e)} className="p-1 text-theme-muted hover:text-theme-secondary rounded transition-colors hover:bg-black/5 dark:hover:bg-white/5">
                                             {copiedIp === host.id ? <Check size={14} className="text-emerald-400" /> : <Copy size={14} />}

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { copyToClipboard as copyTextToClipboard } from '../utils/clipboard';
-import { ChevronDown, ChevronUp, ChevronRight, Plus, Copy, Check, MapPin, GripVertical } from 'lucide-react';
+import { ChevronDown, ChevronUp, ChevronRight, Plus, Copy, Check, Globe2, MapPin, GripVertical } from 'lucide-react';
 import { useServers } from '../hooks/useServers';
 import StatusIndicator from '../components/StatusIndicator';
 import QLFilterIndicator from '../components/hosts/QLFilterIndicator';
@@ -233,11 +233,15 @@ export default function ServersPage() {
                                 >
                                     {host.name}
                                 </button>
-                                <span className="host-provider-cell text-[13px] capitalize truncate text-theme-secondary">
-                                    {host.provider || 'standalone'}
+                                <span className="host-provider-cell text-[13px] capitalize truncate text-theme-secondary flex items-center gap-1.5">
+                                    <Globe2 size={14} className="host-provider-icon text-theme-muted flex-shrink-0" aria-hidden="true" />
+                                    <span className="truncate">{host.provider || 'standalone'}</span>
                                 </span>
                                 <span className="host-region-cell text-[13px] truncate text-theme-secondary flex items-center gap-1.5">
-                                    <span className="host-region-mobile-provider capitalize" aria-hidden="true">{host.provider || 'standalone'}</span>
+                                    <span className="host-region-mobile-provider capitalize">
+                                        <Globe2 size={14} className="host-provider-icon text-theme-muted flex-shrink-0" aria-hidden="true" />
+                                        {host.provider || 'standalone'}
+                                    </span>
                                     <MapPin size={14} className="host-region-icon text-theme-muted flex-shrink-0" />
                                     {host.is_standalone
                                         ? (host.timezone || '—')

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { copyToClipboard as copyTextToClipboard } from '../utils/clipboard';
-import { ChevronDown, ChevronUp, ChevronRight, Plus, Copy, Check, Globe2, MapPin, GripVertical } from 'lucide-react';
+import { ChevronDown, ChevronUp, ChevronRight, Plus, Copy, Check, Globe, MapPin, GripVertical } from 'lucide-react';
 import { useServers } from '../hooks/useServers';
 import StatusIndicator from '../components/StatusIndicator';
 import QLFilterIndicator from '../components/hosts/QLFilterIndicator';
@@ -234,12 +234,12 @@ export default function ServersPage() {
                                     {host.name}
                                 </button>
                                 <span className="host-provider-cell text-[13px] capitalize truncate text-theme-secondary flex items-center gap-1.5">
-                                    <Globe2 size={14} className="host-provider-icon text-theme-muted flex-shrink-0" aria-hidden="true" />
+                                    <Globe size={14} className="host-provider-icon text-theme-muted flex-shrink-0" aria-hidden="true" />
                                     <span className="truncate">{host.provider || 'standalone'}</span>
                                 </span>
                                 <span className="host-region-cell text-[13px] truncate text-theme-secondary flex items-center gap-1.5">
                                     <span className="host-region-mobile-provider capitalize">
-                                        <Globe2 size={14} className="host-provider-icon text-theme-muted flex-shrink-0" aria-hidden="true" />
+                                        <Globe size={14} className="host-provider-icon text-theme-muted flex-shrink-0" aria-hidden="true" />
                                         {host.provider || 'standalone'}
                                     </span>
                                     <MapPin size={14} className="host-region-icon text-theme-muted flex-shrink-0" />

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -268,7 +268,7 @@ export default function ServersPage() {
                                     <QLFilterIndicator qlfilterStatus={host.qlfilter_status} />
                                 </div>
                                 <div className="host-actions-cell flex justify-end" onClick={(e) => e.stopPropagation()}>
-                                    <HostActionsMenu host={host} handleDelete={(id, name) => requestDeleteHost(id, name)} onOpenDrawer={handleOpenHostDrawer} POLLABLE_STATUSES={POLLABLE_HOST_STATUSES} onInstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'install')} onUninstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'uninstall')} onRequestRestart={handleRequestHostRestart} onOpenUpdateWorkshop={openWorkshopModal} onOpenAutoRestart={openAutoRestartModal} />
+                                    <HostActionsMenu host={host} handleDelete={(id, name) => requestDeleteHost(id, name)} onOpenDrawer={handleOpenHostDrawer} onInstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'install')} onUninstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'uninstall')} onRequestRestart={handleRequestHostRestart} onOpenUpdateWorkshop={openWorkshopModal} onOpenAutoRestart={openAutoRestartModal} />
                                 </div>
                             </div>
 

--- a/frontend-react/src/pages/__tests__/ServersPage.test.jsx
+++ b/frontend-react/src/pages/__tests__/ServersPage.test.jsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import ServersPage from '../ServersPage';
+
+const mocks = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  toggleExpand: vi.fn(),
+  noop: vi.fn(),
+  NullComponent: () => null,
+}));
+
+vi.mock('../../hooks/useServers', () => ({
+  POLLABLE_HOST_STATUSES: ['provisioning', 'configuring'],
+  POLLABLE_INSTANCE_STATUSES: ['deploying'],
+  useServers: () => ({
+    serversData: [
+      {
+        id: 1,
+        name: 'Arena Host',
+        provider: 'standalone',
+        region: null,
+        ip_address: '203.0.113.10',
+        status: 'active',
+        qlfilter_status: 'active',
+        timezone: 'UTC',
+        is_standalone: true,
+        expanded: false,
+        instances: [],
+      },
+    ],
+    stats: { totalHosts: 1, totalInstances: 0, runningInstances: 0 },
+    loading: false,
+    error: null,
+    toggleExpand: mocks.toggleExpand,
+    expandAll: mocks.noop,
+    collapseAll: mocks.noop,
+    refreshData: mocks.noop,
+    deleteModal: { open: false, item: null, type: null },
+    requestDeleteHost: mocks.noop,
+    requestDeleteInstance: mocks.noop,
+    confirmDelete: mocks.noop,
+    closeDeleteModal: mocks.noop,
+    restartModal: { open: false, instance: null },
+    requestRestartInstance: mocks.noop,
+    confirmRestart: mocks.noop,
+    closeRestartModal: mocks.noop,
+  }),
+}));
+
+vi.mock('../../components/hosts/SortableHostList', () => ({
+  default: ({ hosts, renderHostCard }) => (
+    <div>
+      {hosts.map((host) => (
+        <div key={host.id}>
+          {renderHostCard(host, { attributes: {}, listeners: {} })}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../../components/HostActionsMenu', () => ({
+  default: () => <button type="button">Actions</button>,
+}));
+
+vi.mock('../../components/StatusIndicator', () => ({
+  default: ({ status }) => <span>{status}</span>,
+}));
+
+vi.mock('../../components/NotificationProvider', () => ({
+  useNotification: () => ({
+    addNotification: mocks.addNotification,
+    showSuccess: mocks.showSuccess,
+    showError: mocks.showError,
+  }),
+}));
+
+vi.mock('../../hooks/useQlfilterActions', () => ({
+  useQlfilterActions: () => ({ handleQlfilterAction: mocks.noop }),
+}));
+
+vi.mock('../../hooks/useHostRestart', () => ({
+  useHostRestart: () => ({
+    hostForRestart: null,
+    isRestartModalOpen: false,
+    requestRestart: mocks.noop,
+    confirmRestart: mocks.noop,
+    closeRestartModal: mocks.noop,
+  }),
+}));
+
+vi.mock('../../hooks/useViewLogs', () => ({
+  useViewLogs: () => ({
+    selectedInstanceForLogs: null,
+    isViewLogsModalOpen: false,
+    openViewLogs: mocks.noop,
+    closeViewLogs: mocks.noop,
+  }),
+}));
+
+vi.mock('../../hooks/useViewChatLogs', () => ({
+  useViewChatLogs: () => ({
+    selectedInstanceForChatLogs: null,
+    isViewChatLogsModalOpen: false,
+    openViewChatLogs: mocks.noop,
+    closeViewChatLogs: mocks.noop,
+  }),
+}));
+
+vi.mock('../../hooks/useInstanceLanRate', () => ({
+  useInstanceLanRate: () => ({
+    lanRateAction: null,
+    isLanRateModalOpen: false,
+    requestToggleLanRate: mocks.noop,
+    confirmToggleLanRate: mocks.noop,
+    closeLanRateModal: mocks.noop,
+  }),
+}));
+
+vi.mock('../../hooks/useInstanceStopStart', () => ({
+  useInstanceStopStart: () => ({
+    stopStartAction: null,
+    isStopStartModalOpen: false,
+    requestStop: mocks.noop,
+    requestStart: mocks.noop,
+    confirmStopStart: mocks.noop,
+    closeStopStartModal: mocks.noop,
+  }),
+}));
+
+vi.mock('../../hooks/useWorkshopUpdate', () => ({
+  useWorkshopUpdate: () => ({
+    isWorkshopModalOpen: false,
+    hostForWorkshopUpdate: null,
+    openWorkshopModal: mocks.noop,
+    closeWorkshopModal: mocks.noop,
+    handleWorkshopUpdateSubmit: mocks.noop,
+  }),
+}));
+
+vi.mock('../../hooks/useHostAutoRestart', () => ({
+  useHostAutoRestart: () => ({
+    isAutoRestartModalOpen: false,
+    hostForAutoRestart: null,
+    openAutoRestartModal: mocks.noop,
+    closeAutoRestartModal: mocks.noop,
+    handleAutoRestartSubmit: mocks.noop,
+  }),
+}));
+
+vi.mock('../../hooks/useServerStatus', () => ({
+  useServerStatus: () => ({}),
+}));
+
+vi.mock('../../hooks/useInstanceOrder', () => ({
+  useInstanceOrder: () => ({
+    getOrderedInstances: (_hostId, instances) => instances,
+    setInstanceOrder: mocks.noop,
+  }),
+}));
+
+vi.mock('../../hooks/useHostOrder', () => ({
+  useHostOrder: () => ({
+    getOrderedHosts: (hosts) => hosts,
+    setHostOrder: mocks.noop,
+  }),
+}));
+
+vi.mock('../../components/ConfirmationModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/hosts/HostDetailDrawer', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/hosts/AddHostModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/instances/AddInstanceModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/instances/InstanceDetailsModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/instances/EditInstanceConfigModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/instances/ViewLogsModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/instances/ViewChatLogsModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/RconConsoleModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/instances/LiveServerStatusModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/hosts/ForceUpdateWorkshopModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/hosts/HostAutoRestartScheduleModal', () => ({ default: mocks.NullComponent }));
+
+describe('ServersPage', () => {
+  it('renders the QLFilter column in the active host-card layout', () => {
+    render(
+      <MemoryRouter>
+        <ServersPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('QL-Filter')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'QLFilter enabled' })).toHaveAttribute(
+      'src',
+      '/images/qlfilter-on.png'
+    );
+  });
+});

--- a/ui/task_logic/server_status_poll.py
+++ b/ui/task_logic/server_status_poll.py
@@ -134,6 +134,9 @@ def poll_all_hosts():
         ]
         if not running:
             continue
+        if not host.ssh_key_path:
+            logger.debug("Skipping host %s — no SSH key configured", host.name)
+            continue
         total_instances += len(running)
         _fetch_and_cache_host(host, running, redis_client)
 


### PR DESCRIPTION
## Summary

- Show QLFilter status badge in host cards on the Servers page
- Fix QLFilter indicator alignment on mobile
- Fix mobile host action button placement and compactness
- Use globe icon as provider icon in host cards
- Fix mobile region icon visibility
- Prevent tight host column overlap
- Align host and instance status columns
- Widen QL-Filter column header so it fits on one line
- Hide "Actions" label on instance menus in mobile view (matches host behaviour)
- Skip poll cycle for hosts with no SSH key configured (fixes TypeError crash)

## Test plan

- [ ] QLFilter status badge appears in host cards
- [ ] QLFilter indicator aligns correctly on mobile
- [ ] Host action buttons are compact on mobile with no "Actions" label
- [ ] Instance action buttons hide "Actions" label on mobile
- [ ] Globe icon shows as provider icon in host cards
- [ ] Region icon visible on mobile
- [ ] Host columns do not overlap
- [ ] "QL-FILTER" header fits on one line
- [ ] No poll cycle crash when a host has no SSH key set
