### PR TITLE
feat: confirm before QLFilter install to warn of instance downtime

### DIFF
--- a/frontend-react/src/components/HostActionsMenu.jsx
+++ b/frontend-react/src/components/HostActionsMenu.jsx
@@ -1,8 +1,9 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { Menu, Transition, Portal } from '@headlessui/react';
 import { useFloating, shift, offset, autoUpdate, flip } from '@floating-ui/react-dom';
 import { Trash2, RefreshCw, ShieldCheck, ShieldOff, Loader2, Eye, PowerIcon } from 'lucide-react';
 import { HostStatus, QLFILTER_STATUS } from '../utils/statusEnums';
+import ConfirmationModal from './ConfirmationModal';
 
 function HostActionsMenu({
   host,
@@ -14,6 +15,8 @@ function HostActionsMenu({
   onOpenUpdateWorkshop,
   onOpenAutoRestart
 }) {
+  const [isInstallQlFilterModalOpen, setIsInstallQlFilterModalOpen] = useState(false);
+
   const { x, y, refs, strategy } = useFloating({
     placement: 'bottom-end',
     middleware: [
@@ -31,6 +34,16 @@ function HostActionsMenu({
   const isHostReady = hostStatus === HostStatus.ACTIVE.toLowerCase() || hostStatus === HostStatus.ERROR.toLowerCase();
 
   return (
+    <>
+    <ConfirmationModal
+      isOpen={isInstallQlFilterModalOpen}
+      onClose={() => setIsInstallQlFilterModalOpen(false)}
+      onConfirm={() => { if (typeof onInstallQlfilter === 'function') onInstallQlfilter(host.id); setIsInstallQlFilterModalOpen(false); }}
+      title="Install QLFilter"
+      message="Installing QLFilter will reconfigure this host. Any running instances will be temporarily unavailable during the configuration process."
+      confirmButtonText="Install"
+      confirmButtonVariant="primary"
+    />
     <Menu as="div" className="relative inline-block text-left ml-2">
       {({ open, close: closeMenu }) => (
         <>
@@ -157,7 +170,7 @@ function HostActionsMenu({
                       } else if (canInstall) {
                         buttonText = 'Install QLFilter';
                         Icon = ShieldCheck;
-                        action = () => { if (typeof onInstallQlfilter === 'function') onInstallQlfilter(host.id); closeMenu(); };
+                        action = () => { closeMenu(); setIsInstallQlFilterModalOpen(true); };
                       } else {
                         buttonText = 'QLFilter Unknown';
                         Icon = ShieldCheck;
@@ -208,6 +221,7 @@ function HostActionsMenu({
         </>
       )}
     </Menu>
+    </>
   );
 }
 

--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -337,6 +337,7 @@ export default function HostDetailDrawer({
         message="Installing QLFilter will reconfigure this host. Any running instances will be temporarily unavailable during the configuration process."
         confirmButtonText="Install"
         confirmButtonVariant="primary"
+        zIndexClass="z-50"
       />
     </>
   );

--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -144,6 +144,8 @@ export default function HostDetailDrawer({
     if (actionable && !busy && !qlBusy) isRestartDisabled = false;
   }
 
+  const [isInstallQlFilterModalOpen, setIsInstallQlFilterModalOpen] = useState(false);
+
   // QLFilter button logic
   let qlBtn = { text: 'QLFilter Unknown', Icon: ShieldCheck, action: null, disabled: true, loading: false, variant: 'secondary' };
   if (internalHost && onQlfilterAction) {
@@ -156,7 +158,7 @@ export default function HostDetailDrawer({
     if (qs === QLFILTER_STATUS.ACTIVE || qs === QLFILTER_STATUS.INACTIVE) {
       qlBtn = { ...qlBtn, text: 'Uninstall QLFilter', Icon: ShieldOff, action: () => onQlfilterAction(internalHost.id, 'uninstall'), variant: 'warning' };
     } else if ([QLFILTER_STATUS.NOT_INSTALLED, QLFILTER_STATUS.ERROR, QLFILTER_STATUS.UNKNOWN].includes(qs)) {
-      qlBtn = { ...qlBtn, text: 'Install QLFilter', Icon: ShieldCheck, action: () => onQlfilterAction(internalHost.id, 'install'), variant: 'primary' };
+      qlBtn = { ...qlBtn, text: 'Install QLFilter', Icon: ShieldCheck, action: () => setIsInstallQlFilterModalOpen(true), variant: 'primary' };
     } else if (processing) {
       qlBtn.text = qs === QLFILTER_STATUS.INSTALLING.toLowerCase() ? 'Installing QLFilter' : 'Uninstalling QLFilter';
       qlBtn.Icon = Loader2;
@@ -325,6 +327,16 @@ export default function HostDetailDrawer({
           : `Are you sure you want to delete the host "${internalHost?.name || ''}"? This action cannot be undone.`}
         confirmButtonText={internalHost?.is_standalone ? 'Remove' : 'Delete'}
         confirmButtonVariant={internalHost?.is_standalone ? 'orange' : 'danger'}
+      />
+
+      <ConfirmationModal
+        isOpen={isInstallQlFilterModalOpen}
+        onClose={() => setIsInstallQlFilterModalOpen(false)}
+        onConfirm={() => { onQlfilterAction(internalHost?.id, 'install'); setIsInstallQlFilterModalOpen(false); }}
+        title="Install QLFilter"
+        message="Installing QLFilter will reconfigure this host. Any running instances will be temporarily unavailable during the configuration process."
+        confirmButtonText="Install"
+        confirmButtonVariant="primary"
       />
     </>
   );


### PR DESCRIPTION
## Summary
- Added confirmation modal before QLFilter install from both HostActionsMenu and HostDetailDrawer
- Modal warns that instances will be temporarily unavailable during host reconfiguration
- Uninstall path is unchanged (no confirmation required)

## Test plan
- [ ] Click "Install QLFilter" from the host actions menu — confirmation modal appears
- [ ] Click "Install QLFilter" from the host detail drawer footer — confirmation modal appears
- [ ] Confirm → install proceeds as before
- [ ] Cancel → no action taken, menu/drawer remains open
- [ ] Uninstall QLFilter still triggers immediately without a modal