### PR TITLE
fix: set qlfilter_status to NOT_INSTALLED after host setup

### DIFF
--- a/migrations/versions/20260427000000_backfill_qlfilter_unknown_to_not_installed.py
+++ b/migrations/versions/20260427000000_backfill_qlfilter_unknown_to_not_installed.py
@@ -1,0 +1,31 @@
+"""Backfill qlfilter_status UNKNOWN -> NOT_INSTALLED for active hosts
+
+QLFilter cannot be configured during host creation — it is only enabled
+explicitly by the user after a host is set up. Any host with UNKNOWN
+qlfilter_status that is ACTIVE was set up before this status was tracked
+correctly; NOT_INSTALLED is the accurate state for those hosts.
+
+Revision ID: 20260427000000
+Revises: 20260424103000
+Create Date: 2026-04-27
+"""
+from alembic import op
+from sqlalchemy import text
+
+revision = '20260427000000'
+down_revision = '20260424103000'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute(text(
+        "UPDATE host SET qlfilter_status = 'NOT_INSTALLED'"
+        " WHERE qlfilter_status = 'UNKNOWN' OR qlfilter_status IS NULL"
+    ))
+
+
+def downgrade():
+    # Cannot recover original UNKNOWN/NULL values — this is intentional.
+    pass

--- a/migrations/versions/20260427000000_backfill_qlfilter_unknown_to_not_installed.py
+++ b/migrations/versions/20260427000000_backfill_qlfilter_unknown_to_not_installed.py
@@ -1,9 +1,10 @@
-"""Backfill qlfilter_status UNKNOWN -> NOT_INSTALLED for active hosts
+"""Backfill qlfilter_status UNKNOWN -> NOT_INSTALLED for all hosts
 
 QLFilter cannot be configured during host creation — it is only enabled
-explicitly by the user after a host is set up. Any host with UNKNOWN
-qlfilter_status that is ACTIVE was set up before this status was tracked
-correctly; NOT_INSTALLED is the accurate state for those hosts.
+explicitly by the user after a host is set up. Any host with UNKNOWN or NULL
+qlfilter_status was created before this status was tracked correctly;
+NOT_INSTALLED is the accurate state for all such hosts regardless of their
+current host status.
 
 Revision ID: 20260427000000
 Revises: 20260424103000

--- a/ui/task_logic/ansible_host_setup.py
+++ b/ui/task_logic/ansible_host_setup.py
@@ -5,7 +5,7 @@ from rq import get_current_job
 
 # Import database and models - requires app context
 from ui import db
-from ui.models import Host, HostStatus # Need Host and HostStatus
+from ui.models import Host, HostStatus, QLFilterStatus
 from .common import append_log # Import from the common module
 # Note: No need to import _run_ansible_playbook as this task uses direct subprocess calls
 
@@ -163,6 +163,7 @@ def setup_host_ansible_logic(host_id):
 
             # --- Final Success ---
             host.status = HostStatus.ACTIVE
+            host.qlfilter_status = QLFilterStatus.NOT_INSTALLED
             append_log(host, f"Task finished successfully. Host is ACTIVE.")
             db.session.commit()
             log.info(f"Finished task setup_host_ansible for host_id: {host_id}. Status: ACTIVE")


### PR DESCRIPTION
## Summary

- `qlfilter_status` defaulted to `UNKNOWN` on all newly deployed hosts, which is semantically wrong — QLFilter cannot be configured during host creation and is only enabled explicitly by the user via HostActionsMenu or HostDetailDrawer
- After a successful host setup, the status is definitively `NOT_INSTALLED`
- Adds a data migration to backfill all existing hosts where `qlfilter_status` is `UNKNOWN` or `NULL` to `NOT_INSTALLED`
- Sets `NOT_INSTALLED` on `host.qlfilter_status` in `ansible_host_setup.py` when setup completes successfully

## Test plan

- [ ] Deploy a new host and confirm `qlfilter_status` is `not_installed` in `GET /api/hosts` response after setup completes
- [ ] Confirm host card shows "QLFilter not installed" tooltip instead of "QLFilter status unknown"
- [ ] Run `flask db upgrade` and confirm existing UNKNOWN/NULL rows are updated to NOT_INSTALLED
- [ ] Confirm QLFilter install action still appears for NOT_INSTALLED hosts in HostActionsMenu