### PR TITLE
Fix server name column width

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -756,6 +756,15 @@ body {
   padding-right: 20px;
 }
 
+@media (min-width: 901px) {
+  .server-grid.host-header-row,
+  .server-grid.host-row {
+    grid-template-columns:
+      56px minmax(0, 2.2fr) minmax(0, 0.75fr) minmax(0, 0.9fr)
+      70px 56px 70px 140px 60px 90px;
+  }
+}
+
 /* Expand/collapse animation */
 .expand-icon {
   transition: transform 0.25s ease;


### PR DESCRIPTION
## Summary
- Add a desktop-only host grid override for the Servers page.
- Give the host name column more of the available width while preserving the existing instance-row grid.
- Keep long host names single-line, with truncation only when the available desktop width is genuinely constrained.

## Root Cause
The host row reused the same grid as instance rows, including a wide status/connect column needed by instances. That left the host name column too narrow even on full-width desktop layouts.

## Validation
- `pnpm exec vitest run src/pages/__tests__/ServersPage.test.jsx`
- `pnpm build`

Note: `pnpm lint` still fails on existing unrelated frontend lint issues in files outside this change, including CodeMirror language files, `CodeMirrorEditor.jsx`, `SortableHostCard.jsx`, and others.