### PR TITLE
Fix LAN rate support for legacy Debian 12 hosts

### DIFF
--- a/frontend-react/src/components/instances/__tests__/EditInstanceConfigModal.test.jsx
+++ b/frontend-react/src/components/instances/__tests__/EditInstanceConfigModal.test.jsx
@@ -239,11 +239,33 @@ describe('EditInstanceConfigModal preset saving', () => {
 
     fireEvent.click(toggle);
 
+    expect(toggle).toBeDisabled();
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByText('99k LAN rate is not compatible with Ubuntu.')).toBeInTheDocument();
+  });
+
+  it('allows enabling 99k lan rate for legacy debian12 host records', async () => {
+    mocks.getInstanceById.mockResolvedValue({
+      host_name: 'debian-host',
+      host_os_type: 'debian12',
+      lan_rate_enabled: false,
+      name: 'DebianInst',
+      qlx_plugins: '',
+    });
+
+    render(
+      <EditInstanceConfigModal
+        isOpen={true}
+        onClose={vi.fn()}
+        instanceId={9}
+        instanceName="DebianInst"
+        onConfigSaved={vi.fn()}
+      />
+    );
+
+    const toggle = await screen.findByRole('button', { name: /toggle 99k lan rate/i });
     expect(toggle).not.toBeDisabled();
     expect(toggle).toHaveAttribute('aria-pressed', 'false');
-
-    fireEvent.click(toggle);
-
-    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByText('99k LAN rate is only supported on Debian hosts.')).not.toBeInTheDocument();
   });
 });

--- a/frontend-react/src/utils/__tests__/lanRateCompatibility.test.js
+++ b/frontend-react/src/utils/__tests__/lanRateCompatibility.test.js
@@ -12,6 +12,12 @@ describe('lanRateCompatibility', () => {
     expect(canEnableLanRate({ osType: 'debian', currentEnabled: false })).toBe(true);
   });
 
+  it('supports legacy debian12 host records', () => {
+    expect(isLanRateSupported('debian12')).toBe(true);
+    expect(canEnableLanRate({ osType: 'debian12', currentEnabled: false })).toBe(true);
+    expect(getLanRateUnsupportedReason('debian12')).toBe(null);
+  });
+
   it('blocks enabling on ubuntu', () => {
     expect(isLanRateSupported('ubuntu')).toBe(false);
     expect(canEnableLanRate({ osType: 'ubuntu', currentEnabled: false })).toBe(false);

--- a/frontend-react/src/utils/lanRateCompatibility.js
+++ b/frontend-react/src/utils/lanRateCompatibility.js
@@ -2,10 +2,15 @@ export const SUPPORTED_LAN_RATE_OS_TYPES = new Set(['debian']);
 export const UBUNTU_99K_LAN_RATE_MESSAGE = '99k LAN rate is not compatible with Ubuntu.';
 export const UNKNOWN_99K_LAN_RATE_MESSAGE = '99k LAN rate is only supported on Debian hosts.';
 
+const OS_TYPE_ALIASES = {
+  debian12: 'debian',
+};
+
 function normalizeOsType(osType) {
   if (typeof osType !== 'string') return null;
   const normalized = osType.trim().toLowerCase();
-  return normalized || null;
+  if (!normalized) return null;
+  return OS_TYPE_ALIASES[normalized] || normalized;
 }
 
 export function isLanRateSupported(osType) {

--- a/tests/test_lan_rate_policy.py
+++ b/tests/test_lan_rate_policy.py
@@ -12,6 +12,15 @@ def test_host_supports_lan_rate_for_debian():
     assert host_supports_lan_rate(SimpleNamespace(os_type='debian')) is True
 
 
+def test_host_supports_lan_rate_for_legacy_debian12():
+    assert host_supports_lan_rate(SimpleNamespace(os_type='debian12')) is True
+    assert would_enable_unsupported_lan_rate(
+        SimpleNamespace(os_type='debian12'),
+        current_enabled=False,
+        requested_enabled=True,
+    ) is False
+
+
 def test_host_supports_lan_rate_for_ubuntu():
     assert host_supports_lan_rate(SimpleNamespace(os_type='ubuntu')) is False
 

--- a/ui/lan_rate_policy.py
+++ b/ui/lan_rate_policy.py
@@ -1,6 +1,9 @@
 """Shared rules for 99k LAN rate compatibility."""
 
 SUPPORTED_LAN_RATE_OS_TYPES = frozenset({"debian"})
+OS_TYPE_ALIASES = {
+    "debian12": "debian",
+}
 UBUNTU_99K_LAN_RATE_MESSAGE = "99k LAN rate is not compatible with Ubuntu."
 UNKNOWN_99K_LAN_RATE_MESSAGE = "99k LAN rate is only supported on Debian hosts."
 
@@ -10,7 +13,9 @@ def _normalized_os_type(host):
     if not isinstance(os_type, str):
         return None
     normalized = os_type.strip().lower()
-    return normalized or None
+    if not normalized:
+        return None
+    return OS_TYPE_ALIASES.get(normalized, normalized)
 
 
 def host_supports_lan_rate(host):


### PR DESCRIPTION
## Summary
- Treat legacy `debian12` host OS records as Debian in backend LAN-rate policy.
- Mirror the same `debian12 -> debian` alias in the frontend LAN-rate compatibility helper.
- Add regression coverage for backend policy, frontend helper behavior, and the edit instance config modal path that showed the incorrect tooltip.
- Update a stale edit-modal test expectation so legacy Ubuntu instances can be disabled, then remain blocked from re-enabling before save.

## Root Cause
PR 23 tightened 99k LAN-rate support from "anything except Ubuntu" to exact `os_type = "debian"`. Existing production standalone hosts can still have the older stored value `debian12`, which Host Details displays as Debian but the new compatibility helpers treated as unknown/unsupported.

## Validation
- `.venv/bin/pytest -p no:cacheprovider tests/test_lan_rate_policy.py tests/test_instance_lan_rate_routes.py tests/test_instance_api_routes.py -v`
- `pnpm exec vitest run src/utils/__tests__/lanRateCompatibility.test.js src/components/instances/__tests__/EditInstanceConfigModal.test.jsx src/components/instances/__tests__/InstanceDetailsModal.test.jsx src/components/__tests__/InstanceActionsMenu.test.jsx`
- `pnpm exec eslint src/utils/lanRateCompatibility.js src/utils/__tests__/lanRateCompatibility.test.js src/components/instances/__tests__/EditInstanceConfigModal.test.jsx`
- `pnpm build`
- `git diff --check`