### PR TITLE
Fix server grid column alignment

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -750,20 +750,10 @@ body {
 .server-grid {
   display: grid;
   column-gap: 12px;
-  grid-template-columns: 56px minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1.25fr) 70px 60px 70px 220px 60px 90px;
+  grid-template-columns: 56px minmax(0, 1.6fr) minmax(0, 0.95fr) minmax(0, 1fr) 70px 60px 70px 140px 60px 90px;
   align-items: center;
   padding-left: 20px;
   padding-right: 20px;
-}
-
-@media (min-width: 901px) {
-  .server-grid.host-header-row,
-  .server-grid.host-row {
-    /* Keep columns 5-10 aligned with instance rows while giving host names more room. */
-    grid-template-columns:
-      56px minmax(0, 1.85fr) minmax(0, 0.7fr) minmax(0, 0.9fr)
-      70px 60px 70px 220px 60px 90px;
-  }
 }
 
 /* Expand/collapse animation */
@@ -818,6 +808,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.instance-status-cell {
+  grid-column: 8 / span 2;
 }
 
 .instance-actions-cell {
@@ -894,7 +888,7 @@ body {
 .instance-row-overlay {
   display: grid;
   column-gap: 12px;
-  grid-template-columns: 56px minmax(0, 1.2fr) minmax(0, 1fr) minmax(0, 1.25fr) 70px 60px 70px 220px 60px 90px;
+  grid-template-columns: 56px minmax(0, 1.6fr) minmax(0, 0.95fr) minmax(0, 1fr) 70px 60px 70px 140px 60px 90px;
   align-items: center;
   padding: 14px 20px;
   background: var(--surface-raised);

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -759,9 +759,10 @@ body {
 @media (min-width: 901px) {
   .server-grid.host-header-row,
   .server-grid.host-row {
+    /* Keep columns 5-10 aligned with instance rows while giving host names more room. */
     grid-template-columns:
-      56px minmax(0, 2.2fr) minmax(0, 0.75fr) minmax(0, 0.9fr)
-      70px 56px 70px 140px 60px 90px;
+      56px minmax(0, 1.85fr) minmax(0, 0.7fr) minmax(0, 0.9fr)
+      70px 60px 70px 220px 60px 90px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Use one shared desktop server grid for host rows, instance rows, and drag overlays so Provider and Server Hostname line up again.
- Tighten the Status to QL-Filter spacing by shrinking the shared status column.
- Let instance status span the status and QL-Filter slots so the Connect button still has room without forcing host rows to carry the extra gap.

## Root Cause
PR #38 fixed host name width by giving host rows a separate desktop grid. That made host and instance columns diverge, and the first follow-up preserved the old wide instance status/connect column, leaving too much empty space before QL-Filter.

## Validation
- `pnpm exec vitest run src/pages/__tests__/ServersPage.test.jsx`
- `pnpm build`

## Notes
- `frontend-react/src/index.css` is already well above the repo's preferred file size limit; this bug fix stays narrowly scoped rather than refactoring the stylesheet.