### PR TITLE
Add confirmation modal for QLFilter uninstall

### DIFF
--- a/frontend-react/src/components/HostActionsMenu.jsx
+++ b/frontend-react/src/components/HostActionsMenu.jsx
@@ -16,6 +16,7 @@ function HostActionsMenu({
   onOpenAutoRestart
 }) {
   const [isInstallQlFilterModalOpen, setIsInstallQlFilterModalOpen] = useState(false);
+  const [isUninstallQlFilterModalOpen, setIsUninstallQlFilterModalOpen] = useState(false);
 
   const { x, y, refs, strategy } = useFloating({
     placement: 'bottom-end',
@@ -43,6 +44,15 @@ function HostActionsMenu({
       message="Installing QLFilter will reconfigure this host. Any running instances will be temporarily unavailable during the configuration process."
       confirmButtonText="Install"
       confirmButtonVariant="primary"
+    />
+    <ConfirmationModal
+      isOpen={isUninstallQlFilterModalOpen}
+      onClose={() => setIsUninstallQlFilterModalOpen(false)}
+      onConfirm={() => { if (typeof onUninstallQlfilter === 'function') onUninstallQlfilter(host.id); setIsUninstallQlFilterModalOpen(false); }}
+      title="Uninstall QLFilter"
+      message="Uninstalling QLFilter will reconfigure this host. Any running instances will be temporarily unavailable during the configuration process."
+      confirmButtonText="Uninstall"
+      confirmButtonVariant="danger"
     />
     <Menu as="div" className="relative inline-block text-left ml-2">
       {({ open, close: closeMenu }) => (
@@ -166,7 +176,7 @@ function HostActionsMenu({
                       } else if (isInstalled) {
                         buttonText = 'Uninstall QLFilter';
                         Icon = ShieldOff;
-                        action = () => { if (typeof onUninstallQlfilter === 'function') onUninstallQlfilter(host.id); closeMenu(); };
+                        action = () => { closeMenu(); setIsUninstallQlFilterModalOpen(true); };
                       } else if (canInstall) {
                         buttonText = 'Install QLFilter';
                         Icon = ShieldCheck;

--- a/frontend-react/src/components/HostActionsMenu.jsx
+++ b/frontend-react/src/components/HostActionsMenu.jsx
@@ -50,7 +50,7 @@ function HostActionsMenu({
       onClose={() => setIsUninstallQlFilterModalOpen(false)}
       onConfirm={() => { if (typeof onUninstallQlfilter === 'function') onUninstallQlfilter(host.id); setIsUninstallQlFilterModalOpen(false); }}
       title="Uninstall QLFilter"
-      message="Uninstalling QLFilter will reconfigure this host. Any running instances will be temporarily unavailable during the configuration process."
+      message="Uninstalling QLFilter will remove packet filtering from this host and reconfigure it. Any running instances will be temporarily unavailable during the process."
       confirmButtonText="Uninstall"
       confirmButtonVariant="danger"
     />


### PR DESCRIPTION
## Summary
- Adds a confirmation modal before uninstalling QLFilter, matching the install confirmation added in PR #36
- Uses `confirmButtonVariant="danger"` to signal the destructive nature of uninstalling
- Uninstall action now opens the modal instead of firing immediately

## Test plan
- [ ] Open the Actions menu for a host with QLFilter installed (ACTIVE or INACTIVE status)
- [ ] Click "Uninstall QLFilter" — confirm the modal appears with a warning message and "Uninstall" button
- [ ] Click Cancel — confirm nothing happens
- [ ] Click Uninstall — confirm uninstallation proceeds as before
- [ ] Verify install confirmation still works as before (regression check)