### PR TITLE
Improve responsive server list layout

### DIFF
--- a/frontend-react/src/components/instances/InstanceRowContent.jsx
+++ b/frontend-react/src/components/instances/InstanceRowContent.jsx
@@ -24,6 +24,7 @@ export default function InstanceRowContent({
             <button
                 onClick={() => onOpenDetails(inst.id)}
                 className="instance-name-cell truncate pl-2 text-left text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
+                title={inst.name}
             >
                 {inst.name}
             </button>

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1099,17 +1099,7 @@ body {
   }
 
   .btn-connect {
-    width: 34px;
-    height: 30px;
-    justify-content: center;
-    gap: 0;
-    padding: 0;
-    font-size: 0;
-  }
-
-  .btn-connect svg {
-    width: 13px;
-    height: 13px;
+    display: none;
   }
 }
 
@@ -1162,21 +1152,7 @@ body {
   }
 
   .btn-connect {
-    width: 34px;
-    height: 30px;
-    justify-content: center;
-    gap: 0;
-    padding: 0;
-    font-size: 0;
-  }
-
-  .btn-connect svg {
-    width: 13px;
-    height: 13px;
-  }
-
-  .btn-connect .connect-tooltip {
-    font-size: 11px;
+    display: none;
   }
 
   .col-label {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -983,6 +983,78 @@ body {
   }
 }
 
+@media (min-width: 901px) and (max-width: 1180px) {
+  .servers-page-shell {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  .server-grid,
+  .instance-row-overlay {
+    column-gap: 10px;
+    grid-template-columns: 42px minmax(160px, 1.6fr) minmax(78px, 0.8fr) minmax(92px, 1fr) 64px 46px 54px 112px 38px 34px;
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .host-actions-trigger,
+  .instance-actions-trigger {
+    gap: 0;
+    padding: 6px;
+  }
+
+  .host-actions-label,
+  .instance-actions-label {
+    display: none;
+  }
+
+  .host-provider-cell,
+  .host-region-cell,
+  .host-ip-cell,
+  .instance-hostname-cell {
+    font-size: 12px;
+  }
+
+  .host-ip-cell {
+    gap: 4px;
+  }
+
+  .host-ip-cell button {
+    padding: 3px;
+  }
+
+  .instance-status-cell {
+    gap: 8px;
+  }
+
+  .live-status-toggle {
+    width: 56px;
+  }
+
+  .btn-connect {
+    width: 34px;
+    height: 30px;
+    justify-content: center;
+    gap: 0;
+    padding: 0;
+    font-size: 0;
+  }
+
+  .btn-connect svg {
+    width: 13px;
+    height: 13px;
+  }
+
+  .btn-connect .connect-tooltip {
+    font-size: 11px;
+  }
+
+  .col-label {
+    font-size: 10px;
+    letter-spacing: 0.8px;
+  }
+}
+
 @media (max-width: 639px) {
   .host-header-row,
   .instances-header-row {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -966,13 +966,122 @@ body {
 }
 
 @media (min-width: 640px) and (max-width: 900px) {
-  .server-grid,
-  .instance-row-overlay {
-    column-gap: 14px;
-    grid-template-columns: 48px minmax(0, 1fr) minmax(0, 0.9fr) minmax(0, 1fr) 58px 48px 58px 112px 44px 32px;
+  .host-header-row,
+  .instances-header-row {
+    display: none;
   }
 
-  .host-actions-trigger {
+  .server-grid,
+  .server-grid.host-row,
+  .instance-row-overlay {
+    grid-template-columns: 32px minmax(0, 1fr) auto auto 34px;
+    gap: 8px 12px;
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .server-grid.host-row,
+  .instance-row-sortable,
+  .instance-row-overlay {
+    align-items: start;
+  }
+
+  .host-row-first-col,
+  .drag-handle {
+    grid-column: 1;
+    grid-row: 1 / span 3;
+    align-self: start;
+    padding-top: 2px;
+  }
+
+  .host-name-cell {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 0;
+  }
+
+  .host-provider-cell {
+    grid-column: 2;
+    grid-row: 2;
+    min-width: 0;
+  }
+
+  .host-region-cell {
+    grid-column: 3 / 6;
+    grid-row: 2;
+    min-width: 0;
+  }
+
+  .host-ip-cell {
+    grid-column: 2 / 6 !important;
+    grid-row: 3;
+    min-width: 0;
+  }
+
+  .host-status-cell {
+    grid-column: 3;
+    grid-row: 1;
+    justify-self: end;
+  }
+
+  .host-qlfilter-cell {
+    grid-column: 4;
+    grid-row: 1;
+    align-self: center;
+    justify-self: end;
+  }
+
+  .host-actions-cell {
+    grid-column: 5;
+    grid-row: 1;
+    align-self: center;
+    justify-self: end;
+  }
+
+  .instance-name-cell {
+    grid-column: 2 / 5;
+    grid-row: 1;
+    min-width: 0;
+    padding-left: 0;
+  }
+
+  .instance-hostname-cell {
+    grid-column: 2 / 5 !important;
+    grid-row: 2;
+    min-width: 0;
+  }
+
+  .instance-status-cell {
+    grid-column: 2 / 5;
+    grid-row: 3;
+    min-width: 0;
+    gap: 8px;
+  }
+
+  .instance-port-cell {
+    grid-column: 2;
+    grid-row: 4;
+  }
+
+  .instance-rate-cell {
+    grid-column: 3;
+    grid-row: 4;
+  }
+
+  .instance-players-cell {
+    grid-column: 4;
+    grid-row: 4;
+  }
+
+  .instance-actions-cell {
+    grid-column: 5;
+    grid-row: 1;
+    align-self: start;
+    justify-self: end;
+  }
+
+  .host-actions-trigger,
+  .instance-actions-trigger {
     gap: 0;
     padding: 6px;
   }
@@ -980,6 +1089,27 @@ body {
   .host-actions-label,
   .instance-actions-label {
     display: none;
+  }
+
+  .host-provider-cell,
+  .host-region-cell,
+  .host-ip-cell,
+  .instance-hostname-cell {
+    font-size: 12px;
+  }
+
+  .btn-connect {
+    width: 34px;
+    height: 30px;
+    justify-content: center;
+    gap: 0;
+    padding: 0;
+    font-size: 0;
+  }
+
+  .btn-connect svg {
+    width: 13px;
+    height: 13px;
   }
 }
 

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1275,7 +1275,7 @@ body {
 
   .host-row-first-col,
   .drag-handle {
-    grid-row: 1 / span 3;
+    grid-row: 1 / span 4;
     align-self: start;
     padding-top: 2px;
   }
@@ -1312,10 +1312,10 @@ body {
   }
 
   .host-status-cell {
-    grid-column: 3;
-    grid-row: 1;
-    justify-self: end;
-    padding-right: 64px;
+    grid-column: 2 / 4;
+    grid-row: 4;
+    justify-self: start;
+    padding-right: 0;
   }
 
   .host-qlfilter-cell {

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1291,7 +1291,7 @@ body {
   }
 
   .host-region-cell {
-    grid-column: 2;
+    grid-column: 2 / 4;
     grid-row: 2;
     min-width: 0;
   }

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1103,6 +1103,98 @@ body {
   }
 }
 
+@media (min-width: 740px) and (max-width: 900px) {
+  .server-grid,
+  .server-grid.host-row,
+  .instance-row-overlay {
+    grid-template-columns: 28px minmax(160px, 1.6fr) minmax(124px, 1.05fr) minmax(88px, 0.75fr) 112px 28px 28px;
+    gap: 6px 10px;
+  }
+
+  .server-card .host-row,
+  .server-card .instance-row {
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
+
+  .host-row-first-col,
+  .drag-handle {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+  }
+
+  .host-name-cell {
+    grid-column: 2 / 4;
+    grid-row: 1;
+  }
+
+  .host-provider-cell {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .host-region-cell {
+    grid-column: 3;
+    grid-row: 2;
+  }
+
+  .host-ip-cell {
+    grid-column: 4 / 6 !important;
+    grid-row: 2;
+  }
+
+  .host-status-cell {
+    grid-column: 5;
+    grid-row: 1;
+  }
+
+  .host-qlfilter-cell {
+    grid-column: 6;
+    grid-row: 1;
+  }
+
+  .host-actions-cell {
+    grid-column: 7;
+    grid-row: 1;
+  }
+
+  .instance-name-cell {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .instance-hostname-cell {
+    grid-column: 3 !important;
+    grid-row: 1;
+  }
+
+  .instance-port-cell {
+    grid-column: 4;
+    grid-row: 1;
+  }
+
+  .instance-rate-cell {
+    grid-column: 4;
+    grid-row: 2;
+  }
+
+  .instance-players-cell {
+    grid-column: 5;
+    grid-row: 2;
+  }
+
+  .instance-status-cell {
+    grid-column: 5;
+    grid-row: 1;
+  }
+
+  .instance-actions-cell {
+    grid-column: 7;
+    grid-row: 1;
+    align-self: center;
+  }
+}
+
 @media (min-width: 901px) and (max-width: 1180px) {
   .servers-page-shell {
     padding-left: 20px;

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -148,7 +148,7 @@ export default function ServersPage() {
     }
 
     return (
-        <div className="max-w-[1280px] mx-auto px-4 py-6 sm:px-8 sm:py-8">
+        <div className="servers-page-shell max-w-[1280px] mx-auto px-4 py-6 sm:px-8 sm:py-8">
             {/* Page Header */}
             <div className="mb-7 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                 <div className="min-w-0">
@@ -230,6 +230,7 @@ export default function ServersPage() {
                                     onClick={(e) => { e.stopPropagation(); handleOpenHostDrawer(host.id); }}
                                     className="host-name-cell text-[15px] font-semibold hover:underline text-left truncate min-w-0"
                                     style={{ color: 'var(--accent-primary)' }}
+                                    title={host.name}
                                 >
                                     {host.name}
                                 </button>


### PR DESCRIPTION
## Summary
- Add dedicated iPad Pro and iPad Mini server-list breakpoints so host and instance names remain readable.
- Hide Connect buttons on iPad layouts to reduce crowding.
- Tighten iPad Mini rows and keep mobile host name/region visible on phone-sized cards.

## Validation
- `pnpm exec vitest run src/pages/__tests__/ServersPage.test.jsx` passed.
- `pnpm build` passed.
- Browser checks covered 1024x1366, 768x1024, and 412x915 responsive layouts.

## Notes
- `pnpm lint` was previously checked and still fails on pre-existing unrelated frontend lint issues outside this change.