### PR TITLE
fix: rename 'Server Hostname' column to 'Hostname'

### DIFF
--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -279,7 +279,7 @@ export default function ServersPage() {
                                 <div className="server-grid py-2.5 instances-header-row">
                                     <span />
                                     <span className="col-label">Name</span>
-                                    <span className="col-label">Server Hostname</span>
+                                    <span className="col-label">Hostname</span>
                                     <span />
                                     <span className="col-label">Port</span>
                                     <span className="col-label">Rate</span>


### PR DESCRIPTION
## Summary
- Renames the instances table column header from \"Server Hostname\" to \"Hostname\" on the Servers page for brevity and consistency

## Test plan
- [ ] Navigate to the Servers page and expand an instance row — verify the column header reads \"Hostname\"
- [ ] Confirm no other column labels or functionality are affected