### PR TITLE
Use resilient DNS resolvers for hosts

### DIFF
--- a/ansible/playbooks/setup_host.yml
+++ b/ansible/playbooks/setup_host.yml
@@ -65,7 +65,7 @@
             address {{ current_ip }}
             netmask {{ current_netmask }}
             gateway {{ current_gateway }}
-            dns-nameservers 1.1.1.1 8.8.8.8
+            dns-nameservers 8.8.8.8 9.9.9.9
       notify: restart networking
       when: ansible_facts['os_family'] == 'Debian' and not is_standalone
 

--- a/ansible/playbooks/setup_host.yml
+++ b/ansible/playbooks/setup_host.yml
@@ -69,6 +69,18 @@
       notify: restart networking
       when: ansible_facts['os_family'] == 'Debian' and not is_standalone
 
+    - name: Configure resolv.conf resolver options
+      copy:
+        dest: /etc/resolv.conf
+        content: |
+          nameserver 8.8.8.8
+          nameserver 9.9.9.9
+          options timeout:2 attempts:2 rotate
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'Debian' and not is_standalone
+
   #######################################################################
   # 1. Base packages & ssh hardening
   #######################################################################

--- a/terraform/startup_scripts/ansible_client_setup.sh
+++ b/terraform/startup_scripts/ansible_client_setup.sh
@@ -34,6 +34,6 @@ sudo chmod 0440 /etc/sudoers.d/$ANSIBLE_USER
 
 # Fix DNS resolution
 echo "Fixing DNS resolution..."
-echo "nameserver 1.1.1.1" > /etc/resolv.conf
+printf "nameserver 8.8.8.8\nnameserver 9.9.9.9\noptions timeout:2 attempts:2 rotate\n" > /etc/resolv.conf
 
 echo "Setup complete."


### PR DESCRIPTION
## Summary
- replace the managed-host ifupdown DNS defaults with `8.8.8.8` and `9.9.9.9`
- update the Terraform bootstrap script so newly provisioned hosts write both resolvers plus short resolver timeout options

## Why
The NJ host had `/etc/resolv.conf` pinned to only `1.1.1.1`, and UDP DNS to that resolver timed out from the host. QLDS then hung while waiting for Steam servers. Using two resolvers that tested successfully from the host avoids making Cloudflare DNS a single point of failure for startup.

## Validation
- `bash -n terraform/startup_scripts/ansible_client_setup.sh`
- `ansible-playbook --syntax-check -i localhost, ansible/playbooks/setup_host.yml`