### PR TITLE
feat: seed BinaryMetadata from builtin preset manifest binary_descriptions

### DIFF
--- a/configs/presets/_builtin/default/preset.json
+++ b/configs/presets/_builtin/default/preset.json
@@ -1,4 +1,7 @@
 {
   "description": "Default QLSM preset",
-  "builtin": true
+  "builtin": true,
+  "binary_descriptions": {
+    "scripts/highfps_hook.so": "Server-side hook enabling high-tickrate (125 Hz) QLDS operation"
+  }
 }

--- a/tests/test_builtin_presets_cli.py
+++ b/tests/test_builtin_presets_cli.py
@@ -318,3 +318,23 @@ def test_sync_no_binary_metadata_when_field_absent(runner, app, tmp_path, monkey
             context_key='duel',
         ).all()
         assert rows == []
+
+
+def test_remove_orphaned_deletes_binary_metadata(runner, app, tmp_path, monkeypatch):
+    import shutil
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions={'scripts/hook.so': 'My hook'})
+    write_so_file('duel', 'scripts/hook.so')
+    assert runner.invoke(args=['sync-builtin-presets']).exit_code == 0
+
+    shutil.rmtree(builtin_preset_path('duel'))
+
+    result = runner.invoke(args=['sync-builtin-presets', '--remove-orphaned'])
+
+    assert result.exit_code == 0
+    with app.app_context():
+        rows = BinaryMetadata.query.filter_by(
+            context_type='preset',
+            context_key='duel',
+        ).all()
+        assert rows == []

--- a/tests/test_builtin_presets_cli.py
+++ b/tests/test_builtin_presets_cli.py
@@ -282,7 +282,7 @@ def test_sync_overwrites_binary_metadata_on_resync(runner, app, tmp_path, monkey
             context_type='preset',
             context_key='duel',
             file_path='scripts/hook.so',
-        ).first()
+        ).one()
         assert row.description == 'New desc'
 
 

--- a/tests/test_builtin_presets_cli.py
+++ b/tests/test_builtin_presets_cli.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from ui import db
-from ui.models import ConfigPreset
+from ui.models import BinaryMetadata, ConfigPreset
 from ui.preset_support import builtin_preset_path
 
 
@@ -247,3 +247,74 @@ def test_sync_rejects_binary_descriptions_not_dict(runner, tmp_path, monkeypatch
 
     assert result.exit_code != 0
     assert 'binary_descriptions' in result.output
+
+
+def test_sync_seeds_binary_metadata_row(runner, app, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions={'scripts/hook.so': 'My hook'})
+    write_so_file('duel', 'scripts/hook.so')
+
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code == 0
+    with app.app_context():
+        row = BinaryMetadata.query.filter_by(
+            context_type='preset',
+            context_key='duel',
+            file_path='scripts/hook.so',
+        ).first()
+        assert row is not None
+        assert row.description == 'My hook'
+
+
+def test_sync_overwrites_binary_metadata_on_resync(runner, app, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions={'scripts/hook.so': 'Old desc'})
+    write_so_file('duel', 'scripts/hook.so')
+    assert runner.invoke(args=['sync-builtin-presets']).exit_code == 0
+
+    write_manifest('duel', 'Duel', binary_descriptions={'scripts/hook.so': 'New desc'})
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code == 0
+    with app.app_context():
+        row = BinaryMetadata.query.filter_by(
+            context_type='preset',
+            context_key='duel',
+            file_path='scripts/hook.so',
+        ).first()
+        assert row.description == 'New desc'
+
+
+def test_sync_deletes_stale_binary_metadata_row(runner, app, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions={'scripts/hook.so': 'My hook'})
+    write_so_file('duel', 'scripts/hook.so')
+    assert runner.invoke(args=['sync-builtin-presets']).exit_code == 0
+
+    write_manifest('duel', 'Duel')
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code == 0
+    with app.app_context():
+        row = BinaryMetadata.query.filter_by(
+            context_type='preset',
+            context_key='duel',
+            file_path='scripts/hook.so',
+        ).first()
+        assert row is None
+
+
+def test_sync_no_binary_metadata_when_field_absent(runner, app, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel')
+
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code == 0
+    with app.app_context():
+        rows = BinaryMetadata.query.filter_by(
+            context_type='preset',
+            context_key='duel',
+        ).all()
+        assert rows == []

--- a/tests/test_builtin_presets_cli.py
+++ b/tests/test_builtin_presets_cli.py
@@ -6,11 +6,22 @@ from ui.models import ConfigPreset
 from ui.preset_support import builtin_preset_path
 
 
-def write_manifest(name, description='Built-in preset', builtin=True):
+def write_manifest(name, description='Built-in preset', builtin=True, binary_descriptions=None):
     preset_dir = builtin_preset_path(name)
     os.makedirs(preset_dir, exist_ok=True)
+    manifest = {'description': description, 'builtin': builtin}
+    if binary_descriptions is not None:
+        manifest['binary_descriptions'] = binary_descriptions
     with open(os.path.join(preset_dir, 'preset.json'), 'w', encoding='utf-8') as handle:
-        json.dump({'description': description, 'builtin': builtin}, handle)
+        json.dump(manifest, handle)
+
+
+def write_so_file(preset_name, relative_path):
+    preset_dir = builtin_preset_path(preset_name)
+    full_path = os.path.join(preset_dir, relative_path)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    with open(full_path, 'wb') as fh:
+        fh.write(b'\x7fELF')
 
 
 def test_sync_builtin_presets_inserts_valid_manifest(runner, app, tmp_path, monkeypatch):
@@ -173,3 +184,66 @@ def test_delete_preset_rejects_internal_namespace(runner, app, tmp_path, monkeyp
     assert result.exit_code == 0
     assert "Cannot delete internal preset namespace '_builtin'" in result.output
     assert os.path.exists(marker)
+
+
+def test_sync_rejects_binary_description_too_long(runner, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions={'scripts/hook.so': 'x' * 101})
+    write_so_file('duel', 'scripts/hook.so')
+
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code != 0
+    assert 'binary_descriptions' in result.output
+
+
+def test_sync_rejects_binary_description_bad_chars(runner, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions={'scripts/hook.so': '<script>'})
+    write_so_file('duel', 'scripts/hook.so')
+
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code != 0
+    assert 'binary_descriptions' in result.output
+
+
+def test_sync_rejects_binary_descriptions_non_so_key(runner, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions={'scripts/hook.py': 'A description'})
+
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code != 0
+    assert 'binary_descriptions' in result.output
+
+
+def test_sync_rejects_binary_descriptions_path_traversal(runner, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions={'../hook.so': 'A description'})
+
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code != 0
+    assert 'binary_descriptions' in result.output
+
+
+def test_sync_rejects_binary_descriptions_missing_file(runner, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions={'scripts/missing.so': 'A description'})
+    # intentionally do NOT create the .so file
+
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code != 0
+    assert 'binary_descriptions' in result.output
+
+
+def test_sync_rejects_binary_descriptions_not_dict(runner, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_manifest('duel', 'Duel', binary_descriptions=['hook.so'])
+
+    result = runner.invoke(args=['sync-builtin-presets'])
+
+    assert result.exit_code != 0
+    assert 'binary_descriptions' in result.output

--- a/ui/builtin_presets.py
+++ b/ui/builtin_presets.py
@@ -157,6 +157,10 @@ def sync_builtin_presets(remove_orphaned=False):
         if os.path.isdir(row.path):
             continue
         if remove_orphaned:
+            BinaryMetadata.query.filter_by(
+                context_type='preset',
+                context_key=row.name,
+            ).delete()
             db.session.delete(row)
             click.echo(f"Removed orphaned built-in preset row: {row.name}")
         else:

--- a/ui/builtin_presets.py
+++ b/ui/builtin_presets.py
@@ -84,6 +84,31 @@ def _iter_builtin_dirs():
             yield name, preset_dir
 
 
+def _sync_binary_metadata(preset_name, desired):
+    """Upsert BinaryMetadata rows for a builtin preset and delete stale ones."""
+    existing_rows = BinaryMetadata.query.filter_by(
+        context_type='preset',
+        context_key=preset_name,
+    ).all()
+
+    existing_by_path = {row.file_path: row for row in existing_rows}
+
+    for file_path, description in desired.items():
+        if file_path in existing_by_path:
+            existing_by_path[file_path].description = description
+        else:
+            db.session.add(BinaryMetadata(
+                context_type='preset',
+                context_key=preset_name,
+                file_path=file_path,
+                description=description,
+            ))
+
+    for file_path, row in existing_by_path.items():
+        if file_path not in desired:
+            db.session.delete(row)
+
+
 def sync_builtin_presets(remove_orphaned=False):
     seen_names = set()
 
@@ -123,6 +148,8 @@ def sync_builtin_presets(remove_orphaned=False):
                 "a user preset with that name already exists. "
                 "Rename or delete it via the UI, then re-run 'flask sync-builtin-presets'."
             )
+
+        _sync_binary_metadata(name, manifest['binary_descriptions'])
 
     for row in ConfigPreset.query.filter_by(is_builtin=True).all():
         if row.name in seen_names:

--- a/ui/builtin_presets.py
+++ b/ui/builtin_presets.py
@@ -16,7 +16,7 @@ from ui.preset_support import (
 
 
 _DESCRIPTION_MAX_LEN = 100
-_DESCRIPTION_RE = re.compile(r'^[^<>{}"]*$')
+_DESCRIPTION_RE = re.compile(r'^[\w .,;:()\'\-]*$')
 
 
 class BuiltinPresetError(ValueError):

--- a/ui/builtin_presets.py
+++ b/ui/builtin_presets.py
@@ -1,11 +1,12 @@
 import json
 import os
+import re
 
 import click
 from flask.cli import with_appcontext
 
 from ui import db
-from ui.models import ConfigPreset
+from ui.models import BinaryMetadata, ConfigPreset
 from ui.preset_support import (
     BUILTIN_PRESETS_DIR,
     builtin_preset_path,
@@ -14,8 +15,47 @@ from ui.preset_support import (
 )
 
 
+_DESCRIPTION_MAX_LEN = 100
+_DESCRIPTION_RE = re.compile(r'^[^<>{}"]*$')
+
+
 class BuiltinPresetError(ValueError):
     pass
+
+
+def _validate_binary_descriptions(binary_descriptions, preset_dir, manifest_path):
+    """Validate binary_descriptions dict from preset.json. Returns the dict on success."""
+    if not isinstance(binary_descriptions, dict):
+        raise BuiltinPresetError(
+            f"{manifest_path}: binary_descriptions must be an object."
+        )
+    for key, value in binary_descriptions.items():
+        if not isinstance(key, str) or not key.endswith('.so'):
+            raise BuiltinPresetError(
+                f"{manifest_path}: binary_descriptions key {key!r} must be a string ending in .so"
+            )
+        if key.startswith('/') or '..' in key:
+            raise BuiltinPresetError(
+                f"{manifest_path}: binary_descriptions key {key!r} must be a relative path with no '..'."
+            )
+        if not isinstance(value, str):
+            raise BuiltinPresetError(
+                f"{manifest_path}: binary_descriptions[{key!r}] must be a string."
+            )
+        if len(value) > _DESCRIPTION_MAX_LEN:
+            raise BuiltinPresetError(
+                f"{manifest_path}: binary_descriptions[{key!r}] exceeds {_DESCRIPTION_MAX_LEN} characters."
+            )
+        if not _DESCRIPTION_RE.match(value):
+            raise BuiltinPresetError(
+                f"{manifest_path}: binary_descriptions[{key!r}] contains invalid characters."
+            )
+        full_path = os.path.join(preset_dir, key)
+        if not os.path.isfile(full_path):
+            raise BuiltinPresetError(
+                f"{manifest_path}: binary_descriptions key {key!r} does not exist at {full_path}."
+            )
+    return binary_descriptions
 
 
 def _load_manifest(preset_dir):
@@ -29,7 +69,10 @@ def _load_manifest(preset_dir):
     if manifest.get('builtin') is not True:
         raise BuiltinPresetError(f"{manifest_path}: builtin must be true.")
 
-    return {'description': description.strip()}
+    binary_descriptions = manifest.get('binary_descriptions', {})
+    validated = _validate_binary_descriptions(binary_descriptions, preset_dir, manifest_path)
+
+    return {'description': description.strip(), 'binary_descriptions': validated}
 
 
 def _iter_builtin_dirs():


### PR DESCRIPTION
## Summary

- Extends `preset.json` with an optional `binary_descriptions` field (`{ "scripts/hook.so": "description" }`)
- `flask sync-builtin-presets` now upserts/deletes `BinaryMetadata` rows for each builtin preset from this field
- Orphan cleanup (`--remove-orphaned`) also deletes associated `BinaryMetadata` rows
- Adds `binary_descriptions` for `scripts/highfps_hook.so` to the default builtin preset manifest

## Validation

- `pytest tests/test_builtin_presets_cli.py -v` — 21 passed (11 new tests covering validation, seeding, overwrite, stale cleanup, and orphan cleanup)