### PR TITLE
feat: add All option to server logs filter

### DIFF
--- a/ansible/playbooks/fetch_instance_logs.yml
+++ b/ansible/playbooks/fetch_instance_logs.yml
@@ -6,7 +6,7 @@
 
   vars:
     game_port: "{{ port }}"
-    # Log filter mode: 'time' or 'lines'
+    # Log filter mode: 'time', 'lines', or 'all'
     log_mode: "{{ filter_mode | default('lines') }}"
     # Time period for time-based filtering (e.g., '1 hour ago', '15 minutes ago')
     log_since: "{{ since | default('1 hour ago') }}"
@@ -30,9 +30,20 @@
       failed_when: false
       when: log_mode == 'lines'
 
+    - name: Query journalctl for all entries (when log_mode is 'all')
+      ansible.builtin.command:
+        cmd: journalctl -u qlds@{{ game_port }}.service --no-pager
+      register: journal_output_all
+      changed_when: false
+      failed_when: false
+      when: log_mode == 'all'
+
     - name: Set combined output
       ansible.builtin.set_fact:
-        combined_output: "{{ (journal_output_time.stdout | default('')) if log_mode == 'time' else (journal_output_lines.stdout | default('')) }}"
+        combined_output: >-
+          {{ (journal_output_time.stdout | default('')) if log_mode == 'time'
+             else (journal_output_all.stdout | default('')) if log_mode == 'all'
+             else (journal_output_lines.stdout | default('')) }}
 
     - name: Output logs to stdout for capture
       ansible.builtin.debug:

--- a/frontend-react/src/components/instances/ViewLogsModal.jsx
+++ b/frontend-react/src/components/instances/ViewLogsModal.jsx
@@ -229,6 +229,12 @@ function ViewLogsModal({ isOpen, onClose, instance }) {
                                             </div>
                                         )}
 
+                                        {filterMode === 'all' && (
+                                            <span className="font-mono text-xs" style={{ color: 'var(--accent-warning, #f59e0b)' }}>
+                                                ⚠ May fetch a very large log — slow on long-running servers
+                                            </span>
+                                        )}
+
                                         {/* Apply Button */}
                                         <button
                                             onClick={fetchLogs}

--- a/frontend-react/src/components/instances/ViewLogsModal.jsx
+++ b/frontend-react/src/components/instances/ViewLogsModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, Fragment } from 'react';
 import { Dialog, Transition, RadioGroup } from '@headlessui/react';
-import { X, RefreshCw, Terminal, AlertCircle, Clock, List, Maximize } from 'lucide-react';
+import { X, RefreshCw, Terminal, AlertCircle, Clock, List, Maximize, DatabaseZap } from 'lucide-react';
 import CodeMirrorEditor from '../CodeMirrorEditor';
 import ExpandedEditorModal from '../ExpandedEditorModal';
 import { logLanguage } from '../../utils/logLanguage';
@@ -16,6 +16,7 @@ import { fetchInstanceRemoteLogs } from '../../services/api';
 const FILTER_MODES = [
     { value: 'lines', label: 'Last N Lines', icon: List },
     { value: 'time', label: 'Time Range', icon: Clock },
+    { value: 'all', label: 'All', icon: DatabaseZap },
 ];
 
 // Line count options
@@ -96,12 +97,10 @@ function ViewLogsModal({ isOpen, onClose, instance }) {
 
     // Get current filter description
     const getFilterDescription = () => {
-        if (filterMode === 'lines') {
-            return `Last ${lineCount} lines`;
-        } else {
-            const option = TIME_OPTIONS.find(o => o.value === timeRange);
-            return option ? `Last ${option.label}` : timeRange;
-        }
+        if (filterMode === 'lines') return `Last ${lineCount} lines`;
+        if (filterMode === 'all') return 'All entries';
+        const option = TIME_OPTIONS.find(o => o.value === timeRange);
+        return option ? `Last ${option.label}` : timeRange;
     };
 
     return (

--- a/ui/routes/instance_routes.py
+++ b/ui/routes/instance_routes.py
@@ -495,9 +495,9 @@ def view_instance_logs_api(instance_id): # Renamed function
 @jwt_required()
 def fetch_remote_logs_api(instance_id):
     """Fetches logs from the remote QLDS instance via Ansible journalctl.
-    
+
     Query parameters:
-        filter_mode: 'time' or 'lines' (default: 'lines')
+        filter_mode: 'time', 'lines', or 'all' (default: 'lines')
         since: Time period for time-based filtering (default: '1 hour ago')
         lines: Number of lines for line-based filtering (default: 500)
     """
@@ -517,11 +517,11 @@ def fetch_remote_logs_api(instance_id):
     lines = request.args.get('lines', 500, type=int)
     
     # Validate filter_mode
-    if filter_mode not in ('time', 'lines'):
-        return jsonify({"error": {"message": "filter_mode must be 'time' or 'lines'"}}), 400
-    
-    # Validate lines (sensible range)
-    if lines < 10 or lines > 10000:
+    if filter_mode not in ('time', 'lines', 'all'):
+        return jsonify({"error": {"message": "filter_mode must be 'time', 'lines', or 'all'"}}), 400
+
+    # Validate lines (sensible range) — not applicable for 'all' mode
+    if filter_mode != 'all' and (lines < 10 or lines > 10000):
         return jsonify({"error": {"message": "lines must be between 10 and 10000"}}), 400
 
     current_app.logger.info(f"Fetching remote logs for instance {instance_id} ({instance.name}) - mode: {filter_mode}, since: {since}, lines: {lines}")

--- a/ui/task_logic/ansible_instance_mgmt.py
+++ b/ui/task_logic/ansible_instance_mgmt.py
@@ -771,7 +771,7 @@ def fetch_instance_remote_logs(instance_id, filter_mode='lines', since='1 hour a
     
     Args:
         instance_id: ID of the instance
-        filter_mode: 'time' for time-based filtering, 'lines' for line count
+        filter_mode: 'time' for time-based filtering, 'lines' for line count, 'all' for full journal
         since: Time period for time-based filtering (e.g., '1 hour ago', '15 minutes ago')
         lines: Number of lines for line-based filtering
     


### PR DESCRIPTION
## Summary
- Adds a third filter mode `all` to the View Logs modal, alongside `Last N Lines` and `Time Range`
- Selecting `All` pulls the complete journald history for the instance with no `--since` or `-n` constraint
- Backend validates the new mode and skips the `lines` range check when `all` is selected
- Ansible playbook gains a new `journalctl` task for `all` mode with appropriate conditional output merging

## Test plan
- [ ] Open View Logs modal, select `All` filter mode and click Apply — should fetch all available journal entries
- [ ] Verify `Last N Lines` and `Time Range` modes continue to work as before
- [ ] Confirm header subtitle shows `All entries` when `all` mode is active