### PR TITLE
Add recommended plan badge

### DIFF
--- a/frontend-react/src/components/common/FloatingListbox.jsx
+++ b/frontend-react/src/components/common/FloatingListbox.jsx
@@ -3,6 +3,16 @@ import { Listbox, Transition, Portal } from '@headlessui/react';
 import { useFloating, offset, flip, shift, autoUpdate } from '@floating-ui/react-dom';
 import { Check, ChevronsUpDown } from 'lucide-react';
 
+function OptionBadge({ children }) {
+  if (!children) return null;
+
+  return (
+    <span className="shrink-0 whitespace-nowrap rounded border border-[var(--accent-primary)] bg-[var(--surface-elevated)] px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase text-[var(--accent-primary)]">
+      {children}
+    </span>
+  );
+}
+
 function FloatingListbox({
   value,
   onChange,
@@ -12,6 +22,7 @@ function FloatingListbox({
   getOptionKey = (option) => option.id,
   getOptionValue = null,
   getOptionDisplay = (option) => option.name,
+  getOptionBadge = null,
   getSelectedDisplay = (selectedValue, opts) => {
     if (!selectedValue) return `Select ${label.toLowerCase()}`;
     const actualOptionValueFn = getOptionValue || getOptionKey;
@@ -21,6 +32,10 @@ function FloatingListbox({
   placeholder = `Select ${label.toLowerCase()}`,
   noOptionsMessage = "No options available."
 }) {
+  const optionValueFn = getOptionValue || getOptionKey;
+  const selectedOption = options.find(opt => optionValueFn(opt) === value);
+  const selectedBadge = selectedOption && getOptionBadge?.(selectedOption);
+  const selectedDisplay = getSelectedDisplay(value, options) || placeholder;
 
   const { x, y, strategy, refs } = useFloating({
     placement: 'bottom-start',
@@ -42,7 +57,14 @@ function FloatingListbox({
                 border: '1px solid var(--surface-border)',
               }}
             >
-              <span className="block truncate">{getSelectedDisplay(value, options) || placeholder}</span>
+              <span className="flex min-w-0 items-center gap-2">
+                <span className="block min-w-0 flex-1 truncate">{selectedDisplay}</span>
+                {selectedBadge && (
+                  <span className="shrink-0 mr-[74px]">
+                    <OptionBadge>{selectedBadge}</OptionBadge>
+                  </span>
+                )}
+              </span>
               <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                 <ChevronsUpDown className="h-4 w-4 text-theme-muted" aria-hidden="true" />
               </span>
@@ -80,25 +102,32 @@ function FloatingListbox({
                       options.map((option) => {
                         const optionKeyValue = getOptionKey(option);
                         const displayValue = getOptionDisplay(option);
-                        const valueForOption = (getOptionValue || getOptionKey)(option);
+                        const valueForOption = optionValueFn(option);
+                        const badge = getOptionBadge?.(option);
 
                         return (
                           <Listbox.Option
                             key={optionKeyValue}
                             value={valueForOption}
                             className={({ active }) =>
-                              `relative cursor-default select-none py-2 pl-3 pr-9 transition-colors ${active ? 'bg-black/[0.04] dark:bg-white/[0.06] text-theme-primary' : 'text-theme-secondary'
+                              `relative cursor-default select-none py-2 px-3 transition-colors ${active ? 'bg-black/[0.04] dark:bg-white/[0.06] text-theme-primary' : 'text-theme-secondary'
                               }`
                             }
                           >
-                            {({ selected, active }) => (
-                              <div className="relative flex items-center justify-between w-full">
-                                <span className={`block truncate ${selected ? 'font-semibold' : 'font-normal'}`}>
+                            {({ selected }) => (
+                              <div className="flex w-full min-w-0 items-center gap-2">
+                                <span className={`block min-w-0 flex-1 truncate ${selected ? 'font-semibold' : 'font-normal'}`}>
                                   {displayValue}
                                 </span>
-                                {selected && (
-                                  <span className="absolute inset-y-0 right-0 flex items-center pr-3" style={{ color: 'var(--accent-primary)' }}>
-                                    <Check className="h-4 w-4" aria-hidden="true" />
+                                {(badge || selected) && (
+                                  <span className="grid w-40 shrink-0 grid-cols-[1fr_auto] items-center gap-2">
+                                    <span className="justify-self-start">
+                                      <OptionBadge>{badge}</OptionBadge>
+                                    </span>
+                                    {selected && (
+                                      <Check className="h-4 w-4" style={{ color: 'var(--accent-primary)' }} aria-hidden="true" />
+                                    )}
+                                    {!selected && <span className="h-4 w-4" aria-hidden="true" />}
                                   </span>
                                 )}
                               </div>

--- a/frontend-react/src/components/common/__tests__/FloatingListbox.test.jsx
+++ b/frontend-react/src/components/common/__tests__/FloatingListbox.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import FloatingListbox from '../FloatingListbox';
+
+describe('FloatingListbox', () => {
+  it('renders an option badge beside the selected option', () => {
+    render(
+      <FloatingListbox
+        label="Plan"
+        value="vhf-1c-1gb"
+        onChange={vi.fn()}
+        options={[
+          {
+            id: 'vhf-1c-1gb',
+            name: 'High Frequency - 1 vCPU / 1 GB RAM / $6/mo',
+            badgeLabel: 'Recommended',
+          },
+          {
+            id: 'vc2-1c-1gb',
+            name: 'Cloud Compute - 1 vCPU / 1 GB RAM / $5/mo',
+          },
+        ]}
+        getOptionBadge={(option) => option.badgeLabel}
+      />
+    );
+
+    const button = screen.getByRole('button');
+    expect(within(button).getByText('Recommended')).toBeInTheDocument();
+
+    expect(button).toHaveTextContent('High Frequency - 1 vCPU / 1 GB RAM / $6/mo');
+  });
+});

--- a/frontend-react/src/components/hosts/AddHostFormFields.jsx
+++ b/frontend-react/src/components/hosts/AddHostFormFields.jsx
@@ -157,6 +157,7 @@ function AddHostFormFields({
             disabled={isVultrUnavailable || !provider || currentSizes.length === 0}
             getOptionKey={(opt) => opt.id}
             getOptionDisplay={(opt) => opt.name}
+            getOptionBadge={(opt) => opt.badgeLabel}
             getSelectedDisplay={(val, opts) => {
               if (!val) return 'Select Size';
               const selectedOpt = opts.find(o => o.id === val);

--- a/frontend-react/src/utils/providerData.js
+++ b/frontend-react/src/utils/providerData.js
@@ -60,7 +60,7 @@ export const providerOptions = {
       ],
       // NOTE: Mirrors ui/vultr_plans.py. Tests assert parity.
       sizes: [
-        { id: 'vhf-1c-1gb', name: planName('vhf', 1, 1024, 6), family: 'vhf', vcpu: 1, ram_mb: 1024, disk_gb: 32, bandwidth_gb: 1024, price_usd: 6.00, locations: LOC_VC2_VHF },
+        { id: 'vhf-1c-1gb', name: planName('vhf', 1, 1024, 6), badgeLabel: 'Recommended', family: 'vhf', vcpu: 1, ram_mb: 1024, disk_gb: 32, bandwidth_gb: 1024, price_usd: 6.00, locations: LOC_VC2_VHF },
         { id: 'vhf-1c-2gb', name: planName('vhf', 1, 2048, 12), family: 'vhf', vcpu: 1, ram_mb: 2048, disk_gb: 64, bandwidth_gb: 2048, price_usd: 12.00, locations: LOC_VC2_VHF },
         { id: 'vhf-2c-2gb', name: planName('vhf', 2, 2048, 18), family: 'vhf', vcpu: 2, ram_mb: 2048, disk_gb: 80, bandwidth_gb: 3072, price_usd: 18.00, locations: LOC_VC2_VHF },
         { id: 'vhf-2c-4gb', name: planName('vhf', 2, 4096, 24), family: 'vhf', vcpu: 2, ram_mb: 4096, disk_gb: 128, bandwidth_gb: 3072, price_usd: 24.00, locations: LOC_VC2_VHF },


### PR DESCRIPTION
## Summary

- Marks the `vhf-1c-1gb` Vultr plan as Recommended in provider data.
- Adds optional badge rendering to the shared `FloatingListbox` component.
- Wires the Machine Size / Plan field to show plan badges and keeps the badge/checkmark layout aligned.
- Adds focused coverage for selected-option badge rendering.

## Validation

- `pnpm exec eslint src/components/common/FloatingListbox.jsx src/components/common/__tests__/FloatingListbox.test.jsx src/components/hosts/AddHostFormFields.jsx src/utils/providerData.js`
- `pnpm exec vitest run src/components/common/__tests__/FloatingListbox.test.jsx src/components/hosts/__tests__/AddHostFormFields.test.jsx`
- `pytest tests/test_vultr_plans.py`
- `pnpm build`

Build completed with the existing Browserslist/chunk-size warnings.