### PR TITLE
fix: apply SQLite WAL mode and busy_timeout reliably across all workers

### DIFF
--- a/tests/test_wal_mode.py
+++ b/tests/test_wal_mode.py
@@ -15,7 +15,7 @@ def test_sqlite_wal_mode_enabled(tmp_path):
         assert result == 'wal', f"Expected 'wal', got '{result}'"
 
 def test_sqlite_busy_timeout_set(tmp_path):
-    """busy_timeout must be set to 5000ms on SQLite connections."""
+    """busy_timeout must be set to 30000ms on SQLite connections."""
     db_path = tmp_path / "test.db"
     app = create_app({
         'TESTING': True,
@@ -24,4 +24,4 @@ def test_sqlite_busy_timeout_set(tmp_path):
     with app.app_context():
         db.create_all()
         result = db.session.execute(text("PRAGMA busy_timeout")).scalar()
-        assert result == 5000, f"Expected 5000, got {result}"
+        assert result == 30000, f"Expected 30000, got {result}"

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -24,9 +24,11 @@ db = SQLAlchemy()
 def _set_sqlite_pragmas(dbapi_connection, connection_record):
     if isinstance(dbapi_connection, _sqlite3.Connection):
         cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA journal_mode=WAL")
-        cursor.execute("PRAGMA busy_timeout=30000")
-        cursor.close()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA busy_timeout=30000")
+        finally:
+            cursor.close()
 
 rq = RQ()
 jwt = JWTManager()

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -11,9 +11,23 @@ from flask_jwt_extended import JWTManager
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from werkzeug.middleware.proxy_fix import ProxyFix
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+import sqlite3 as _sqlite3
 
 # Initialize extensions
 db = SQLAlchemy()
+
+# Class-level listener fires for every SQLite connection from every engine,
+# regardless of when the engine was created or how many workers are running.
+@event.listens_for(Engine, "connect")
+def _set_sqlite_pragmas(dbapi_connection, connection_record):
+    if isinstance(dbapi_connection, _sqlite3.Connection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=30000")
+        cursor.close()
+
 rq = RQ()
 jwt = JWTManager()
 limiter = Limiter(
@@ -88,19 +102,6 @@ def create_app(test_config=None):
     
     # Initialize extensions with app
     db.init_app(app)
-
-    # Enable WAL mode for SQLite to support concurrent writes from multiple workers.
-    # Also set busy_timeout so brief write contention retries instead of failing.
-    from sqlalchemy import event
-
-    with app.app_context():
-        @event.listens_for(db.engine, "connect")
-        def _set_sqlite_pragmas(dbapi_connection, connection_record):
-            if 'sqlite' in app.config.get('SQLALCHEMY_DATABASE_URI', ''):
-                cursor = dbapi_connection.cursor()
-                cursor.execute("PRAGMA journal_mode=WAL")
-                cursor.execute("PRAGMA busy_timeout=5000")
-                cursor.close()
 
     migrate.init_app(app, db)
     rq.init_app(app)


### PR DESCRIPTION
## Summary

- Replaces the broken instance-level SQLAlchemy `connect` event listener (registered inside `with app.app_context()`) with a module-level class-level listener on the `Engine` class
- The old approach silently failed in production: `journal_mode` remained `'delete'` and `busy_timeout` was Python's sqlite3 default (5s), not our configured value
- New listener fires for every SQLite connection from every engine in every process, regardless of creation order
- Increases `busy_timeout` from 5000ms → 30000ms to handle burst contention from parallel instance restarts
- Updates `tests/test_wal_mode.py` to assert the new timeout value

## Root cause

`PRAGMA journal_mode=WAL` fails silently when other processes already have the DB open (web + 2 workers + poller all start simultaneously). The class-level listener approach avoids this by ensuring every new physical connection sets the pragma — including connections made before the app fully initializes.

## Test plan

- [ ] `pytest tests/test_wal_mode.py` passes (both WAL mode and busy_timeout assertions)
- [ ] Deploy to prod, then verify: `docker exec qlsm-worker-1 python3 -c "import sqlite3; c=sqlite3.connect('/app/instance/qlds_ui.db'); print(c.execute('PRAGMA journal_mode').fetchone())"`  → `('wal',)`
- [ ] Trigger 4+ rapid instance restarts and confirm no `database is locked` errors in worker logs