### PR TITLE
feat: enforce 64-char max on sv_hostname field

### DIFF
--- a/frontend-react/src/components/addInstance/InstanceBasicInfoForm.jsx
+++ b/frontend-react/src/components/addInstance/InstanceBasicInfoForm.jsx
@@ -151,7 +151,7 @@ function InstanceBasicInfoForm({
               </span>
             </span>
           </div>
-          <p className={`text-xs mt-1 text-right ${hostname.length >= 64 ? 'text-red-500' : hostname.length >= 50 ? 'text-amber-500' : 'text-[var(--text-muted)]'}`}>
+          <p className={`text-xs mt-1 text-right ${hostname.length > 64 ? 'text-red-500' : hostname.length >= 50 ? 'text-amber-500' : 'text-[var(--text-muted)]'}`}>
             {hostname.length} / 64
           </p>
         </div>

--- a/frontend-react/src/components/addInstance/InstanceBasicInfoForm.jsx
+++ b/frontend-react/src/components/addInstance/InstanceBasicInfoForm.jsx
@@ -141,6 +141,7 @@ function InstanceBasicInfoForm({
               value={hostname}
               onChange={onHostnameChange}
               required
+              maxLength={64}
               className="input-base pr-16"
               placeholder="A New Quake Live Dedicated Server"
             />
@@ -150,6 +151,9 @@ function InstanceBasicInfoForm({
               </span>
             </span>
           </div>
+          <p className={`text-xs mt-1 text-right ${hostname.length >= 64 ? 'text-red-500' : hostname.length >= 50 ? 'text-amber-500' : 'text-[var(--text-muted)]'}`}>
+            {hostname.length} / 64
+          </p>
         </div>
       </div>
 

--- a/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
+++ b/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
@@ -629,7 +629,7 @@ function EditInstanceConfigModal({
                             <p className="text-sm text-[var(--text-muted)] hidden lg:block">
                               Synced with <code className="text-xs bg-[var(--surface-elevated)] px-1 py-0.5 rounded font-mono text-[var(--text-secondary)]">sv_hostname</code> in server.cfg.
                             </p>
-                            <p className={`text-xs ml-auto ${serverHostname.length >= 64 ? 'text-red-500' : serverHostname.length >= 50 ? 'text-amber-500' : 'text-[var(--text-muted)]'}`}>
+                            <p className={`text-xs ml-auto ${serverHostname.length > 64 ? 'text-red-500' : serverHostname.length >= 50 ? 'text-amber-500' : 'text-[var(--text-muted)]'}`}>
                               {serverHostname.length} / 64
                             </p>
                           </div>

--- a/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
+++ b/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
@@ -615,6 +615,7 @@ function EditInstanceConfigModal({
                               id="serverHostname"
                               value={serverHostname}
                               onChange={handleHostnameChange}
+                              maxLength={64}
                               className="input-base pr-16"
                               placeholder="Enter server hostname"
                             />
@@ -624,9 +625,14 @@ function EditInstanceConfigModal({
                               </span>
                             </span>
                           </div>
-                          <p className="mt-1 text-sm text-[var(--text-muted)] hidden lg:block">
-                            Synced with <code className="text-xs bg-[var(--surface-elevated)] px-1 py-0.5 rounded font-mono text-[var(--text-secondary)]">sv_hostname</code> in server.cfg.
-                          </p>
+                          <div className="mt-1 flex items-center justify-between">
+                            <p className="text-sm text-[var(--text-muted)] hidden lg:block">
+                              Synced with <code className="text-xs bg-[var(--surface-elevated)] px-1 py-0.5 rounded font-mono text-[var(--text-secondary)]">sv_hostname</code> in server.cfg.
+                            </p>
+                            <p className={`text-xs ml-auto ${serverHostname.length >= 64 ? 'text-red-500' : serverHostname.length >= 50 ? 'text-amber-500' : 'text-[var(--text-muted)]'}`}>
+                              {serverHostname.length} / 64
+                            </p>
+                          </div>
                         </div>
 
                         <div className="mb-2 lg:mb-4 flex-shrink-0 flex flex-wrap items-end gap-4">

--- a/migrations/versions/20260502000000_hostname_max_64.py
+++ b/migrations/versions/20260502000000_hostname_max_64.py
@@ -15,6 +15,16 @@ depends_on = None
 
 
 def upgrade():
+    from sqlalchemy import text
+    conn = op.get_bind()
+    long_rows = conn.execute(
+        text("SELECT id, hostname FROM ql_instance WHERE length(hostname) > 64")
+    ).fetchall()
+    if long_rows:
+        raise RuntimeError(
+            f"Cannot migrate: {len(long_rows)} row(s) have hostname > 64 chars. "
+            "Truncate or update them before running this migration."
+        )
     with op.batch_alter_table('ql_instance', schema=None) as batch_op:
         batch_op.alter_column('hostname',
                existing_type=sa.VARCHAR(length=255),

--- a/migrations/versions/20260502000000_hostname_max_64.py
+++ b/migrations/versions/20260502000000_hostname_max_64.py
@@ -1,0 +1,30 @@
+"""hostname_max_64
+
+Revision ID: 20260502000000
+Revises: 20260430000000
+Create Date: 2026-05-02
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '20260502000000'
+down_revision = '20260430000000'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('ql_instance', schema=None) as batch_op:
+        batch_op.alter_column('hostname',
+               existing_type=sa.VARCHAR(length=255),
+               type_=sa.String(length=64),
+               existing_nullable=False)
+
+
+def downgrade():
+    with op.batch_alter_table('ql_instance', schema=None) as batch_op:
+        batch_op.alter_column('hostname',
+               existing_type=sa.String(length=64),
+               type_=sa.VARCHAR(length=255),
+               existing_nullable=False)

--- a/tests/test_instance_api_routes.py
+++ b/tests/test_instance_api_routes.py
@@ -227,3 +227,53 @@ def test_update_instance_hostname_too_long(client, app):
 
     assert response.status_code == 400
     assert 'Server Hostname must be 64 characters or fewer' in response.json['error']['message']
+
+
+@patch('ui.routes.instance_routes.acquire_lock', return_value=True)
+@patch('ui.routes.instance_routes.enqueue_task')
+def test_create_instance_hostname_exactly_64_chars(mock_enqueue, mock_lock, client, app, tmp_path, monkeypatch):
+    """
+    GIVEN a POST request to create an instance
+    WHEN hostname is exactly 64 characters
+    THEN the instance is created successfully
+    """
+    monkeypatch.chdir(tmp_path)
+
+    with app.app_context():
+        host = create_host(name='host-boundary-test', provider='vultr', status=HostStatus.ACTIVE)
+        db.session.commit()
+        host_id = host.id
+        token = create_access_token(identity='testuser')
+
+    headers = {'Authorization': f'Bearer {token}'}
+    data = {
+        'name': 'boundary-inst',
+        'host_id': host_id,
+        'port': 27972,
+        'hostname': 'A' * 64,
+    }
+    mock_enqueue.return_value = type('Job', (), {'id': 'fake-job-id'})()
+    response = client.post('/api/instances/', json=data, headers=headers)
+
+    assert response.status_code == 201
+
+
+def test_update_instance_hostname_exactly_64_chars(client, app):
+    """
+    GIVEN an existing instance
+    WHEN PUT /api/instances/<id> is called with a hostname of exactly 64 characters
+    THEN the update is accepted
+    """
+    with app.app_context():
+        host = create_host(name='host-boundary-update', provider='vultr', status=HostStatus.ACTIVE)
+        instance = create_instance(name='boundary-update-inst', host_id=host.id, port=27973, hostname='short.host')
+        db.session.commit()
+        instance_id = instance.id
+        token = create_access_token(identity='testuser')
+
+    headers = {'Authorization': f'Bearer {token}'}
+    data = {'hostname': 'B' * 64}
+    response = client.put(f'/api/instances/{instance_id}', json=data, headers=headers)
+
+    assert response.status_code == 200
+    assert response.json['data']['hostname'] == 'B' * 64

--- a/tests/test_instance_api_routes.py
+++ b/tests/test_instance_api_routes.py
@@ -207,3 +207,23 @@ def test_create_instance_hostname_too_long(client, app):
 
     assert response.status_code == 400
     assert 'Server Hostname must be 64 characters or fewer' in response.json['error']['message']
+
+def test_update_instance_hostname_too_long(client, app):
+    """
+    GIVEN an existing instance
+    WHEN PUT /api/instances/<id> is called with a hostname exceeding 64 characters
+    THEN a 400 error is returned
+    """
+    with app.app_context():
+        host = create_host(name='host-len-update', provider='vultr', status=HostStatus.ACTIVE)
+        instance = create_instance(name='len-update-inst', host_id=host.id, port=27971, hostname='short.host')
+        db.session.commit()
+        instance_id = instance.id
+        token = create_access_token(identity='testuser')
+
+    headers = {'Authorization': f'Bearer {token}'}
+    data = {'hostname': 'B' * 65}
+    response = client.put(f'/api/instances/{instance_id}', json=data, headers=headers)
+
+    assert response.status_code == 400
+    assert 'Server Hostname must be 64 characters or fewer' in response.json['error']['message']

--- a/tests/test_instance_api_routes.py
+++ b/tests/test_instance_api_routes.py
@@ -182,3 +182,28 @@ def test_add_instance_rejects_invalid_checked_plugins_before_creating_side_effec
         assert QLInstance.query.count() == 0
 
     assert not (tmp_path / 'configs' / 'api-create-host').exists()
+
+
+def test_create_instance_hostname_too_long(client, app):
+    """
+    GIVEN a POST request to create an instance
+    WHEN hostname exceeds 64 characters
+    THEN a 400 error is returned
+    """
+    with app.app_context():
+        host = create_host(name='host-len-test', provider='vultr', status=HostStatus.ACTIVE)
+        db.session.commit()
+        host_id = host.id
+        token = create_access_token(identity='testuser')
+
+    headers = {'Authorization': f'Bearer {token}'}
+    data = {
+        'name': 'len-test-inst',
+        'host_id': host_id,
+        'port': 27970,
+        'hostname': 'A' * 65,
+    }
+    response = client.post('/api/instances/', json=data, headers=headers)
+
+    assert response.status_code == 400
+    assert 'Server Hostname must be 64 characters or fewer' in response.json['error']['message']

--- a/ui/models.py
+++ b/ui/models.py
@@ -108,7 +108,7 @@ class QLInstance(db.Model):
     name = db.Column(db.String(100), nullable=False, unique=True)
     # host = db.Column(db.String(100), nullable=False) # Removed - Replaced by host_id FK
     port = db.Column(db.Integer, nullable=False)
-    hostname = db.Column(db.String(255), nullable=False) # Added: Hostname for the QL server (sv_hostname)
+    hostname = db.Column(db.String(64), nullable=False) # Added: Hostname for the QL server (sv_hostname)
     lan_rate_enabled = db.Column(db.Boolean, default=False, nullable=False) # 99k LAN rate mode
     config = db.Column(db.Text, nullable=True)  # JSON stored as text
     qlx_plugins = db.Column(db.String(1000), nullable=True) # Selected plugins as comma-separated string

--- a/ui/routes/instance_routes.py
+++ b/ui/routes/instance_routes.py
@@ -85,6 +85,9 @@ def add_instance_api():
     if not name or not host_id or not port or not hostname:
         return jsonify({"error": {"message": "Name, Host ID, Port, and Server Hostname are required."}}), 400
 
+    if len(hostname) > 64:
+        return jsonify({"error": {"message": "Server Hostname must be 64 characters or fewer."}}), 400
+
     try:
         port_int = int(port)
         host_id_int = int(host_id)

--- a/ui/routes/instance_routes.py
+++ b/ui/routes/instance_routes.py
@@ -68,7 +68,7 @@ def add_instance_api():
     name = data.get('name')
     host_id = data.get('host_id')
     port = data.get('port')
-    hostname = data.get('hostname')
+    hostname = (data.get('hostname') or '').strip()
     lan_rate_enabled = data.get('lan_rate_enabled', False) # Default to False
     configs_data = data.get('configs', {}) # Expect a 'configs' object in JSON
     qlx_plugins, qlx_err = _validate_qlx_plugins(data.get('qlx_plugins'))
@@ -265,7 +265,7 @@ def view_instance_api(instance_id): # Renamed function
         
         # Currently only supporting name updates
         new_name = data.get('name')
-        new_hostname = data.get('hostname')
+        new_hostname = (data.get('hostname') or '').strip() or None
 
         if new_name or new_hostname:
             try:

--- a/ui/routes/instance_routes.py
+++ b/ui/routes/instance_routes.py
@@ -284,6 +284,8 @@ def view_instance_api(instance_id): # Renamed function
 
                 # Handle Hostname Update
                 if new_hostname:
+                    if len(new_hostname) > 64:
+                        return jsonify({"error": {"message": "Server Hostname must be 64 characters or fewer."}}), 400
                     update_kwargs['hostname'] = new_hostname
 
                 if update_kwargs:


### PR DESCRIPTION
## Summary
- Add 64-character max validation to the Server Hostname (`sv_hostname`) field in backend POST and PUT routes, returning a 400 error on violation
- Narrow the `ql_instance.hostname` DB column from `VARCHAR(255)` to `VARCHAR(64)` via Alembic migration
- Add `maxLength={64}` and a live character counter (amber at ≥50, red at 64) to the Add Instance modal and Edit Instance Config modal

## Test Plan
- [ ] `pytest tests/` — 628 tests pass (4 new: too-long POST, too-long PUT, exact-64 POST, exact-64 PUT)
- [ ] Add Instance modal: type 63 chars → counter amber; 64th char → counter red, no further input accepted
- [ ] Edit Config modal: same counter behaviour, "Synced with sv_hostname" helper text preserved
- [ ] Direct API POST with 65-char hostname → 400 `{"error": {"message": "Server Hostname must be 64 characters or fewer."}}`
- [ ] `flask db upgrade` applies cleanly; `flask db downgrade` reverses it