### PR TITLE
fix: allow newlines and slashes in preset binary descriptions

### DIFF
--- a/ui/builtin_presets.py
+++ b/ui/builtin_presets.py
@@ -16,7 +16,7 @@ from ui.preset_support import (
 
 
 _DESCRIPTION_MAX_LEN = 1000
-_DESCRIPTION_RE = re.compile(r'^[\w .,;:()\'\-]*$')
+_DESCRIPTION_RE = re.compile(r'^[\w .,;:()\'\-/\n]*$')
 
 
 class BuiltinPresetError(ValueError):


### PR DESCRIPTION
## Summary
- `_DESCRIPTION_RE` in `ui/builtin_presets.py` only allowed `[\w .,;:()'-]` — no newlines or slashes
- The built-in default preset's `highfps_hook.so` description uses multi-line formatting (`\n`), causing the validator to throw on startup
- The `qlsm-web-1` container was crash-looping with: `binary_descriptions['scripts/highfps_hook.so'] contains invalid characters`
- Fix: add `\n` and `/` to the allowed character class

## Test plan
- Deploy to the affected server and confirm `qlsm-web-1` starts cleanly without the validation error
- Confirm `flask sync-builtin-presets` completes without error

---
Generated with [Claude Code](https://claude.com/claude-code)