### PR TITLE
fix: docker publish workflow path filter and deploy path

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,7 @@ on:
       # Game assets & bootstrap data
       - "ql-assets/**"
       - "configs/presets/default/**"
+      - "configs/presets/_builtin/**"
       # Build definition itself
       - "Dockerfile"
       - ".dockerignore"
@@ -94,8 +95,8 @@ jobs:
     steps:
       - name: Pull and deploy new image
         run: |
-          docker compose -f /opt/qlsm/docker-compose.yml pull
-          docker compose -f /opt/qlsm/docker-compose.yml up -d --wait
+          docker compose -f /root/qlsm/docker-compose.yml pull
+          docker compose -f /root/qlsm/docker-compose.yml up -d --wait
 
       - name: Auto-rollback on failure
         if: failure()
@@ -104,7 +105,7 @@ jobs:
           docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous
           docker tag  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous \
                       ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          docker compose -f /opt/qlsm/docker-compose.yml up -d
+          docker compose -f /root/qlsm/docker-compose.yml up -d
 
       - name: Report status
-        run: docker compose -f /opt/qlsm/docker-compose.yml ps
+        run: docker compose -f /root/qlsm/docker-compose.yml ps


### PR DESCRIPTION
## Summary
- Add `configs/presets/_builtin/**` to the path filter — changes to built-in preset files (e.g. `preset.json`) were silently skipping the image build, as demonstrated when PR #59 merged without triggering a rebuild
- Correct the deploy job's compose file path from `/opt/qlsm/docker-compose.yml` (does not exist) to `/root/qlsm/docker-compose.yml` (actual install location)

## Test plan
- Merge and verify that a change to `configs/presets/_builtin/**` triggers a build run
- Verify the deploy job completes successfully on the next triggered build

---
Generated with [Claude Code](https://claude.com/claude-code)