### PR TITLE
fix: add --wait to rollback deploy step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -105,7 +105,7 @@ jobs:
           docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous
           docker tag  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:previous \
                       ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          docker compose -f /root/qlsm/docker-compose.yml up -d
+          docker compose -f /root/qlsm/docker-compose.yml up -d --wait
 
       - name: Report status
         run: docker compose -f /root/qlsm/docker-compose.yml ps


### PR DESCRIPTION
## Summary
- The auto-rollback step used `up -d` without `--wait`, meaning it could report success while containers were still starting or crash-looping
- The initial deploy already uses `up -d --wait` — this makes rollback consistent

## Test plan
- Verify rollback step waits for healthy containers before reporting success

---
Generated with [Claude Code](https://claude.com/claude-code)