### PR TITLE
fix: always overwrite _builtin presets on seed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ seed_builtin_presets() {
             if [ "$preset_name" = "default" ] && [ -d /app/configs/presets/default ] && [ ! -d "$BUILTIN_PRESETS_DST/default" ]; then
                 continue
             fi
-            cp -an "$preset_dir" "$BUILTIN_PRESETS_DST/"
+            cp -a "$preset_dir" "$BUILTIN_PRESETS_DST/"
         done
     fi
 }


### PR DESCRIPTION
## Summary
- `seed_builtin_presets` used `cp -an` (no-clobber), so a stale `preset.json` from an older image on the bind mount would never be replaced by an updated one
- This caused users who had installed before a preset fix was shipped to remain broken even after pulling the new image — the bad file on disk took precedence
- `_builtin` presets are image-owned and should always reflect the current image; drop `-n` so updates win

## Test plan
- Fresh install: same behaviour (no existing files to clobber)
- Existing install after image update: `_builtin/default/preset.json` now gets replaced correctly on container start

---
Generated with [Claude Code](https://claude.com/claude-code)