### PR TITLE
fix: stabilize polling effect deps in useHosts and useInstances

### DIFF
--- a/frontend-react/src/hooks/useHosts.js
+++ b/frontend-react/src/hooks/useHosts.js
@@ -52,25 +52,19 @@ export function useHosts() {
     fetchHostsData(true);
   }, [fetchHostsData]);
 
+  const shouldPoll = useMemo(
+    () => hosts.some(host =>
+      POLLABLE_HOST_STATUSES.includes(host.status) ||
+      POLLABLE_QLFILTER_STATUSES.includes(host.qlfilter_status)
+    ),
+    [hosts]
+  );
+
   useEffect(() => {
-    let intervalId;
-    const shouldPollForHostStatus = hosts.some(host => POLLABLE_HOST_STATUSES.includes(host.status));
-    const shouldPollForQlfilterStatus = hosts.some(host => POLLABLE_QLFILTER_STATUSES.includes(host.qlfilter_status));
-    
-    const shouldPoll = shouldPollForHostStatus || shouldPollForQlfilterStatus;
-
-    if (shouldPoll) {
-      intervalId = setInterval(() => {
-        fetchHostsData(false);
-      }, POLLING_INTERVAL);
-    }
-
-    return () => {
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-    };
-  }, [hosts, fetchHostsData]);
+    if (!shouldPoll) return;
+    const intervalId = setInterval(() => fetchHostsData(false), POLLING_INTERVAL);
+    return () => clearInterval(intervalId);
+  }, [shouldPoll, fetchHostsData]);
 
   const handleDeleteRequest = (hostId, hostName) => {
     setSelectedHost({ id: hostId, name: hostName });

--- a/frontend-react/src/hooks/useInstances.js
+++ b/frontend-react/src/hooks/useInstances.js
@@ -56,22 +56,16 @@ export function useInstances() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Ensure initial fetch runs only once on mount
 
+  const shouldPoll = useMemo(
+    () => instances.some(instance => POLLABLE_INSTANCE_STATUSES.includes(instance.status)),
+    [instances]
+  );
+
   useEffect(() => {
-    let intervalId;
-    const shouldPoll = instances.some(instance => POLLABLE_INSTANCE_STATUSES.includes(instance.status));
-
-    if (shouldPoll) {
-      intervalId = setInterval(() => {
-        refreshInstances(false);
-      }, POLLING_INTERVAL);
-    }
-
-    return () => {
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-    };
-  }, [instances, refreshInstances]);
+    if (!shouldPoll) return;
+    const intervalId = setInterval(() => refreshInstances(false), POLLING_INTERVAL);
+    return () => clearInterval(intervalId);
+  }, [shouldPoll, refreshInstances]);
 
   const handleDeleteRequest = (instanceId, instanceName) => {
     setSelectedInstance({ id: instanceId, name: instanceName });


### PR DESCRIPTION
## Summary

- `useHosts` and `useInstances` had `hosts`/`instances` arrays in the polling `useEffect` dependency array
- This caused the interval to be torn down and recreated on every poll cycle — `clearInterval` + `setInterval` every 3s
- Fix: derive a stable `shouldPoll` boolean via `useMemo`, use that as the effect dependency instead

The effect now fires only when the polling decision changes (transitional status appears or clears), not on every data update.

## Test plan

- [ ] Deploy an instance or host — verify polling starts and status updates appear
- [ ] After deployment completes — verify polling stops (no more requests in Network tab)
- [ ] Idle state — confirm no polling requests when all statuses are stable