### PR TITLE
perf(css): remove expensive infinite background-position and filter animations

### DIFF
--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1659,21 +1659,10 @@ body {
       var(--surface-border) 20px);
   background-size: 20px 20px;
   pointer-events: none;
-  animation: navbar-grid-drift 60s linear infinite;
 }
 
 .dark .navbar-grid-pattern {
   opacity: 0.08;
-}
-
-@keyframes navbar-grid-drift {
-  0% {
-    background-position: 0 0;
-  }
-
-  100% {
-    background-position: 20px 20px;
-  }
 }
 
 /* Top accent line with animated glow */
@@ -1689,7 +1678,6 @@ body {
       var(--accent-primary) 30%,
       var(--accent-primary) 70%,
       transparent 100%);
-  animation: navbar-accent-pulse 4s ease-in-out infinite;
 }
 
 .dark .navbar-accent-top {
@@ -1713,18 +1701,6 @@ body {
 
 .dark .navbar-accent-bottom {
   opacity: 0.3;
-}
-
-@keyframes navbar-accent-pulse {
-
-  0%,
-  100% {
-    filter: brightness(1);
-  }
-
-  50% {
-    filter: brightness(1.3);
-  }
 }
 
 /* Main content container */
@@ -3294,22 +3270,11 @@ body {
       var(--surface-border) 39px,
       var(--surface-border) 40px);
   background-size: 40px 40px;
-  animation: login-grid-drift 120s linear infinite;
   z-index: -2;
 }
 
 .dark .login-grid-pattern {
   opacity: 0.12;
-}
-
-@keyframes login-grid-drift {
-  0% {
-    background-position: 0 0;
-  }
-
-  100% {
-    background-position: 40px 40px;
-  }
 }
 
 /* Gradient overlay (dark mode) */
@@ -4255,4 +4220,11 @@ body {
 
 .dark .host-card-overlay {
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5), 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .login-icon-glow,
+  .login-icon-ring {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary

The login page and navbar ran multiple infinite CSS animations that forced full-area paints and composite filter passes every frame:

- `login-grid-drift` (120s, fullscreen `background-position`) — removed
- `navbar-grid-drift` (60s, `background-position`) — removed
- `navbar-accent-pulse` (4s, `filter: brightness`) — removed

`background-position` and `filter` cannot use the GPU compositor fast-path. The two grid drifts shifted by 40px / 20px over 120s / 60s — imperceptibly slow but still triggering paint every frame. The accent pulse sat on a 2px line.

Also adds a `prefers-reduced-motion` block disabling the remaining decorative spin/glow animations on the login icon for users with the OS-level preference set.

Net: -28 lines of CSS, no JS changes.

## Test plan

- [ ] Open login page in dev — confirm static grid pattern is still visible, page no longer pegs CPU
- [ ] Log in — confirm navbar still looks right (grid pattern visible, accent line visible at base opacity)
- [ ] Check navbar accent line: stays at 0.4 opacity (light) / 1.0 (dark), no more pulsing
- [ ] Login icon: glow + ring still animate normally (these are GPU fast-path)
- [ ] DevTools Performance Monitor: idle CPU on login should drop noticeably
- [ ] Toggle prefers-reduced-motion in DevTools → Rendering → confirm login icon animations stop