### PR TITLE
fix: reconcile LAN rate on config save

### DIFF
--- a/ansible/playbooks/sync_instance_configs_and_restart.yml
+++ b/ansible/playbooks/sync_instance_configs_and_restart.yml
@@ -121,6 +121,10 @@
         state: started
       when: firewall_mode_effective == 'helper'
 
+    - name: Reconcile LAN rate network rules
+      ansible.builtin.import_tasks: tasks/reconcile_lan_rate_network.yml
+      when: reconcile_lan_rate_network | default(false)
+
     - name: Restart QLDS service
       ansible.builtin.systemd:
         name: "qlds@{{ game_port }}"

--- a/ansible/playbooks/tasks/reconcile_lan_rate_network.yml
+++ b/ansible/playbooks/tasks/reconcile_lan_rate_network.yml
@@ -1,0 +1,90 @@
+---
+- name: Ensure route_localnet is enabled
+  sysctl:
+    name: "{{ item }}"
+    value: 1
+    sysctl_set: yes
+    state: present
+    reload: yes
+  loop:
+    - net.ipv4.conf.all.route_localnet
+    - net.ipv4.conf.default.route_localnet
+    - net.ipv4.conf.lo.route_localnet
+  when:
+    - firewall_mode_effective == 'full'
+    - lan_rate_enabled | default(false)
+
+- name: Check if INPUT SNAT rule exists (required for NAT)
+  command: iptables -t nat -C INPUT -d 127.0.0.1 -j SNAT --to-source 127.0.0.1
+  register: input_snat_check
+  failed_when: false
+  changed_when: false
+  when:
+    - firewall_mode_effective == 'full'
+    - lan_rate_enabled | default(false)
+
+- name: Add INPUT SNAT rule (required for NAT)
+  command: iptables -t nat -A INPUT -d 127.0.0.1 -j SNAT --to-source 127.0.0.1
+  when:
+    - firewall_mode_effective == 'full'
+    - lan_rate_enabled | default(false)
+    - input_snat_check.rc != 0
+
+- name: Check if PREROUTING DNAT rule exists
+  command: iptables -t nat -C PREROUTING -p udp --dport {{ game_port }} -j DNAT --to-destination 127.0.0.1
+  register: prerouting_check
+  failed_when: false
+  changed_when: false
+  when:
+    - firewall_mode_effective == 'full'
+    - lan_rate_enabled | default(false)
+
+- name: Add PREROUTING DNAT rule
+  command: iptables -t nat -A PREROUTING -p udp --dport {{ game_port }} -j DNAT --to-destination 127.0.0.1
+  when:
+    - firewall_mode_effective == 'full'
+    - lan_rate_enabled | default(false)
+    - prerouting_check.rc != 0
+
+- name: Check if POSTROUTING SNAT rule exists
+  command: iptables -t nat -C POSTROUTING -p udp -d 127.0.0.1 --dport {{ game_port }} -j SNAT --to-source 127.0.0.1
+  register: postrouting_check
+  failed_when: false
+  changed_when: false
+  when:
+    - firewall_mode_effective == 'full'
+    - lan_rate_enabled | default(false)
+
+- name: Add POSTROUTING SNAT rule
+  command: iptables -t nat -A POSTROUTING -p udp -d 127.0.0.1 --dport {{ game_port }} -j SNAT --to-source 127.0.0.1
+  when:
+    - firewall_mode_effective == 'full'
+    - lan_rate_enabled | default(false)
+    - postrouting_check.rc != 0
+
+- name: Remove PREROUTING DNAT rule
+  command: iptables -t nat -D PREROUTING -p udp --dport {{ game_port }} -j DNAT --to-destination 127.0.0.1
+  when:
+    - firewall_mode_effective == 'full'
+    - not (lan_rate_enabled | default(false))
+  ignore_errors: yes
+
+- name: Remove POSTROUTING SNAT rule
+  command: iptables -t nat -D POSTROUTING -p udp -d 127.0.0.1 --dport {{ game_port }} -j SNAT --to-source 127.0.0.1
+  when:
+    - firewall_mode_effective == 'full'
+    - not (lan_rate_enabled | default(false))
+  ignore_errors: yes
+
+- name: Ensure iptables directory exists
+  file:
+    path: /etc/iptables
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  when: firewall_mode_effective == 'full'
+
+- name: Save iptables rules
+  shell: iptables-save > /etc/iptables/rules.v4
+  when: firewall_mode_effective == 'full'

--- a/ansible/playbooks/update_instance_lan_rate.yml
+++ b/ansible/playbooks/update_instance_lan_rate.yml
@@ -13,25 +13,7 @@
 
   tasks:
   #######################################################################
-  # 1. Ensure route_localnet is enabled (only if enabling LAN rate)
-  #######################################################################
-    - name: Ensure route_localnet is enabled
-      sysctl:
-        name: "{{ item }}"
-        value: 1
-        sysctl_set: yes
-        state: present
-        reload: yes
-      loop:
-        - net.ipv4.conf.all.route_localnet
-        - net.ipv4.conf.default.route_localnet
-        - net.ipv4.conf.lo.route_localnet
-      when:
-        - firewall_mode_effective == 'full'
-        - lan_rate_enabled | default(false)
-
-  #######################################################################
-  # 2. Re-render systemd service file with updated qlds_args
+  # 1. Re-render systemd service file with updated qlds_args
   #######################################################################
     - name: Render QLDS systemd service file
       ansible.builtin.template:
@@ -61,90 +43,13 @@
       when: firewall_mode_effective == 'helper'
 
   #######################################################################
-  # 3. Add or remove NAT iptables rules based on lan_rate_enabled
+  # 2. Add or remove NAT iptables rules based on lan_rate_enabled
   #######################################################################
-    # Add NAT rules (when enabling LAN rate)
-    - name: Check if INPUT SNAT rule exists (required for NAT)
-      command: iptables -t nat -C INPUT -d 127.0.0.1 -j SNAT --to-source 127.0.0.1
-      register: input_snat_check
-      failed_when: false
-      changed_when: false
-      when:
-        - firewall_mode_effective == 'full'
-        - lan_rate_enabled | default(false)
-
-    - name: Add INPUT SNAT rule (required for NAT)
-      command: iptables -t nat -A INPUT -d 127.0.0.1 -j SNAT --to-source 127.0.0.1
-      when:
-        - firewall_mode_effective == 'full'
-        - lan_rate_enabled | default(false)
-        - input_snat_check.rc != 0
-
-    - name: Check if PREROUTING DNAT rule exists
-      command: iptables -t nat -C PREROUTING -p udp --dport {{ game_port }} -j DNAT --to-destination 127.0.0.1
-      register: prerouting_check
-      failed_when: false
-      changed_when: false
-      when:
-        - firewall_mode_effective == 'full'
-        - lan_rate_enabled | default(false)
-
-    - name: Add PREROUTING DNAT rule
-      command: iptables -t nat -A PREROUTING -p udp --dport {{ game_port }} -j DNAT --to-destination 127.0.0.1
-      when:
-        - firewall_mode_effective == 'full'
-        - lan_rate_enabled | default(false)
-        - prerouting_check.rc != 0
-
-    - name: Check if POSTROUTING SNAT rule exists
-      command: iptables -t nat -C POSTROUTING -p udp -d 127.0.0.1 --dport {{ game_port }} -j SNAT --to-source 127.0.0.1
-      register: postrouting_check
-      failed_when: false
-      changed_when: false
-      when:
-        - firewall_mode_effective == 'full'
-        - lan_rate_enabled | default(false)
-
-    - name: Add POSTROUTING SNAT rule
-      command: iptables -t nat -A POSTROUTING -p udp -d 127.0.0.1 --dport {{ game_port }} -j SNAT --to-source 127.0.0.1
-      when:
-        - firewall_mode_effective == 'full'
-        - lan_rate_enabled | default(false)
-        - postrouting_check.rc != 0
-
-    # Remove NAT rules (when disabling LAN rate)
-    - name: Remove PREROUTING DNAT rule
-      command: iptables -t nat -D PREROUTING -p udp --dport {{ game_port }} -j DNAT --to-destination 127.0.0.1
-      when:
-        - firewall_mode_effective == 'full'
-        - not (lan_rate_enabled | default(false))
-      ignore_errors: yes
-
-    - name: Remove POSTROUTING SNAT rule
-      command: iptables -t nat -D POSTROUTING -p udp -d 127.0.0.1 --dport {{ game_port }} -j SNAT --to-source 127.0.0.1
-      when:
-        - firewall_mode_effective == 'full'
-        - not (lan_rate_enabled | default(false))
-      ignore_errors: yes
+    - name: Reconcile LAN rate network rules
+      ansible.builtin.import_tasks: tasks/reconcile_lan_rate_network.yml
 
   #######################################################################
-  # 4. Persist iptables rules
-  #######################################################################
-    - name: Ensure iptables directory exists
-      file:
-        path: /etc/iptables
-        state: directory
-        owner: root
-        group: root
-        mode: '0755'
-      when: firewall_mode_effective == 'full'
-
-    - name: Save iptables rules
-      shell: iptables-save > /etc/iptables/rules.v4
-      when: firewall_mode_effective == 'full'
-
-  #######################################################################
-  # 5. Restart the instance service
+  # 3. Restart the instance service
   #######################################################################
     - name: Restart QLDS service
       ansible.builtin.systemd:

--- a/tests/test_lock_routes.py
+++ b/tests/test_lock_routes.py
@@ -295,4 +295,5 @@ def test_manage_instance_config_updates_lan_rate_and_queues_single_apply_task(
     assert args[0].__name__ == 'apply_instance_config'
     assert args[1] == 1
     assert kwargs['restart'] is True
+    assert kwargs['reconcile_lan_rate_network'] is True
     assert 'lock_token' in kwargs

--- a/tests/test_task_apply_config.py
+++ b/tests/test_task_apply_config.py
@@ -28,6 +28,7 @@ def _make_mock_instance(instance_id=12, status=InstanceStatus.RUNNING):
     mock_instance.status = status
     mock_instance.host = mock_host
     mock_instance.config = '+set sv_hostname "Test Server"'
+    mock_instance.lan_rate_enabled = False
     return mock_instance
 
 
@@ -84,6 +85,53 @@ def test_apply_instance_config_passes_cpu_affinity(
     mock_ensure_affinity.assert_called_once_with(mock_instance)
     extravars = mock_run_playbook.call_args.kwargs['extravars']
     assert extravars['cpu_affinity'] == 1
+
+
+@patch(f'{TASK_LOGIC_MODULE}._run_ansible_playbook')
+@patch(f'{TASK_LOGIC_MODULE}._build_qlds_args_string', return_value='mock_qlds_args')
+@patch(f'{TASK_LOGIC_MODULE}._prepare_instance_zmq')
+@patch(f'{TASK_LOGIC_MODULE}.append_log')
+@patch(f'{TASK_LOGIC_MODULE}.db.session')
+@patch(f'{TASK_LOGIC_MODULE}.get_current_job')
+def test_apply_instance_config_passes_lan_rate_state(
+    mock_get_job, mock_session, mock_append_log, mock_prep_zmq,
+    mock_build_args, mock_run_playbook, test_app
+):
+    mock_job = MagicMock(); mock_job.id = 'test-job-id'
+    mock_get_job.return_value = mock_job
+
+    mock_instance = _make_mock_instance(status=InstanceStatus.RUNNING)
+    mock_instance.lan_rate_enabled = True
+    mock_session.get.return_value = mock_instance
+    mock_run_playbook.return_value = (SimpleAnsibleResult(0, 'ok', ''), None)
+
+    apply_instance_config(12)
+
+    extravars = mock_run_playbook.call_args.kwargs['extravars']
+    assert extravars['lan_rate_enabled'] is True
+
+
+@patch(f'{TASK_LOGIC_MODULE}._run_ansible_playbook')
+@patch(f'{TASK_LOGIC_MODULE}._build_qlds_args_string', return_value='mock_qlds_args')
+@patch(f'{TASK_LOGIC_MODULE}._prepare_instance_zmq')
+@patch(f'{TASK_LOGIC_MODULE}.append_log')
+@patch(f'{TASK_LOGIC_MODULE}.db.session')
+@patch(f'{TASK_LOGIC_MODULE}.get_current_job')
+def test_apply_instance_config_passes_lan_rate_reconcile_flag(
+    mock_get_job, mock_session, mock_append_log, mock_prep_zmq,
+    mock_build_args, mock_run_playbook, test_app
+):
+    mock_job = MagicMock(); mock_job.id = 'test-job-id'
+    mock_get_job.return_value = mock_job
+
+    mock_instance = _make_mock_instance(status=InstanceStatus.RUNNING)
+    mock_session.get.return_value = mock_instance
+    mock_run_playbook.return_value = (SimpleAnsibleResult(0, 'ok', ''), None)
+
+    apply_instance_config(12, reconcile_lan_rate_network=True)
+
+    extravars = mock_run_playbook.call_args.kwargs['extravars']
+    assert extravars['reconcile_lan_rate_network'] is True
 
 
 @patch(f'{TASK_LOGIC_MODULE}._run_ansible_playbook')

--- a/ui/routes/instance_routes.py
+++ b/ui/routes/instance_routes.py
@@ -866,7 +866,15 @@ def manage_instance_config_api(instance_id): # Renamed and combined GET/POST fro
                 return jsonify({"error": {"message": f"An instance with the name '{new_name}' already exists."}}), 409
 
             restart = data.get('restart', True)
-            job = enqueue_task(apply_instance_config, instance.id, restart=restart, lock_token=lock_token, on_failure=instance_job_failure_handler)
+            reconcile_lan_rate_network = 'lan_rate_enabled' in data
+            job = enqueue_task(
+                apply_instance_config,
+                instance.id,
+                restart=restart,
+                reconcile_lan_rate_network=reconcile_lan_rate_network,
+                lock_token=lock_token,
+                on_failure=instance_job_failure_handler,
+            )
             if job:
                 lock_transferred = True
                 current_app.logger.info(f"Enqueued job {job.id} for apply_instance_config for instance {instance.id}")

--- a/ui/task_logic/ansible_instance_mgmt.py
+++ b/ui/task_logic/ansible_instance_mgmt.py
@@ -450,7 +450,7 @@ def start_instance_logic(instance_id):
         return f"Error during instance {instance_id} start: {e}"
 
 
-def apply_instance_config_logic(instance_id, restart=True):
+def apply_instance_config_logic(instance_id, restart=True, reconcile_lan_rate_network=False):
     """
     Logic for applying configuration to a QL instance via Ansible.
     This involves syncing config files and optionally restarting the service.
@@ -492,6 +492,8 @@ def apply_instance_config_logic(instance_id, restart=True):
             'id': instance.id,             # Keep id
             'qlds_args': qlds_args_string, # Pass constructed args for service re-templating
             'cpu_affinity': cpu_affinity,
+            'lan_rate_enabled': instance.lan_rate_enabled,
+            'reconcile_lan_rate_network': reconcile_lan_rate_network,
             'restart_service': restart     # Pass restart flag
         }
         apply_config_extravars = with_self_host_network_extravars(instance, apply_config_extravars)

--- a/ui/tasks.py
+++ b/ui/tasks.py
@@ -179,10 +179,14 @@ def start_instance(instance_id, lock_token=None):
 
 @rq.job(timeout=300)
 @with_app_context
-def apply_instance_config(instance_id, restart=True, lock_token=None):
+def apply_instance_config(instance_id, restart=True, reconcile_lan_rate_network=False, lock_token=None):
     """RQ task entry point for applying configuration to a QL instance."""
     try:
-        return apply_instance_config_logic(instance_id, restart=restart)
+        return apply_instance_config_logic(
+            instance_id,
+            restart=restart,
+            reconcile_lan_rate_network=reconcile_lan_rate_network,
+        )
     finally:
         if lock_token:
             from ui.task_lock import release_lock


### PR DESCRIPTION
## Summary

Fixes the regression where saving instance config with `lan_rate_enabled` updated the service args but skipped the host networking changes needed for 99k LAN rate.

## Root Cause

The edit-config save path queues `apply_instance_config`. That task re-renders the QLDS systemd args from the database, so `sv_serverType 1` and `sv_lanForceRate 1` were applied, but `sync_instance_configs_and_restart.yml` did not reconcile `route_localnet` or the NAT rules. The dedicated LAN-rate endpoint used `update_instance_lan_rate.yml`, which did apply those network changes.

## Changes

- Pass an explicit `reconcile_lan_rate_network` flag from config saves that include `lan_rate_enabled`.
- Pass current `lan_rate_enabled` state through `apply_instance_config` to Ansible.
- Extract the LAN-rate sysctl/NAT tasks into a shared task file.
- Import the shared task from both the dedicated LAN-rate playbook and the config-sync playbook when requested.
- Add focused tests for task args and config-save queue behavior.

## Validation

- `SECRET_KEY=test pytest tests/test_task_apply_config.py tests/test_instance_lan_rate_routes.py tests/test_lock_routes.py -q`
- `SECRET_KEY=test pytest tests/test_task_self_host_instance_network.py tests/test_task_decorators.py -q`
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ansible-playbook --syntax-check ansible/playbooks/sync_instance_configs_and_restart.yml -i localhost,`
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ansible-playbook --syntax-check ansible/playbooks/update_instance_lan_rate.yml -i localhost,`
- `python3 -m py_compile ui/routes/instance_routes.py ui/task_logic/ansible_instance_mgmt.py ui/tasks.py tests/test_task_apply_config.py tests/test_lock_routes.py`
- `git diff --check`