### PR TITLE
bug: stop upload editor content feedback

### DIFF
--- a/docs/plans/2026-05-10-file-upload-editor-blink-design.md
+++ b/docs/plans/2026-05-10-file-upload-editor-blink-design.md
@@ -1,0 +1,24 @@
+# File Upload Editor Blink Design
+
+## Problem
+
+Uploading a text file into the file manager auto-opens it in the inline CodeMirror editor, but the editor blinks rapidly, cannot be typed into, and can later show the uploaded file as blank. Deleting a file while it is in this bad state can leave a stale tree row that cannot be selected.
+
+## Root Cause
+
+`CodeMirrorEditor` dispatches a full-document replacement when its `value` prop changes. That transaction is tagged as `userEvent: 'setValue'`, but the shared update listener only checks `update.docChanged`, so it forwards the programmatic replacement back through `onChange` as if the user typed it.
+
+During upload auto-selection, the parent may briefly render the editor with temporary or stale content while the adapter finishes reading the uploaded file. The editor then writes that transient value back into the adapter, which can erase the uploaded content and create a render/write feedback loop.
+
+## Chosen Approach
+
+Teach `CodeMirrorEditor` to ignore programmatic value-sync transactions and only call `onChange` for real user edits. This fixes the shared editor contract instead of special-casing upload selection in the file manager.
+
+## Alternatives Considered
+
+- Delay upload selection until the adapter tree refreshes. This reduces one race, but leaves the editor able to write parent-driven replacements back into state.
+- Special-case uploaded files in `useFileManagerController`. This is narrower, but still allows the same feedback bug when any parent-driven content update reaches CodeMirror.
+
+## Testing
+
+Add focused regression coverage that proves a programmatic editor value update does not call `onChange`. Keep the existing file manager upload selection test to cover the controller behavior that auto-opens uploaded files.

--- a/docs/plans/2026-05-10-file-upload-editor-blink.md
+++ b/docs/plans/2026-05-10-file-upload-editor-blink.md
@@ -1,0 +1,73 @@
+# File Upload Editor Blink Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop uploaded files from blinking or being overwritten when the inline CodeMirror editor auto-opens them.
+
+**Architecture:** Keep upload auto-selection in the file manager, but fix the shared editor contract. `CodeMirrorEditor` should update its document from props without emitting `onChange`; only user edits should flow back to the parent.
+
+**Tech Stack:** React, CodeMirror 6, Vitest, Testing Library, jsdom.
+
+---
+
+### Task 1: Add Editor Regression Coverage
+
+**Files:**
+- Create: `frontend-react/src/components/__tests__/CodeMirrorEditor.test.jsx`
+
+**Step 1: Write the failing test**
+
+Create a test that renders `CodeMirrorEditor` inside `ThemeProvider` with `value=""`, rerenders it with `value="uploaded content"`, and asserts `onChange` was not called by the prop-driven update.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd frontend-react && pnpm exec vitest run src/components/__tests__/CodeMirrorEditor.test.jsx`
+
+Expected: FAIL because the current update listener reports programmatic `setValue` transactions through `onChange`.
+
+### Task 2: Ignore Programmatic Set-Value Updates
+
+**Files:**
+- Modify: `frontend-react/src/components/CodeMirrorEditor.jsx`
+
+**Step 1: Implement the minimal fix**
+
+In the `EditorView.updateListener`, skip updates where `update.transactions` contains a transaction with `tr.isUserEvent('setValue')`.
+
+**Step 2: Run the focused editor test**
+
+Run: `cd frontend-react && pnpm exec vitest run src/components/__tests__/CodeMirrorEditor.test.jsx`
+
+Expected: PASS.
+
+### Task 3: Verify File Manager Upload Path
+
+**Files:**
+- Existing test: `frontend-react/src/components/fileManager/__tests__/useFileManagerController.test.js`
+
+**Step 1: Run upload/controller coverage**
+
+Run: `cd frontend-react && pnpm exec vitest run src/components/fileManager/__tests__/useFileManagerController.test.js`
+
+Expected: PASS, including the existing "selects and opens the uploaded file" case.
+
+### Task 4: Commit
+
+**Files:**
+- `docs/plans/2026-05-10-file-upload-editor-blink-design.md`
+- `docs/plans/2026-05-10-file-upload-editor-blink.md`
+- `frontend-react/src/components/CodeMirrorEditor.jsx`
+- `frontend-react/src/components/__tests__/CodeMirrorEditor.test.jsx`
+
+**Step 1: Inspect diff**
+
+Run: `git status --short` and `git diff --stat`.
+
+**Step 2: Commit**
+
+Run:
+
+```bash
+git add docs/plans/2026-05-10-file-upload-editor-blink-design.md docs/plans/2026-05-10-file-upload-editor-blink.md frontend-react/src/components/CodeMirrorEditor.jsx frontend-react/src/components/__tests__/CodeMirrorEditor.test.jsx
+git commit -m "bug: stop upload editor content feedback"
+```

--- a/frontend-react/src/components/CodeMirrorEditor.jsx
+++ b/frontend-react/src/components/CodeMirrorEditor.jsx
@@ -139,7 +139,10 @@ const getExtensions = (currentLanguage, currentLinterSource, onChangeCallback, i
     ])),
     ...(isDark ? [oneDark, darkEditorTheme] : [lightEditorTheme]),
     EditorView.updateListener.of((update) => {
-      if (update.docChanged && !isReadOnly) {
+      const isProgrammaticValueSync = update.transactions.some(transaction =>
+        transaction.isUserEvent('setValue')
+      );
+      if (update.docChanged && !isReadOnly && !isProgrammaticValueSync) {
         onChangeCallback(update.state.doc.toString());
       }
     }),

--- a/frontend-react/src/components/__tests__/CodeMirrorEditor.test.jsx
+++ b/frontend-react/src/components/__tests__/CodeMirrorEditor.test.jsx
@@ -1,0 +1,52 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import CodeMirrorEditor from '../CodeMirrorEditor';
+import { ThemeProvider } from '../../context/ThemeContext';
+
+function renderEditor({ value, onChange }) {
+  return (
+    <ThemeProvider>
+      <CodeMirrorEditor
+        value={value}
+        onChange={onChange}
+        isActiveTab={true}
+      />
+    </ThemeProvider>
+  );
+}
+
+describe('CodeMirrorEditor', () => {
+  beforeAll(() => {
+    const rect = {
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    };
+    Range.prototype.getBoundingClientRect = () => rect;
+    Range.prototype.getClientRects = () => [];
+  });
+
+  it('does not emit onChange for parent-driven value syncs', async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(renderEditor({ value: '', onChange }));
+
+    await waitFor(() => {
+      expect(document.querySelector('.cm-editor')).toBeInTheDocument();
+    });
+
+    onChange.mockClear();
+    rerender(renderEditor({ value: 'uploaded content', onChange }));
+
+    await waitFor(() => {
+      expect(document.querySelector('.cm-content')).toHaveTextContent('uploaded content');
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent CodeMirror parent-driven value syncs from being reported as user edits.
- Add regression coverage for uploaded-file style content syncs so programmatic updates do not call `onChange`.
- Include the approved design and implementation plan under `docs/plans/`.

## Root Cause
`CodeMirrorEditor` tagged prop-driven document replacements with `userEvent: 'setValue'`, but its update listener still forwarded any `docChanged` transaction to `onChange`. During upload auto-open, that allowed temporary or stale editor values to be written back into the file adapter, causing blinking and possible blank file content.

## Validation
- `pnpm exec vitest run src/components/__tests__/CodeMirrorEditor.test.jsx`
- `pnpm exec vitest run src/components/fileManager/__tests__/useFileManagerController.test.js`
- `pnpm exec eslint src/components/CodeMirrorEditor.jsx src/components/__tests__/CodeMirrorEditor.test.jsx`

## Notes
- Full `pnpm lint` still fails on pre-existing unrelated lint errors in files outside this change.