### PR TITLE
Add .ent CodeMirror highlighting

### DIFF
--- a/docs/plans/2026-05-10-ent-codemirror-highlighting-design.md
+++ b/docs/plans/2026-05-10-ent-codemirror-highlighting-design.md
@@ -1,0 +1,19 @@
+# Ent CodeMirror Highlighting Design
+
+## Goal
+
+Add syntax highlighting and lint diagnostics for uploaded `.ent` config files in the React CodeMirror editor.
+
+## Approach
+
+Create a dedicated CodeMirror 6 stream language for Quake entity files because `.ent` content is not JSON: entity attributes are adjacent quoted key/value strings without colons or commas. The mode will highlight braces as operators, keys as attribute names, values as strings, comments as line comments, and malformed tokens as invalid.
+
+Add a small linter that reports unbalanced entity braces and non-empty lines that are not entity braces, comments, or `"key" "value"` pairs. The linter is advisory inside the editor and does not change backend upload or save validation.
+
+## Integration
+
+Route `.ent` files through the new language and linter in the config file managers used by Add Instance and Edit Instance. Expanded editors receive the same language and linter through the existing file-manager callbacks.
+
+## Testing
+
+Add focused unit tests for the `.ent` linter and routing tests in the Add Instance and Edit Instance component suites. Run the affected frontend tests with Vitest.

--- a/docs/plans/2026-05-10-ent-codemirror-highlighting.md
+++ b/docs/plans/2026-05-10-ent-codemirror-highlighting.md
@@ -1,0 +1,67 @@
+# Ent CodeMirror Highlighting Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add CodeMirror syntax highlighting and lint diagnostics for user-uploaded `.ent` files.
+
+**Architecture:** Implement a dedicated CodeMirror 6 stream language because `.ent` files use Quake-style quoted key/value pairs, not JSON. Route `.ent` files to the new language and linter through the existing config file-manager hooks in Add Instance and Edit Instance.
+
+**Tech Stack:** React, CodeMirror 6 `StreamLanguage`, CodeMirror lint diagnostics, Vitest.
+
+---
+
+### Task 1: Add The `.ent` Language And Linter
+
+**Files:**
+- Create: `frontend-react/src/codemirror-lang-qlent.js`
+- Test: `frontend-react/src/codemirror-lang-qlent.test.js`
+
+**Step 1: Write tests**
+
+Add tests for:
+- valid entity blocks with quoted key/value pairs produce no diagnostics
+- missing closing brace reports an error
+- malformed non-empty lines report an error
+
+**Step 2: Implement language and linter**
+
+Create `qlentLanguage` with token styles for comments, braces, keys, values, and invalid text. Export `qlentLinter(view)` for diagnostics.
+
+**Step 3: Verify**
+
+Run: `pnpm exec vitest run src/codemirror-lang-qlent.test.js`
+
+### Task 2: Route `.ent` Files To The New Mode
+
+**Files:**
+- Modify: `frontend-react/src/components/addInstance/AddInstanceForm.jsx`
+- Modify: `frontend-react/src/components/instances/EditInstanceConfigModal.jsx`
+- Test: `frontend-react/src/components/addInstance/__tests__/AddInstanceForm.test.jsx`
+- Test: `frontend-react/src/components/instances/__tests__/EditInstanceConfigModal.test.jsx`
+
+**Step 1: Write routing tests**
+
+Add component tests that open an `.ent` config file and assert the file manager receives the `.ent` language and linter.
+
+**Step 2: Implement routing**
+
+Import `qlentLanguage` and `qlentLinter`, return them for filenames ending in `.ent`, and leave existing `.cfg`, `.txt`, factory, and plugin behavior unchanged.
+
+**Step 3: Verify**
+
+Run:
+- `pnpm exec vitest run src/codemirror-lang-qlent.test.js`
+- `pnpm exec vitest run src/components/addInstance/__tests__/AddInstanceForm.test.jsx src/components/instances/__tests__/EditInstanceConfigModal.test.jsx`
+
+### Task 3: Final Checks
+
+**Files:**
+- Review changed files with `git diff`
+
+**Step 1: Run affected frontend tests**
+
+Run the commands from Task 2.
+
+**Step 2: Commit**
+
+Commit docs, implementation, and tests with a focused feature commit.

--- a/frontend-react/src/codemirror-lang-qlent.js
+++ b/frontend-react/src/codemirror-lang-qlent.js
@@ -1,0 +1,121 @@
+import { StreamLanguage } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+
+const QUOTED_STRING = /"(?:[^"\\]|\\.)*"/;
+const BLANK_OR_COMMENT = /^\s*(?:\/\/.*)?$/;
+const OPEN_ENTITY = /^\s*\{\s*(?:(?:\/\/).*)?$/;
+const CLOSE_ENTITY = /^\s*\}\s*(?:(?:\/\/).*)?$/;
+const KEY_VALUE_PAIR = /^\s*"(?:[^"\\]|\\.)*"\s+"(?:[^"\\]|\\.)*"\s*(?:(?:\/\/).*)?$/;
+
+export const qlentLanguage = StreamLanguage.define({
+  startState: function () {
+    return {
+      afterKey: false,
+    };
+  },
+  token: function (stream, state) {
+    if (stream.sol()) {
+      state.afterKey = false;
+    }
+
+    if (stream.eatSpace()) {
+      return null;
+    }
+
+    if (stream.match('//')) {
+      stream.skipToEnd();
+      return 'comment';
+    }
+
+    if (stream.match('{') || stream.match('}')) {
+      state.afterKey = false;
+      return 'operator';
+    }
+
+    if (stream.match(QUOTED_STRING)) {
+      if (state.afterKey) {
+        state.afterKey = false;
+        return 'string';
+      }
+      state.afterKey = true;
+      return 'attributeName';
+    }
+
+    stream.next();
+    return 'invalid';
+  },
+  languageData: {
+    commentTokens: { line: '//' },
+  },
+  tokenTable: {
+    comment: t.lineComment,
+    operator: t.operator,
+    attributeName: t.attributeName,
+    string: t.string,
+    invalid: t.invalid,
+  },
+});
+
+export const qlentLinter = (view) => {
+  const diagnostics = [];
+  let entityDepth = 0;
+
+  for (let n = 1; n <= view.state.doc.lines; n++) {
+    const line = view.state.doc.line(n);
+    const text = line.text;
+
+    if (BLANK_OR_COMMENT.test(text)) {
+      continue;
+    }
+
+    if (OPEN_ENTITY.test(text)) {
+      entityDepth += 1;
+      continue;
+    }
+
+    if (CLOSE_ENTITY.test(text)) {
+      if (entityDepth === 0) {
+        diagnostics.push({
+          from: line.from + text.indexOf('}'),
+          to: line.from + text.indexOf('}') + 1,
+          severity: 'error',
+          message: 'Closing brace has no matching opening brace.',
+        });
+      } else {
+        entityDepth -= 1;
+      }
+      continue;
+    }
+
+    if (KEY_VALUE_PAIR.test(text)) {
+      if (entityDepth === 0) {
+        diagnostics.push({
+          from: line.from,
+          to: line.to,
+          severity: 'error',
+          message: 'Entity key/value pairs must be inside braces.',
+        });
+      }
+      continue;
+    }
+
+    const firstContent = text.search(/\S/);
+    diagnostics.push({
+      from: line.from + Math.max(firstContent, 0),
+      to: line.to,
+      severity: 'error',
+      message: 'Expected {, }, // comment, or a quoted "key" "value" pair.',
+    });
+  }
+
+  if (entityDepth > 0) {
+    diagnostics.push({
+      from: view.state.doc.length,
+      to: view.state.doc.length,
+      severity: 'error',
+      message: 'Missing closing brace for entity block.',
+    });
+  }
+
+  return diagnostics;
+};

--- a/frontend-react/src/codemirror-lang-qlent.js
+++ b/frontend-react/src/codemirror-lang-qlent.js
@@ -69,7 +69,16 @@ export const qlentLinter = (view) => {
     }
 
     if (OPEN_ENTITY.test(text)) {
-      entityDepth += 1;
+      if (entityDepth > 0) {
+        diagnostics.push({
+          from: line.from + text.indexOf('{'),
+          to: line.from + text.indexOf('{') + 1,
+          severity: 'error',
+          message: 'Nested entity blocks are not allowed.',
+        });
+      } else {
+        entityDepth += 1;
+      }
       continue;
     }
 

--- a/frontend-react/src/codemirror-lang-qlent.test.js
+++ b/frontend-react/src/codemirror-lang-qlent.test.js
@@ -1,0 +1,59 @@
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it } from 'vitest';
+
+import { qlentLinter } from './codemirror-lang-qlent';
+
+function lint(doc) {
+  return qlentLinter({
+    state: EditorState.create({ doc }),
+  });
+}
+
+describe('qlentLinter', () => {
+  it('accepts entity blocks with quoted key/value pairs', () => {
+    const diagnostics = lint(`{
+"_lightmapscale" ".5"
+"author" "Tom 'Phantazm11' Perryman"
+"message" "Corrosion"
+"classname" "worldspawn"
+}`);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('reports missing closing braces', () => {
+    const diagnostics = lint(`{
+"classname" "worldspawn"`);
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        severity: 'error',
+        message: 'Missing closing brace for entity block.',
+      }),
+    ]);
+  });
+
+  it('reports malformed non-empty lines', () => {
+    const diagnostics = lint(`{
+classname worldspawn
+}`);
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        severity: 'error',
+        message: 'Expected {, }, // comment, or a quoted "key" "value" pair.',
+      }),
+    ]);
+  });
+
+  it('reports key/value pairs outside braces', () => {
+    const diagnostics = lint('"classname" "worldspawn"');
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        severity: 'error',
+        message: 'Entity key/value pairs must be inside braces.',
+      }),
+    ]);
+  });
+});

--- a/frontend-react/src/codemirror-lang-qlent.test.js
+++ b/frontend-react/src/codemirror-lang-qlent.test.js
@@ -56,4 +56,24 @@ classname worldspawn
       }),
     ]);
   });
+
+  it('reports nested entity blocks', () => {
+    const diagnostics = lint(`{
+"classname" "worldspawn"
+{
+"message" "nested"
+}
+}`);
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        severity: 'error',
+        message: 'Nested entity blocks are not allowed.',
+      }),
+      expect.objectContaining({
+        severity: 'error',
+        message: 'Closing brace has no matching opening brace.',
+      }),
+    ]);
+  });
 });

--- a/frontend-react/src/components/addInstance/AddInstanceForm.jsx
+++ b/frontend-react/src/components/addInstance/AddInstanceForm.jsx
@@ -25,6 +25,7 @@ import {
 import { qlmappoolLanguage } from '../../codemirror-lang-qlmappool';
 import { qlaccessLanguage } from '../../codemirror-lang-qlaccess';
 import { qlworkshopLanguage } from '../../codemirror-lang-qlworkshop';
+import { qlentLanguage, qlentLinter } from '../../codemirror-lang-qlent';
 import {
   getLanRateUnsupportedReason,
   isLanRateSupported,
@@ -87,6 +88,7 @@ function extractPresetConfigs(presetData) {
 
 function getConfigLanguage(fileName) {
   if (fileName?.toLowerCase().endsWith('.cfg')) return qlcfgLanguage;
+  if (fileName?.toLowerCase().endsWith('.ent')) return qlentLanguage;
   return CONFIG_LANGUAGE_MAP[fileName] || undefined;
 }
 
@@ -579,7 +581,7 @@ function AddInstanceForm({
     } finally {
       setIsLoadingPreset(false);
     }
-  }, [checkedPlugins, resetFactories, syncConfigState]);
+  }, [checkedPlugins, resetConfigs, resetFactories, syncConfigState]);
 
 
   // Handle saving current config as a preset
@@ -707,7 +709,12 @@ function AddInstanceForm({
   const handleInternalServerCfgLint = useCallback((hasErrors) => { setServerCfgHasLintErrors(hasErrors); if (onServerCfgLintStatusChange) onServerCfgLintStatusChange(hasErrors); }, [onServerCfgLintStatusChange]);
   const qlCfgLinterSource = useCallback(() => (createQlCfgLinter(availablePorts, handleInternalServerCfgLint)), [availablePorts, handleInternalServerCfgLint]);
   const getLinterSourceForFile = useCallback(
-    (fileName) => (fileName?.toLowerCase().endsWith('.cfg') ? qlCfgLinterSource : null),
+    (fileName) => {
+      const lowerName = fileName?.toLowerCase() || '';
+      if (lowerName.endsWith('.cfg')) return qlCfgLinterSource;
+      if (lowerName.endsWith('.ent')) return qlentLinter;
+      return null;
+    },
     [qlCfgLinterSource],
   );
   const handleExpandEditor = useCallback((selectedFile, content = '') => {

--- a/frontend-react/src/components/addInstance/__tests__/AddInstanceForm.test.jsx
+++ b/frontend-react/src/components/addInstance/__tests__/AddInstanceForm.test.jsx
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
   getFactoryTree: vi.fn(),
   getPresetById: vi.fn(),
   fileManagerProps: [],
+  qlentLanguage: { name: 'qlent' },
+  qlentLinter: vi.fn(),
   savePreset: vi.fn(),
   saveBinaryMeta: vi.fn(),
   updatePreset: vi.fn(),
@@ -37,7 +39,7 @@ vi.mock('../../../services/draftApi', () => ({
 
 vi.mock('../../fileManager', () => ({
   CONFIG_CAPS: {
-    allowedExtensions: ['.cfg', '.txt'],
+    allowedExtensions: ['.cfg', '.txt', '.ent'],
     protectedFiles: ['server.cfg', 'mappool.txt', 'access.txt', 'workshop.txt'],
   },
   PLUGIN_CAPS: {
@@ -152,6 +154,11 @@ vi.mock('../../../codemirror-lang-qlaccess', () => ({
 
 vi.mock('../../../codemirror-lang-qlworkshop', () => ({
   qlworkshopLanguage: {},
+}));
+
+vi.mock('../../../codemirror-lang-qlent', () => ({
+  qlentLanguage: mocks.qlentLanguage,
+  qlentLinter: mocks.qlentLinter,
 }));
 
 describe('AddInstanceForm draft lifecycle', () => {
@@ -397,6 +404,37 @@ describe('AddInstanceForm draft lifecycle', () => {
 
     expect(configManagerProps.getLanguageForFile('custom.cfg')).toEqual({});
     expect(configManagerProps.getLinterSourceForFile('custom.cfg')).toEqual(expect.any(Function));
+  });
+
+  it('uses entity highlighting and linting for .ent config files', async () => {
+    render(
+      <AddInstanceForm
+        initialData={{
+          hosts: [],
+          presets: [],
+          defaultConfigContents: {
+            'server.cfg': '',
+            'mappool.txt': '',
+            'access.txt': '',
+            'workshop.txt': '',
+            'custom_entities/items.ent': '{\n"classname" "worldspawn"\n}',
+          },
+        }}
+        initialHostId={null}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        isLoadingSubmit={false}
+        formError={null}
+        onServerCfgLintStatusChange={vi.fn()}
+        onDirtyStateChange={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mocks.fileManagerProps.length).toBeGreaterThan(0));
+    const configManagerProps = mocks.fileManagerProps.find(props => props.defaultSelectedPath === 'server.cfg');
+
+    expect(configManagerProps.getLanguageForFile('custom_entities/items.ent')).toBe(mocks.qlentLanguage);
+    expect(configManagerProps.getLinterSourceForFile('custom_entities/items.ent')).toBe(mocks.qlentLinter);
   });
 
   it('uses python highlighting for plugin .py files', async () => {

--- a/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
+++ b/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
@@ -16,6 +16,7 @@ import { qlcfgLanguage, createQlCfgLinter, stripManagedCvars } from '../../codem
 import { qlmappoolLanguage } from '../../codemirror-lang-qlmappool';
 import { qlaccessLanguage } from '../../codemirror-lang-qlaccess';
 import { qlworkshopLanguage } from '../../codemirror-lang-qlworkshop';
+import { qlentLanguage, qlentLinter } from '../../codemirror-lang-qlent';
 import {
   canEnableLanRate,
   getLanRateUnsupportedReason,
@@ -31,6 +32,7 @@ const LANGUAGE_MAP = {
 };
 const getLanguageForFile = (fileName) => {
   if (fileName?.toLowerCase().endsWith('.cfg')) return qlcfgLanguage;
+  if (fileName?.toLowerCase().endsWith('.ent')) return qlentLanguage;
   return LANGUAGE_MAP[fileName] || null;
 };
 const FACTORY_LANGUAGE = json();
@@ -205,9 +207,12 @@ function EditInstanceConfigModal({
 
   // Linter for server.cfg — no port validation in edit mode, but shows managed-cvar info tooltips
   const qlCfgLinterSource = useCallback(() => createQlCfgLinter([], () => {}), []);
-  const getLinterSource = (fileName) => (
-    fileName?.toLowerCase().endsWith('.cfg') ? qlCfgLinterSource : null
-  );
+  const getLinterSource = (fileName) => {
+    const lowerName = fileName?.toLowerCase() || '';
+    if (lowerName.endsWith('.cfg')) return qlCfgLinterSource;
+    if (lowerName.endsWith('.ent')) return qlentLinter;
+    return null;
+  };
 
   // Configure plugins based on checkboxes
   const togglePluginSelection = useCallback((filename, checked = undefined) => {

--- a/frontend-react/src/components/instances/__tests__/EditInstanceConfigModal.test.jsx
+++ b/frontend-react/src/components/instances/__tests__/EditInstanceConfigModal.test.jsx
@@ -18,14 +18,22 @@ const mocks = vi.hoisted(() => ({
   updateInstance: vi.fn(),
   updateInstanceConfig: vi.fn(),
   fileManagerProps: [],
+  qlentLanguage: { name: 'qlent' },
+  qlentLinter: vi.fn(),
   useDraftWorkspace: vi.fn(),
 }));
 
 vi.mock('@headlessui/react', () => {
   const Dialog = ({ children }) => <div>{children}</div>;
-  Dialog.Panel = ({ children, transition: _transition, ...props }) => <div {...props}>{children}</div>;
+  Dialog.Panel = ({ children, transition: _transition, ...props }) => {
+    void _transition;
+    return <div {...props}>{children}</div>;
+  };
   Dialog.Title = ({ children, ...props }) => <div {...props}>{children}</div>;
-  const DialogBackdrop = ({ children, transition: _transition, ...props }) => <div {...props}>{children}</div>;
+  const DialogBackdrop = ({ children, transition: _transition, ...props }) => {
+    void _transition;
+    return <div {...props}>{children}</div>;
+  };
 
   const Transition = ({ show, children }) => (show ? <>{children}</> : null);
   Transition.Child = ({ children }) => <>{children}</>;
@@ -88,7 +96,7 @@ vi.mock('../../common/InfoTooltip', () => ({
 
 vi.mock('../../fileManager', () => ({
   CONFIG_CAPS: {
-    allowedExtensions: ['.cfg', '.txt'],
+    allowedExtensions: ['.cfg', '.txt', '.ent'],
     protectedFiles: ['server.cfg', 'mappool.txt', 'access.txt', 'workshop.txt'],
   },
   PLUGIN_CAPS: {
@@ -149,6 +157,11 @@ vi.mock('../../../codemirror-lang-qlaccess', () => ({
 
 vi.mock('../../../codemirror-lang-qlworkshop', () => ({
   qlworkshopLanguage: {},
+}));
+
+vi.mock('../../../codemirror-lang-qlent', () => ({
+  qlentLanguage: mocks.qlentLanguage,
+  qlentLinter: mocks.qlentLinter,
 }));
 
 describe('EditInstanceConfigModal preset saving', () => {
@@ -366,6 +379,33 @@ describe('EditInstanceConfigModal preset saving', () => {
     expect(pluginManagerProps.getLanguageForFile('balance.py')).toBeTruthy();
     expect(pluginManagerProps.getLanguageForFile('readme.txt')).toBeNull();
     expect(pluginManagerProps.onExpandEditor).toEqual(expect.any(Function));
+  });
+
+  it('uses entity highlighting and linting for .ent config files', async () => {
+    mocks.getInstanceConfig.mockResolvedValue({
+      'server.cfg': 'set sv_hostname "Test123"',
+      'mappool.txt': '',
+      'access.txt': '',
+      'workshop.txt': '',
+      'custom_entities/items.ent': '{\n"classname" "worldspawn"\n}',
+      factories: {},
+    });
+
+    render(
+      <EditInstanceConfigModal
+        isOpen={true}
+        onClose={vi.fn()}
+        instanceId={1}
+        instanceName="Test123"
+        onConfigSaved={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /save configuration/i })).toBeInTheDocument());
+    const configManagerProps = mocks.fileManagerProps.find(props => props.defaultSelectedPath === 'server.cfg');
+
+    expect(configManagerProps.getLanguageForFile('custom_entities/items.ent')).toBe(mocks.qlentLanguage);
+    expect(configManagerProps.getLinterSourceForFile('custom_entities/items.ent')).toBe(mocks.qlentLinter);
   });
 
   it('uses JSON highlighting and linting for factory files', async () => {


### PR DESCRIPTION
## Summary

- Adds a dedicated CodeMirror stream language for Quake `.ent` entity files.
- Adds editor lint diagnostics for malformed entity lines, unmatched closing braces, missing closing braces, and key/value pairs outside entity blocks.
- Routes `.ent` config files through the new language and linter in Add Instance and Edit Instance file managers, including expanded editor flows.

## Validation

- `pnpm exec eslint src/codemirror-lang-qlent.js src/codemirror-lang-qlent.test.js src/components/addInstance/AddInstanceForm.jsx src/components/addInstance/__tests__/AddInstanceForm.test.jsx src/components/instances/EditInstanceConfigModal.jsx src/components/instances/__tests__/EditInstanceConfigModal.test.jsx`
- `pnpm exec vitest run src/codemirror-lang-qlent.test.js`
- `pnpm exec vitest run src/components/addInstance/__tests__/AddInstanceForm.test.jsx`
- `pnpm exec vitest run src/components/instances/__tests__/EditInstanceConfigModal.test.jsx`