### PR TITLE
hotfix: restore config sync deletion

### DIFF
--- a/ansible/playbooks/add_qlds_instance.yml
+++ b/ansible/playbooks/add_qlds_instance.yml
@@ -169,14 +169,16 @@
         archive: yes
         recursive: yes
         rsync_path: "sudo -u ql rsync"
-        delete: no
+        # QLSM owns cfg/txt/ent config state under baseq3; keep reserved dirs
+        # excluded below and do not pass --delete-excluded.
+        delete: yes
         rsync_opts:
+          - "--exclude=scripts/***"
+          - "--exclude=factories/***"
           - "--include=*/"
           - "--include=*.cfg"
           - "--include=*.txt"
           - "--include=*.ent"
-          - "--exclude=scripts/***"
-          - "--exclude=factories/***"
           - "--exclude=*"
           - "--prune-empty-dirs"
       delegate_to: localhost

--- a/ansible/playbooks/sync_instance_configs_and_restart.yml
+++ b/ansible/playbooks/sync_instance_configs_and_restart.yml
@@ -24,14 +24,16 @@
         archive: yes
         recursive: yes
         rsync_path: "sudo -u ql rsync"
-        delete: no
+        # QLSM owns cfg/txt/ent config state under baseq3; keep reserved dirs
+        # excluded below and do not pass --delete-excluded.
+        delete: yes
         rsync_opts:
+          - "--exclude=scripts/***"
+          - "--exclude=factories/***"
           - "--include=*/"
           - "--include=*.cfg"
           - "--include=*.txt"
           - "--include=*.ent"
-          - "--exclude=scripts/***"
-          - "--exclude=factories/***"
           - "--exclude=*"
           - "--prune-empty-dirs"
       delegate_to: localhost


### PR DESCRIPTION
## Summary

Restores `delete: yes` on the instance config sync task in both instance creation and config-apply playbooks.

## Why

QLSM removes deleted config files/folders from its local desired state, but the remote `baseq3` sync used `delete: no`, leaving stale files on disk after users delete them in the UI and apply config.

## Scope

- Reconciles QLSM-managed `*.cfg`, `*.txt`, and `*.ent` files under `baseq3`
- Keeps `scripts/***` and `factories/***` excluded
- Does not pass `--delete-excluded`, so excluded paths remain protected
- Adds inline comments documenting this ownership boundary

## Validation

- `git diff --check`
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook --syntax-check ansible/playbooks/sync_instance_configs_and_restart.yml`
- `ANSIBLE_LOCAL_TEMP=/tmp/ansible-local ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote ansible-playbook --syntax-check ansible/playbooks/add_qlds_instance.yml`