### PR TITLE
bug: backfill missing common plugins

### DIFF
--- a/ansible/playbooks/add_qlds_instance.yml
+++ b/ansible/playbooks/add_qlds_instance.yml
@@ -195,15 +195,17 @@
       delegate_to: localhost
       become: false
 
-    - name: Copy common minqlx-plugins to instance directory
-      ansible.builtin.copy:
-        src: "{{ common_assets_dir }}/minqlx-plugins/"
-        dest: "{{ qlds_dir }}/minqlx-plugins/"
-        owner: ql
-        group: ql
-        mode: preserve
-        remote_src: yes
-        force: no
+    - name: Backfill common minqlx-plugins to instance directory
+      ansible.builtin.command:
+        argv:
+          - rsync
+          - -a
+          - --ignore-existing
+          - --itemize-changes
+          - "{{ common_assets_dir }}/minqlx-plugins/"
+          - "{{ qlds_dir }}/minqlx-plugins/"
+      register: common_minqlx_backfill
+      changed_when: common_minqlx_backfill.stdout != ""
 
     - name: Remove existing factory files before syncing (ensures only selected factories remain)
       ansible.builtin.shell: |

--- a/ansible/playbooks/sync_instance_configs_and_restart.yml
+++ b/ansible/playbooks/sync_instance_configs_and_restart.yml
@@ -51,15 +51,17 @@
 
       become: false
 
-    - name: Copy common minqlx-plugins to instance directory
-      ansible.builtin.copy:
-        src: "/home/ql/assets/common/minqlx-plugins/"
-        dest: "{{ qlds_dir }}/minqlx-plugins/"
-        owner: ql
-        group: ql
-        mode: preserve
-        remote_src: yes
-        force: no
+    - name: Backfill common minqlx-plugins to instance directory
+      ansible.builtin.command:
+        argv:
+          - rsync
+          - -a
+          - --ignore-existing
+          - --itemize-changes
+          - /home/ql/assets/common/minqlx-plugins/
+          - "{{ qlds_dir }}/minqlx-plugins/"
+      register: common_minqlx_backfill
+      changed_when: common_minqlx_backfill.stdout != ""
 
     - name: Remove existing factory files before syncing (ensures only selected factories remain)
       ansible.builtin.shell: |


### PR DESCRIPTION
## Summary

Fix the common minqlx plugin deployment step so missing common plugins are backfilled into each instance without overwriting instance-edited plugin files.

## Root Cause

The previous fix changed the common plugin directory copy to `force: no` to protect edited instance plugins like `ban.py`. With Ansible's directory copy behavior, that can skip the whole common plugin copy when the destination directory already exists, so hidden system plugins such as `serverchecker.py` may be absent from an instance even though `qlx_plugins` includes `serverchecker`.

## Changes

- Replace the common minqlx plugin directory copy with an `rsync --ignore-existing` backfill in both instance creation and config sync playbooks.
- Keep instance-specific scripts as the authoritative override source while still restoring missing internal/common plugins.

## Validation

- `ansible-playbook --syntax-check -i localhost, ansible/playbooks/add_qlds_instance.yml`
- `ansible-playbook --syntax-check -i localhost, ansible/playbooks/sync_instance_configs_and_restart.yml`
- `git diff --check`

## Live Host Note

Backfilled missing common plugins on `45.77.155.110` for instance `27961`; verified `serverchecker.py` now exists and `ban.py` line 202 still uses the Redis 2.x `zadd(base_key, score, member)` syntax. The game service was not restarted by this PR.