### PR TITLE
feat: autofill self-host IP from window.location.hostname

### DIFF
--- a/frontend-react/src/components/hosts/AddHostModal.jsx
+++ b/frontend-react/src/components/hosts/AddHostModal.jsx
@@ -116,7 +116,9 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   useEffect(() => {
     if (!isOpen || !providerOptionsReady || provider !== 'self') return;
     setSshUser(selfHostDefaults?.ssh_user || 'root');
-    setIpAddress(selfHostDefaults?.host_ip || window.location.hostname || '');
+    const guessedHostname = window.location.hostname;
+    const guessedIp = (guessedHostname && guessedHostname !== 'localhost' && guessedHostname !== '127.0.0.1') ? guessedHostname : '';
+    setIpAddress(selfHostDefaults?.host_ip || guessedIp);
   }, [isOpen, provider, providerOptionsReady, selfHostDefaults]);
 
   const resetForm = () => {

--- a/frontend-react/src/components/hosts/AddHostModal.jsx
+++ b/frontend-react/src/components/hosts/AddHostModal.jsx
@@ -116,7 +116,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   useEffect(() => {
     if (!isOpen || !providerOptionsReady || provider !== 'self') return;
     setSshUser(selfHostDefaults?.ssh_user || 'root');
-    setIpAddress(selfHostDefaults?.host_ip || '');
+    setIpAddress(selfHostDefaults?.host_ip || window.location.hostname || '');
   }, [isOpen, provider, providerOptionsReady, selfHostDefaults]);
 
   const resetForm = () => {


### PR DESCRIPTION
## Summary
- Pre-populates the IP address field with `window.location.hostname` when adding a QLSM self-deployment host
- Falls back to the server-returned `host_ip` from `getSelfHostDefaults()` if available, then to the hostname, then empty string

## Test plan
- Open Add Host modal with provider set to "QLSM Host (self-deployment)"
- Verify the IP address field is pre-filled with the hostname/IP from the browser's address bar
- Verify it remains editable

---
Generated with [Claude Code](https://claude.com/claude-code)