### PR TITLE
feat: always inject net_ip="" to force QLDS to bind all interfaces

### DIFF
--- a/docs/user/operations/edit-configs.md
+++ b/docs/user/operations/edit-configs.md
@@ -48,6 +48,7 @@ These cvars are ignored by QLSM regardless of whether they are present in `serve
 
 | Cvar | How QLSM manages it | Effect of value in `server.cfg` |
 | --- | --- | --- |
+| `net_ip` | Forced by QLSM. | Ignored. QLSM always injects `""` (binds all interfaces, required for 99k LAN rate to work). |
 | `net_port` | Stored as the instance port and passed at launch. | Ignored. A value in `server.cfg` does not change the instance port. |
 | `sv_serverType` | Controlled by the 99k LAN rate toggle. | Ignored. QLSM injects `1` when 99k LAN rate is enabled, otherwise `2`. |
 | `sv_lanForceRate` | Controlled by the 99k LAN rate toggle. | Ignored. QLSM injects `1` when 99k LAN rate is enabled, otherwise `0`. |

--- a/frontend-react/src/codemirror-lang-qlcfg.js
+++ b/frontend-react/src/codemirror-lang-qlcfg.js
@@ -56,6 +56,7 @@ export const qlcfgLanguage = StreamLanguage.define({
 const MANAGED_CVARS = {
   sv_servertype: 'Managed by the 99k LAN rate toggle. Default: 2 (99k LAN rate OFF).',
   sv_lanforcerate: 'Managed by the 99k LAN rate toggle. Default: 0 (99k LAN rate OFF).',
+  net_ip: 'Forced to "" by the app (binds all interfaces, required for 99k LAN rate).',
   net_strict: 'Forced to 1 by the app.',
   qlx_serverbrandname: 'Derived from the sv_hostname value.',
   qlx_redisdatabase: 'Managed by the app.',

--- a/tests/test_task_deploy_instance.py
+++ b/tests/test_task_deploy_instance.py
@@ -324,3 +324,13 @@ def test_build_qlds_args_self_host_escapes_redis_password(test_app, monkeypatch)
         result = _build_qlds_args_string(inst)
 
         assert '+set qlx_redisPassword "shared\\\\secret\\"quoted"' in result
+
+
+def test_build_qlds_args_always_injects_empty_net_ip(test_app):
+    """net_ip must always be injected as empty string so QLDS binds to
+    0.0.0.0, which is required for 99k LAN rate DNAT to work."""
+    with test_app.app_context():
+        for lan_rate in (True, False):
+            inst = _make_instance_for_args(lan_rate_enabled=lan_rate)
+            result = _build_qlds_args_string(inst)
+            assert '+set net_ip ""' in result

--- a/ui/task_logic/ansible_instance_mgmt.py
+++ b/ui/task_logic/ansible_instance_mgmt.py
@@ -87,6 +87,7 @@ def _build_qlds_args_string(instance):
 
     redis_db_index = instance.port - 27959
     parts += [
+        '+set net_ip ""',
         '+set net_strict 1',
         f'+set net_port {instance.port}',
         f'+set sv_hostname "{instance.hostname}"',


### PR DESCRIPTION
## Summary

- Always pass `+set net_ip ""` in `_build_qlds_args_string` so QLDS binds to `0.0.0.0` on every launch
- Prevents a user-set `net_ip` in `server.cfg` from silently breaking 99k LAN rate (the DNAT trick redirects traffic to `127.0.0.1`, which QLDS only receives if it listens on all interfaces)
- Adds `net_ip` to `MANAGED_CVARS` in the CodeMirror `server.cfg` linter — users who set it will see: *"This cvar will be ignored. Forced to `""` by the app (binds all interfaces, required for 99k LAN rate)."*
- Adds `net_ip` to the managed cvars table in `docs/user/operations/edit-configs.md`
- Adds a test asserting `+set net_ip ""` is present regardless of `lan_rate_enabled` state

## Root cause context

When 99k LAN rate is enabled, an iptables PREROUTING DNAT rule redirects incoming UDP game traffic to `127.0.0.1`. If a server has `set net_ip "x.x.x.x"` in `server.cfg`, QLDS binds only to that public IP and ignores the loopback traffic — clients can't connect. The working reference server (NJ) had no `net_ip` set, so QLDS defaulted to `0.0.0.0`.

## Test plan

- `pytest tests/test_task_deploy_instance.py` — 16 tests pass
- Enable 99k LAN rate on a server with `net_ip` set in `server.cfg` and verify clients can connect
- Open the server.cfg editor and type `set net_ip "1.2.3.4"` — verify the info tooltip appears
