### PR TITLE
feat: performance/capacity chips in plan selector and host drawer

### DIFF
--- a/frontend-react/src/components/common/FloatingListbox.jsx
+++ b/frontend-react/src/components/common/FloatingListbox.jsx
@@ -13,6 +13,47 @@ function OptionBadge({ children }) {
   );
 }
 
+const PERF_CHIP_STYLES = {
+  'Hi-Perf': {
+    color: 'var(--accent-primary)',
+    border: '1px solid var(--accent-primary)',
+    background: 'var(--surface-elevated)',
+  },
+  'Low-Perf': {
+    color: '#f59e0b',
+    border: '1px solid rgba(245,158,11,0.4)',
+    background: 'rgba(245,158,11,0.08)',
+  },
+};
+
+const QL_CHIP_STYLE = {
+  color: '#3b82f6',
+  border: '1px solid rgba(59,130,246,0.35)',
+  background: 'rgba(59,130,246,0.08)',
+};
+
+const CHIP_BASE = 'shrink-0 whitespace-nowrap rounded px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase';
+
+function PerfChip({ label }) {
+  if (!label) return null;
+  return (
+    <span className={CHIP_BASE} style={PERF_CHIP_STYLES[label] ?? PERF_CHIP_STYLES['Hi-Perf']}>
+      {label}
+    </span>
+  );
+}
+
+function QLChip({ count, plural = 'servers' }) {
+  if (!count) return null;
+  const noun = count === 1 ? plural.replace(/s$/, '') : plural;
+  return (
+    <span className={CHIP_BASE} style={QL_CHIP_STYLE}>
+      {count} QL {noun}
+    </span>
+  );
+}
+
+
 function FloatingListbox({
   value,
   onChange,
@@ -23,6 +64,7 @@ function FloatingListbox({
   getOptionValue = null,
   getOptionDisplay = (option) => option.name,
   getOptionBadge = null,
+  getOptionBadges = null,
   getSelectedDisplay = (selectedValue, opts) => {
     if (!selectedValue) return `Select ${label.toLowerCase()}`;
     const actualOptionValueFn = getOptionValue || getOptionKey;
@@ -35,6 +77,7 @@ function FloatingListbox({
   const optionValueFn = getOptionValue || getOptionKey;
   const selectedOption = options.find(opt => optionValueFn(opt) === value);
   const selectedBadge = selectedOption && getOptionBadge?.(selectedOption);
+  const selectedBadges = selectedOption && getOptionBadges?.(selectedOption);
   const selectedDisplay = getSelectedDisplay(value, options) || placeholder;
 
   const { x, y, strategy, refs } = useFloating({
@@ -59,7 +102,12 @@ function FloatingListbox({
             >
               <span className="flex min-w-0 items-center gap-2">
                 <span className="block min-w-0 flex-1 truncate">{selectedDisplay}</span>
-                {selectedBadge && (
+                {selectedBadges?.perfLabel && (
+                  <span className="shrink-0 mr-[74px]">
+                    <PerfChip label={selectedBadges.perfLabel} />
+                  </span>
+                )}
+                {!selectedBadges && selectedBadge && (
                   <span className="shrink-0 mr-[74px]">
                     <OptionBadge>{selectedBadge}</OptionBadge>
                   </span>
@@ -104,6 +152,7 @@ function FloatingListbox({
                         const displayValue = getOptionDisplay(option);
                         const valueForOption = optionValueFn(option);
                         const badge = getOptionBadge?.(option);
+                        const badges = getOptionBadges?.(option);
 
                         return (
                           <Listbox.Option
@@ -115,22 +164,38 @@ function FloatingListbox({
                             }
                           >
                             {({ selected }) => (
-                              <div className="flex w-full min-w-0 items-center gap-2">
-                                <span className={`block min-w-0 flex-1 truncate ${selected ? 'font-semibold' : 'font-normal'}`}>
-                                  {displayValue}
-                                </span>
-                                {(badge || selected) && (
-                                  <span className="grid w-40 shrink-0 grid-cols-[1fr_auto] items-center gap-2">
-                                    <span className="justify-self-start">
-                                      <OptionBadge>{badge}</OptionBadge>
-                                    </span>
-                                    {selected && (
-                                      <Check className="h-4 w-4" style={{ color: 'var(--accent-primary)' }} aria-hidden="true" />
-                                    )}
-                                    {!selected && <span className="h-4 w-4" aria-hidden="true" />}
+                              getOptionBadges ? (
+                                <div className="flex w-full min-w-0 items-center gap-2">
+                                  <span className={`block min-w-0 flex-1 truncate ${selected ? 'font-semibold' : 'font-normal'}`}>
+                                    {displayValue}
                                   </span>
-                                )}
-                              </div>
+                                  <span className="flex shrink-0 items-center gap-1.5">
+                                    <PerfChip label={badges?.perfLabel} />
+                                    <QLChip count={badges?.qlCount} />
+                                  </span>
+                                  {selected
+                                    ? <Check className="h-4 w-4 shrink-0" style={{ color: 'var(--accent-primary)' }} aria-hidden="true" />
+                                    : <span className="h-4 w-4 shrink-0" aria-hidden="true" />
+                                  }
+                                </div>
+                              ) : (
+                                <div className="flex w-full min-w-0 items-center gap-2">
+                                  <span className={`block min-w-0 flex-1 truncate ${selected ? 'font-semibold' : 'font-normal'}`}>
+                                    {displayValue}
+                                  </span>
+                                  {(badge || selected) && (
+                                    <span className="grid w-40 shrink-0 grid-cols-[1fr_auto] items-center gap-2">
+                                      <span className="justify-self-start">
+                                        <OptionBadge>{badge}</OptionBadge>
+                                      </span>
+                                      {selected && (
+                                        <Check className="h-4 w-4" style={{ color: 'var(--accent-primary)' }} aria-hidden="true" />
+                                      )}
+                                      {!selected && <span className="h-4 w-4" aria-hidden="true" />}
+                                    </span>
+                                  )}
+                                </div>
+                              )
                             )}
                           </Listbox.Option>
                         );

--- a/frontend-react/src/components/hosts/AddHostFormFields.jsx
+++ b/frontend-react/src/components/hosts/AddHostFormFields.jsx
@@ -157,7 +157,7 @@ function AddHostFormFields({
             disabled={isVultrUnavailable || !provider || currentSizes.length === 0}
             getOptionKey={(opt) => opt.id}
             getOptionDisplay={(opt) => opt.name}
-            getOptionBadge={(opt) => opt.badgeLabel}
+            getOptionBadges={(opt) => opt.perfLabel ? { perfLabel: opt.perfLabel, qlCount: opt.qlCount } : null}
             getSelectedDisplay={(val, opts) => {
               if (!val) return 'Select Size';
               const selectedOpt = opts.find(o => o.id === val);

--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -7,9 +7,28 @@ import { useNotification } from '../NotificationProvider';
 import StatusIndicator from '../StatusIndicator';
 import { formatDateTime } from '../../utils/uiUtils';
 import { formatVultrRegion, formatVultrPlan } from '../../utils/formatters';
+import { getPlan } from '../../utils/providerData';
 import { HostStatus, QLFILTER_STATUS } from '../../utils/statusEnums';
 import { copyToClipboard } from '../../utils/clipboard';
 import { validateHostName, HOST_NAME_MAX_LENGTH } from '../../utils/resourceValidation';
+
+const CHIP_BASE = 'shrink-0 whitespace-nowrap rounded px-1.5 py-0.5 font-mono text-[10px] font-bold uppercase';
+const PERF_CHIP_STYLES = {
+  'Hi-Perf':  { color: 'var(--accent-primary)', border: '1px solid var(--accent-primary)', background: 'var(--surface-elevated)' },
+  'Low-Perf': { color: '#f59e0b', border: '1px solid rgba(245,158,11,0.4)', background: 'rgba(245,158,11,0.08)' },
+};
+const QL_CHIP_STYLE = { color: '#3b82f6', border: '1px solid rgba(59,130,246,0.35)', background: 'rgba(59,130,246,0.08)' };
+
+function PerfChip({ label }) {
+  if (!label) return null;
+  return <span className={CHIP_BASE} style={PERF_CHIP_STYLES[label] ?? PERF_CHIP_STYLES['Hi-Perf']}>{label}</span>;
+}
+
+function QLChip({ count, plural = 'servers' }) {
+  if (!count) return null;
+  const noun = count === 1 ? plural.replace(/s$/, '') : plural;
+  return <span className={CHIP_BASE} style={QL_CHIP_STYLE}>{count} QL {noun}</span>;
+}
 
 const OS_TYPE_LABELS = {
   debian: 'Debian',
@@ -245,11 +264,31 @@ export default function HostDetailDrawer({
                             <Field label="OS Type">
                               {OS_TYPE_LABELS[internalHost.os_type] || internalHost.os_type || 'Unknown'}
                             </Field>
+                            {internalHost.cpu_count > 0 && (
+                              <Field label="Capacity">
+                                <QLChip count={internalHost.cpu_count} plural="instances" />
+                              </Field>
+                            )}
                           </>
                         ) : (
                           <>
                             <Field label="Region">{formatVultrRegion(internalHost.region)}</Field>
-                            <Field label="Size">{formatVultrPlan(internalHost.machine_size)}</Field>
+                            <Field label="Plan">
+                              {(() => {
+                                const plan = getPlan('vultr', internalHost.machine_size);
+                                return (
+                                  <div className="flex flex-col gap-1.5">
+                                    <span>{formatVultrPlan(internalHost.machine_size)}</span>
+                                    {(plan?.perfLabel || plan?.qlCount) && (
+                                      <span className="flex flex-wrap gap-1.5">
+                                        <PerfChip label={plan.perfLabel} />
+                                        <QLChip count={plan.qlCount} />
+                                      </span>
+                                    )}
+                                  </div>
+                                );
+                              })()}
+                            </Field>
                           </>
                         )}
                         <Field label="IP Address">

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -1588,6 +1588,7 @@ body {
   color: var(--text-muted);
   white-space: nowrap;
   flex-shrink: 0;
+  text-align: right;
 }
 
 .drawer-field dd {

--- a/frontend-react/src/utils/providerData.js
+++ b/frontend-react/src/utils/providerData.js
@@ -1,13 +1,15 @@
 // Contains data for cloud providers used in host creation/management.
 
-// Per-plan region availability buckets, sourced from Vultr /v2/plans.
+// Per-plan region availability buckets, sourced from Vultr /v2/plans API.
 // vc2 / vhf share the same regional footprint (no hnl, no mxp).
 // vhp-amd is offered in mxp but not hnl. vhp-intel is offered in hnl but not mxp.
+// voc-c-amd is offered in both hnl and mxp (superset of vhp-amd and vhp-intel).
 const FAMILY_LABELS = {
-  'vc2':       'Cloud Compute (Shared)',
-  'vhf':       'High Frequency',
-  'vhp-amd':   'High Performance (AMD)',
-  'vhp-intel': 'High Performance (Intel)',
+  'vc2':       'Cloud Compute — Shared',
+  'vhf':       'High Frequency — Shared',
+  'vhp-amd':   'High Performance — Shared (AMD)',
+  'vhp-intel': 'High Performance — Shared (Intel)',
+  'voc-c-amd': 'Dedicated CPU (AMD)',
 };
 
 function planName(family, vcpu, ram_mb, price_usd) {
@@ -17,9 +19,10 @@ function planName(family, vcpu, ram_mb, price_usd) {
   return `${label} — ${vcpu} vCPU / ${ramGb} GB RAM / $${price}/mo`;
 }
 
-const LOC_VC2_VHF =['ams','atl','blr','bom','cdg','del','dfw','ewr','fra','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto'];
-const LOC_VHP_AMD = ['ams','atl','blr','bom','cdg','del','dfw','ewr','fra','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','mxp','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto'];
-const LOC_VHP_INTEL = ['ams','atl','blr','bom','cdg','del','dfw','ewr','fra','hnl','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto'];
+const LOC_VC2_VHF  = ['ams','atl','blr','bom','cdg','del','dfw','ewr','fra','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto'];
+const LOC_VHP_AMD  = ['ams','atl','blr','bom','cdg','del','dfw','ewr','fra','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','mxp','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto'];
+const LOC_VHP_INTEL= ['ams','atl','blr','bom','cdg','del','dfw','ewr','fra','hnl','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto'];
+const LOC_VOC_C    = ['ams','atl','blr','bom','cdg','del','dfw','ewr','fra','hnl','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','mxp','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto'];
 
 export const providerOptions = {
     vultr: {
@@ -60,43 +63,34 @@ export const providerOptions = {
       ],
       // NOTE: Mirrors ui/vultr_plans.py. Tests assert parity.
       sizes: [
-        { id: 'vhf-1c-1gb', name: planName('vhf', 1, 1024, 6), badgeLabel: 'Recommended', family: 'vhf', vcpu: 1, ram_mb: 1024, disk_gb: 32, bandwidth_gb: 1024, price_usd: 6.00, locations: LOC_VC2_VHF },
-        { id: 'vhf-1c-2gb', name: planName('vhf', 1, 2048, 12), family: 'vhf', vcpu: 1, ram_mb: 2048, disk_gb: 64, bandwidth_gb: 2048, price_usd: 12.00, locations: LOC_VC2_VHF },
-        { id: 'vhf-2c-2gb', name: planName('vhf', 2, 2048, 18), family: 'vhf', vcpu: 2, ram_mb: 2048, disk_gb: 80, bandwidth_gb: 3072, price_usd: 18.00, locations: LOC_VC2_VHF },
-        { id: 'vhf-2c-4gb', name: planName('vhf', 2, 4096, 24), family: 'vhf', vcpu: 2, ram_mb: 4096, disk_gb: 128, bandwidth_gb: 3072, price_usd: 24.00, locations: LOC_VC2_VHF },
-        { id: 'vhf-3c-8gb', name: planName('vhf', 3, 8192, 48), family: 'vhf', vcpu: 3, ram_mb: 8192, disk_gb: 256, bandwidth_gb: 4096, price_usd: 48.00, locations: LOC_VC2_VHF },
-        { id: 'vc2-1c-1gb', name: planName('vc2', 1, 1024, 5), family: 'vc2', vcpu: 1, ram_mb: 1024, disk_gb: 25, bandwidth_gb: 1024, price_usd: 5.00, locations: LOC_VC2_VHF },
-        { id: 'vc2-1c-2gb', name: planName('vc2', 1, 2048, 10), family: 'vc2', vcpu: 1, ram_mb: 2048, disk_gb: 55, bandwidth_gb: 2048, price_usd: 10.00, locations: LOC_VC2_VHF },
-        { id: 'vc2-2c-2gb', name: planName('vc2', 2, 2048, 15), family: 'vc2', vcpu: 2, ram_mb: 2048, disk_gb: 65, bandwidth_gb: 3072, price_usd: 15.00, locations: LOC_VC2_VHF },
-        { id: 'vc2-2c-4gb', name: planName('vc2', 2, 4096, 20), family: 'vc2', vcpu: 2, ram_mb: 4096, disk_gb: 80, bandwidth_gb: 3072, price_usd: 20.00, locations: LOC_VC2_VHF },
-        { id: 'vc2-4c-8gb', name: planName('vc2', 4, 8192, 40), family: 'vc2', vcpu: 4, ram_mb: 8192, disk_gb: 160, bandwidth_gb: 4096, price_usd: 40.00, locations: LOC_VC2_VHF },
+        { id: 'vhf-1c-1gb', name: planName('vhf', 1, 1024, 6), perfLabel: 'Low-Perf', qlCount: 1, family: 'vhf', vcpu: 1, ram_mb: 1024, disk_gb: 32, bandwidth_gb: 1024, price_usd: 6.00, locations: LOC_VC2_VHF },
+        { id: 'vhf-1c-2gb', name: planName('vhf', 1, 2048, 12), perfLabel: 'Low-Perf', qlCount: 1, family: 'vhf', vcpu: 1, ram_mb: 2048, disk_gb: 64, bandwidth_gb: 2048, price_usd: 12.00, locations: LOC_VC2_VHF },
+        { id: 'vhf-2c-2gb', name: planName('vhf', 2, 2048, 18), perfLabel: 'Low-Perf', qlCount: 2, family: 'vhf', vcpu: 2, ram_mb: 2048, disk_gb: 80, bandwidth_gb: 3072, price_usd: 18.00, locations: LOC_VC2_VHF },
+        { id: 'vhf-2c-4gb', name: planName('vhf', 2, 4096, 24), perfLabel: 'Low-Perf', qlCount: 2, family: 'vhf', vcpu: 2, ram_mb: 4096, disk_gb: 128, bandwidth_gb: 3072, price_usd: 24.00, locations: LOC_VC2_VHF },
+        { id: 'vhf-3c-8gb', name: planName('vhf', 3, 8192, 48), perfLabel: 'Low-Perf', qlCount: 3, family: 'vhf', vcpu: 3, ram_mb: 8192, disk_gb: 256, bandwidth_gb: 4096, price_usd: 48.00, locations: LOC_VC2_VHF },
         // Overkill for QL workloads (max realistic load: 4 instances x 24 players). Re-enable if needed.
         // { id: 'vhf-4c-16gb', name: 'vhf-4c-16gb (4 VCPU, 16384 RAM, 384 DISK, 5120GB BW, $96.00/mo)', family: 'vhf', vcpu: 4, ram_mb: 16384, disk_gb: 384, bandwidth_gb: 5120, price_usd: 96.00 },
-        { id: 'vhp-1c-1gb-amd', name: planName('vhp-amd', 1, 1024, 6), family: 'vhp-amd', vcpu: 1, ram_mb: 1024, disk_gb: 25, bandwidth_gb: 2048, price_usd: 6.00, locations: LOC_VHP_AMD },
-        { id: 'vhp-1c-2gb-amd', name: planName('vhp-amd', 1, 2048, 12), family: 'vhp-amd', vcpu: 1, ram_mb: 2048, disk_gb: 50, bandwidth_gb: 3072, price_usd: 12.00, locations: LOC_VHP_AMD },
-        { id: 'vhp-2c-2gb-amd', name: planName('vhp-amd', 2, 2048, 18), family: 'vhp-amd', vcpu: 2, ram_mb: 2048, disk_gb: 60, bandwidth_gb: 4096, price_usd: 18.00, locations: LOC_VHP_AMD },
-        { id: 'vhp-2c-4gb-amd', name: planName('vhp-amd', 2, 4096, 24), family: 'vhp-amd', vcpu: 2, ram_mb: 4096, disk_gb: 100, bandwidth_gb: 5120, price_usd: 24.00, locations: LOC_VHP_AMD },
-        { id: 'vhp-4c-8gb-amd', name: planName('vhp-amd', 4, 8192, 48), family: 'vhp-amd', vcpu: 4, ram_mb: 8192, disk_gb: 180, bandwidth_gb: 6144, price_usd: 48.00, locations: LOC_VHP_AMD },
+        { id: 'voc-c-1c-2gb-25s-amd', name: planName('voc-c-amd', 1, 2048, 28), perfLabel: 'Hi-Perf', qlCount: 1, family: 'voc-c-amd', vcpu: 1, ram_mb: 2048, disk_gb: 25, bandwidth_gb: 4096, price_usd: 28.00, locations: LOC_VOC_C },
+        { id: 'voc-c-2c-4gb-50s-amd', name: planName('voc-c-amd', 2, 4096, 40), perfLabel: 'Hi-Perf', qlCount: 2, family: 'voc-c-amd', vcpu: 2, ram_mb: 4096, disk_gb: 50, bandwidth_gb: 5120, price_usd: 40.00, locations: LOC_VOC_C },
+        { id: 'voc-c-4c-8gb-75s-amd', name: planName('voc-c-amd', 4, 8192, 80), perfLabel: 'Hi-Perf', qlCount: 4, family: 'voc-c-amd', vcpu: 4, ram_mb: 8192, disk_gb: 75, bandwidth_gb: 6144, price_usd: 80.00, locations: LOC_VOC_C },
+        // Other voc-* subfamilies (general-purpose, memory, storage) omitted — overkill for QL.
+        { id: 'vc2-1c-1gb', name: planName('vc2', 1, 1024, 5), perfLabel: 'Low-Perf', qlCount: 1, family: 'vc2', vcpu: 1, ram_mb: 1024, disk_gb: 25, bandwidth_gb: 1024, price_usd: 5.00, locations: LOC_VC2_VHF },
+        { id: 'vc2-1c-2gb', name: planName('vc2', 1, 2048, 10), perfLabel: 'Low-Perf', qlCount: 1, family: 'vc2', vcpu: 1, ram_mb: 2048, disk_gb: 55, bandwidth_gb: 2048, price_usd: 10.00, locations: LOC_VC2_VHF },
+        { id: 'vc2-2c-2gb', name: planName('vc2', 2, 2048, 15), perfLabel: 'Low-Perf', qlCount: 2, family: 'vc2', vcpu: 2, ram_mb: 2048, disk_gb: 65, bandwidth_gb: 3072, price_usd: 15.00, locations: LOC_VC2_VHF },
+        { id: 'vc2-2c-4gb', name: planName('vc2', 2, 4096, 20), perfLabel: 'Low-Perf', qlCount: 2, family: 'vc2', vcpu: 2, ram_mb: 4096, disk_gb: 80, bandwidth_gb: 3072, price_usd: 20.00, locations: LOC_VC2_VHF },
+        { id: 'vc2-4c-8gb', name: planName('vc2', 4, 8192, 40), perfLabel: 'Low-Perf', qlCount: 4, family: 'vc2', vcpu: 4, ram_mb: 8192, disk_gb: 160, bandwidth_gb: 4096, price_usd: 40.00, locations: LOC_VC2_VHF },
+        { id: 'vhp-1c-1gb-amd', name: planName('vhp-amd', 1, 1024, 6), perfLabel: 'Hi-Perf', qlCount: 1, family: 'vhp-amd', vcpu: 1, ram_mb: 1024, disk_gb: 25, bandwidth_gb: 2048, price_usd: 6.00, locations: LOC_VHP_AMD },
+        { id: 'vhp-1c-2gb-amd', name: planName('vhp-amd', 1, 2048, 12), perfLabel: 'Hi-Perf', qlCount: 1, family: 'vhp-amd', vcpu: 1, ram_mb: 2048, disk_gb: 50, bandwidth_gb: 3072, price_usd: 12.00, locations: LOC_VHP_AMD },
+        { id: 'vhp-2c-2gb-amd', name: planName('vhp-amd', 2, 2048, 18), perfLabel: 'Hi-Perf', qlCount: 2, family: 'vhp-amd', vcpu: 2, ram_mb: 2048, disk_gb: 60, bandwidth_gb: 4096, price_usd: 18.00, locations: LOC_VHP_AMD },
+        { id: 'vhp-2c-4gb-amd', name: planName('vhp-amd', 2, 4096, 24), perfLabel: 'Hi-Perf', qlCount: 2, family: 'vhp-amd', vcpu: 2, ram_mb: 4096, disk_gb: 100, bandwidth_gb: 5120, price_usd: 24.00, locations: LOC_VHP_AMD },
+        { id: 'vhp-4c-8gb-amd', name: planName('vhp-amd', 4, 8192, 48), perfLabel: 'Hi-Perf', qlCount: 4, family: 'vhp-amd', vcpu: 4, ram_mb: 8192, disk_gb: 180, bandwidth_gb: 6144, price_usd: 48.00, locations: LOC_VHP_AMD },
         // { id: 'vhp-4c-12gb-amd', name: 'vhp-4c-12gb-amd (4 VCPU, 12288 RAM, 260 DISK, 7168GB BW, $72.00/mo)', family: 'vhp-amd', vcpu: 4, ram_mb: 12288, disk_gb: 260, bandwidth_gb: 7168, price_usd: 72.00 },
-        { id: 'vhp-1c-1gb-intel', name: planName('vhp-intel', 1, 1024, 6), family: 'vhp-intel', vcpu: 1, ram_mb: 1024, disk_gb: 25, bandwidth_gb: 2048, price_usd: 6.00, locations: LOC_VHP_INTEL },
-        { id: 'vhp-1c-2gb-intel', name: planName('vhp-intel', 1, 2048, 12), family: 'vhp-intel', vcpu: 1, ram_mb: 2048, disk_gb: 50, bandwidth_gb: 3072, price_usd: 12.00, locations: LOC_VHP_INTEL },
-        { id: 'vhp-2c-2gb-intel', name: planName('vhp-intel', 2, 2048, 18), family: 'vhp-intel', vcpu: 2, ram_mb: 2048, disk_gb: 60, bandwidth_gb: 4096, price_usd: 18.00, locations: LOC_VHP_INTEL },
-        { id: 'vhp-2c-4gb-intel', name: planName('vhp-intel', 2, 4096, 24), family: 'vhp-intel', vcpu: 2, ram_mb: 4096, disk_gb: 100, bandwidth_gb: 5120, price_usd: 24.00, locations: LOC_VHP_INTEL },
-        { id: 'vhp-4c-8gb-intel', name: planName('vhp-intel', 4, 8192, 48), family: 'vhp-intel', vcpu: 4, ram_mb: 8192, disk_gb: 180, bandwidth_gb: 6144, price_usd: 48.00, locations: LOC_VHP_INTEL }
+        { id: 'vhp-1c-1gb-intel', name: planName('vhp-intel', 1, 1024, 6), perfLabel: 'Hi-Perf', qlCount: 1, family: 'vhp-intel', vcpu: 1, ram_mb: 1024, disk_gb: 25, bandwidth_gb: 2048, price_usd: 6.00, locations: LOC_VHP_INTEL },
+        { id: 'vhp-1c-2gb-intel', name: planName('vhp-intel', 1, 2048, 12), perfLabel: 'Hi-Perf', qlCount: 1, family: 'vhp-intel', vcpu: 1, ram_mb: 2048, disk_gb: 50, bandwidth_gb: 3072, price_usd: 12.00, locations: LOC_VHP_INTEL },
+        { id: 'vhp-2c-2gb-intel', name: planName('vhp-intel', 2, 2048, 18), perfLabel: 'Hi-Perf', qlCount: 2, family: 'vhp-intel', vcpu: 2, ram_mb: 2048, disk_gb: 60, bandwidth_gb: 4096, price_usd: 18.00, locations: LOC_VHP_INTEL },
+        { id: 'vhp-2c-4gb-intel', name: planName('vhp-intel', 2, 4096, 24), perfLabel: 'Hi-Perf', qlCount: 2, family: 'vhp-intel', vcpu: 2, ram_mb: 4096, disk_gb: 100, bandwidth_gb: 5120, price_usd: 24.00, locations: LOC_VHP_INTEL },
+        { id: 'vhp-4c-8gb-intel', name: planName('vhp-intel', 4, 8192, 48), perfLabel: 'Hi-Perf', qlCount: 4, family: 'vhp-intel', vcpu: 4, ram_mb: 8192, disk_gb: 180, bandwidth_gb: 6144, price_usd: 48.00, locations: LOC_VHP_INTEL }
         // { id: 'vhp-4c-12gb-intel', name: 'vhp-4c-12gb-intel (4 VCPU, 12288 RAM, 260 DISK, 7168GB BW, $72.00/mo)', family: 'vhp-intel', vcpu: 4, ram_mb: 12288, disk_gb: 260, bandwidth_gb: 7168, price_usd: 72.00 },
-        // Optimized Cloud (voc-*) plans omitted - designed for storage/DB workloads, overkill for QL.
-        // { id: 'voc-c-1c-2gb-25s-amd', name: 'voc-c-1c-2gb-25s-amd (1 VCPU, 2048 RAM, 25 DISK, 4096GB BW, $28.00/mo)', family: 'voc-c-amd', vcpu: 1, ram_mb: 2048, disk_gb: 25, bandwidth_gb: 4096, price_usd: 28.00 },
-        // { id: 'voc-g-1c-4gb-30s-amd', name: 'voc-g-1c-4gb-30s-amd (1 VCPU, 4096 RAM, 30 DISK, 4096GB BW, $30.00/mo)', family: 'voc-g-amd', vcpu: 1, ram_mb: 4096, disk_gb: 30, bandwidth_gb: 4096, price_usd: 30.00 },
-        // { id: 'voc-m-1c-8gb-50s-amd', name: 'voc-m-1c-8gb-50s-amd (1 VCPU, 8192 RAM, 50 DISK, 5120GB BW, $40.00/mo)', family: 'voc-m-amd', vcpu: 1, ram_mb: 8192, disk_gb: 50, bandwidth_gb: 5120, price_usd: 40.00 },
-        // { id: 'voc-c-2c-4gb-50s-amd', name: 'voc-c-2c-4gb-50s-amd (2 VCPU, 4096 RAM, 50 DISK, 5120GB BW, $40.00/mo)', family: 'voc-c-amd', vcpu: 2, ram_mb: 4096, disk_gb: 50, bandwidth_gb: 5120, price_usd: 40.00 },
-        // { id: 'voc-g-2c-8gb-50s-amd', name: 'voc-g-2c-8gb-50s-amd (2 VCPU, 8192 RAM, 50 DISK, 5120GB BW, $60.00/mo)', family: 'voc-g-amd', vcpu: 2, ram_mb: 8192, disk_gb: 50, bandwidth_gb: 5120, price_usd: 60.00 },
-        // { id: 'voc-c-2c-4gb-75s-amd', name: 'voc-c-2c-4gb-75s-amd (2 VCPU, 4096 RAM, 75 DISK, 5120GB BW, $45.00/mo)', family: 'voc-c-amd', vcpu: 2, ram_mb: 4096, disk_gb: 75, bandwidth_gb: 5120, price_usd: 45.00 },
-        // { id: 'voc-c-4c-8gb-75s-amd', name: 'voc-c-4c-8gb-75s-amd (4 VCPU, 8192 RAM, 75 DISK, 6144GB BW, $80.00/mo)', family: 'voc-c-amd', vcpu: 4, ram_mb: 8192, disk_gb: 75, bandwidth_gb: 6144, price_usd: 80.00 },
-        // { id: 'voc-g-4c-16gb-80s-amd', name: 'voc-g-4c-16gb-80s-amd (4 VCPU, 16384 RAM, 80 DISK, 6144GB BW, $120.00/mo)', family: 'voc-g-amd', vcpu: 4, ram_mb: 16384, disk_gb: 80, bandwidth_gb: 6144, price_usd: 120.00 },
-        // { id: 'voc-m-2c-16gb-100s-amd', name: 'voc-m-2c-16gb-100s-amd (2 VCPU, 16384 RAM, 100 DISK, 6144GB BW, $80.00/mo)', family: 'voc-m-amd', vcpu: 2, ram_mb: 16384, disk_gb: 100, bandwidth_gb: 6144, price_usd: 80.00 },
-        // { id: 'voc-s-1c-8gb-150s-amd', name: 'voc-s-1c-8gb-150s-amd (1 VCPU, 8192 RAM, 150 DISK, 4096GB BW, $75.00/mo)', family: 'voc-s-amd', vcpu: 1, ram_mb: 8192, disk_gb: 150, bandwidth_gb: 4096, price_usd: 75.00 },
-        // { id: 'voc-c-4c-8gb-150s-amd', name: 'voc-c-4c-8gb-150s-amd (4 VCPU, 8192 RAM, 150 DISK, 6144GB BW, $90.00/mo)', family: 'voc-c-amd', vcpu: 4, ram_mb: 8192, disk_gb: 150, bandwidth_gb: 6144, price_usd: 90.00 },
-        // { id: 'voc-m-2c-16gb-200s-amd', name: 'voc-m-2c-16gb-200s-amd (2 VCPU, 16384 RAM, 200 DISK, 6144GB BW, $100.00/mo)', family: 'voc-m-amd', vcpu: 2, ram_mb: 16384, disk_gb: 200, bandwidth_gb: 6144, price_usd: 100.00 }
       ],
     },
     linode: { // Placeholder for Linode if needed later

--- a/ui/vultr_plans.py
+++ b/ui/vultr_plans.py
@@ -9,9 +9,11 @@ that both catalogs list the same plan IDs.
 # Per-plan region availability buckets, sourced from Vultr /v2/plans.
 # vc2 / vhf share the same regional footprint (no hnl, no mxp).
 # vhp-amd is offered in mxp but not hnl. vhp-intel is offered in hnl but not mxp.
-_LOC_VC2_VHF = ('ams','atl','blr','bom','cdg','del','dfw','ewr','fra','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto')
-_LOC_VHP_AMD = ('ams','atl','blr','bom','cdg','del','dfw','ewr','fra','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','mxp','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto')
-_LOC_VHP_INTEL = ('ams','atl','blr','bom','cdg','del','dfw','ewr','fra','hnl','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto')
+# voc-c-amd is offered in both hnl and mxp (superset of vhp-amd and vhp-intel).
+_LOC_VC2_VHF  = ('ams','atl','blr','bom','cdg','del','dfw','ewr','fra','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto')
+_LOC_VHP_AMD  = ('ams','atl','blr','bom','cdg','del','dfw','ewr','fra','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','mxp','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto')
+_LOC_VHP_INTEL= ('ams','atl','blr','bom','cdg','del','dfw','ewr','fra','hnl','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto')
+_LOC_VOC_C    = ('ams','atl','blr','bom','cdg','del','dfw','ewr','fra','hnl','icn','itm','jnb','lax','lhr','mad','man','mel','mex','mia','mxp','nrt','ord','sao','scl','sea','sgp','sjc','sto','syd','tlv','waw','yto')
 
 
 def _locations(plan_id):
@@ -21,6 +23,8 @@ def _locations(plan_id):
         return _LOC_VHP_AMD
     if plan_id.startswith("vhp-") and plan_id.endswith("-intel"):
         return _LOC_VHP_INTEL
+    if plan_id.startswith("voc-c-") and plan_id.endswith("-amd"):
+        return _LOC_VOC_C
     return ()
 
 
@@ -44,6 +48,7 @@ _FAMILY_LABELS = {
     "vhf":       "High Frequency",
     "vhp-amd":   "High Performance (AMD)",
     "vhp-intel": "High Performance (Intel)",
+    "voc-c-amd": "Dedicated CPU (AMD)",
 }
 
 
@@ -101,11 +106,13 @@ VULTR_PLANS = [
     _plan("vhp-4c-8gb-intel", 4, 8192, 180, 6144, 48.00),
     # _plan("vhp-4c-12gb-intel", 4, 12288, 260, 7168, 72.00),
 
-    # voc: Optimized Cloud (omitted - designed for storage/DB workloads, overkill for QL)
-    # _plan("voc-c-1c-2gb-25s-amd", 1, 2048, 25, 4096, 28.00),
+    # voc-c: Dedicated CPU (AMD) — one physical core per instance, ideal for QL workloads
+    _plan("voc-c-1c-2gb-25s-amd", 1, 2048, 25, 4096, 28.00),
+    _plan("voc-c-2c-4gb-50s-amd", 2, 4096, 50, 5120, 40.00),
+    _plan("voc-c-4c-8gb-75s-amd", 4, 8192, 75, 6144, 80.00),
+    # Other voc-* subfamilies (general-purpose, memory, storage) omitted — overkill for QL.
     # _plan("voc-g-1c-4gb-30s-amd", 1, 4096, 30, 4096, 30.00),
     # _plan("voc-m-1c-8gb-50s-amd", 1, 8192, 50, 5120, 40.00),
-    # _plan("voc-c-2c-4gb-50s-amd", 2, 4096, 50, 5120, 40.00),
     # _plan("voc-g-2c-8gb-50s-amd", 2, 8192, 50, 5120, 60.00),
     # _plan("voc-c-2c-4gb-75s-amd", 2, 4096, 75, 5120, 45.00),
     # _plan("voc-c-4c-8gb-75s-amd", 4, 8192, 75, 6144, 80.00),


### PR DESCRIPTION
## Summary

- **All Vultr plans** now carry structured `perfLabel` (`Hi-Perf` / `Low-Perf`) and `qlCount` fields replacing the old monolithic `badgeLabel` string
- **Dedicated CPU plans** (`voc-c-amd`) added with accurate regional footprint (`LOC_VOC_C`) sourced directly from the Vultr `/v2/plans` API — covers both `hnl` and `mxp`, superset of VHP AMD and Intel footprints
- **Plan selector dropdown** (Add Host modal): `FloatingListbox` gains a `getOptionBadges` prop; each option renders a green `Hi-Perf` or amber `Low-Perf` chip and a blue `X QL servers` chip inline with the plan name; trigger button shows only the perf chip when a plan is selected
- **Host Detail Drawer**: Vultr "Size" field renamed to "Plan" — shows hardware spec + chips below; standalone/self hosts gain a "Capacity" field showing a blue `X QL instances` chip derived from `host.cpu_count` (lazy-detected via Ansible `nproc`, already in the API response)
- **Drawer labels** right-aligned via `.drawer-field dt { text-align: right }`

## Test plan

- [ ] Open Add Host modal → select Vultr → pick a continent/region → confirm all plans show inline perf + QL chips; selecting a plan shows only the perf chip in the trigger button
- [ ] Confirm `vc2-*` / `vhf-*` show amber Low-Perf chip; `vhp-*` / `voc-c-*` show green Hi-Perf chip
- [ ] Open Host Detail Drawer for a Vultr host with a known plan — confirm "Plan" field shows spec + chips
- [ ] Open Host Detail Drawer for a standalone host with `cpu_count` set — confirm "Capacity" field appears with blue chip
- [ ] Open Host Detail Drawer for a standalone host with `cpu_count = null` — confirm no Capacity field
- [ ] Confirm drawer field labels are right-aligned