### PR TITLE
feat: detect QLSM self-host and redirect standalone add

### DIFF
--- a/frontend-react/src/components/hosts/AddHostFormFields.jsx
+++ b/frontend-react/src/components/hosts/AddHostFormFields.jsx
@@ -47,6 +47,7 @@ function AddHostFormFields({
   connectionTestStatus,
   connectionTestMessage,
   onTestConnection,
+  onSwitchToSelfHost,
   osInfo,
 }) {
   const isStandalone = provider === 'standalone';
@@ -270,6 +271,7 @@ function AddHostFormFields({
             connectionTestStatus={connectionTestStatus}
             connectionTestMessage={connectionTestMessage}
             onTestConnection={onTestConnection}
+            onSwitchToSelfHost={onSwitchToSelfHost}
           />
         </>
       )}

--- a/frontend-react/src/components/hosts/AddHostModal.jsx
+++ b/frontend-react/src/components/hosts/AddHostModal.jsx
@@ -46,7 +46,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   // Standalone-specific state
   const [ipAddress, setIpAddress] = useState('');
   const [sshPort, setSshPort] = useState(22);
-  const [sshUser, setSshUser] = useState('root');
+  const [sshUser, setSshUser] = useState('');
   const [sshKey, setSshKey] = useState('');
   const [sshPassword, setSshPassword] = useState('');
   const [standaloneAuthMethod, setStandaloneAuthMethod] = useState('key');
@@ -115,10 +115,12 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
 
   useEffect(() => {
     if (!isOpen || !providerOptionsReady || provider !== 'self') return;
-    setSshUser(selfHostDefaults?.ssh_user || 'root');
     const guessedHostname = window.location.hostname;
     const guessedIp = (guessedHostname && guessedHostname !== 'localhost' && guessedHostname !== '127.0.0.1') ? guessedHostname : '';
-    setIpAddress(selfHostDefaults?.host_ip || guessedIp);
+    // Only seed defaults when fields are empty — on a redirect from standalone the
+    // user's typed values must be preserved.
+    if (!ipAddress) setIpAddress(selfHostDefaults?.host_ip || guessedIp);
+    if (!sshUser) setSshUser(selfHostDefaults?.ssh_user || 'root');
   }, [isOpen, provider, providerOptionsReady, selfHostDefaults]);
 
   const resetForm = () => {
@@ -132,7 +134,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
     setLoading(false);
     setIpAddress('');
     setSshPort(22);
-    setSshUser('root');
+    setSshUser('');
     setSshKey('');
     setSshPassword('');
     setStandaloneAuthMethod('key');
@@ -175,17 +177,36 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
     setConnectionTestMessage('');
     try {
       const result = await testHostConnection(buildStandaloneConnectionData());
-      if (result.success) {
-        setConnectionTestStatus('success');
-        setConnectionTestMessage(result.message || 'Connection successful');
-      } else {
+      if (!result.success) {
         setConnectionTestStatus('failed');
         setConnectionTestMessage(result.message || 'Connection failed');
+        return;
       }
+      if (result.qlsm_detected) {
+        if (selfHostExists) {
+          setConnectionTestStatus('qlsm_blocked');
+          setConnectionTestMessage('This server is your QLSM host and is already registered as a self-host.');
+        } else {
+          setConnectionTestStatus('qlsm_redirect');
+          setConnectionTestMessage('This server is running QLSM. Add it as your self-host instead?');
+        }
+        return;
+      }
+      setConnectionTestStatus('success');
+      setConnectionTestMessage(result.message || 'Connection successful');
     } catch (err) {
       setConnectionTestStatus('failed');
       setConnectionTestMessage(err.error?.message || err.message || 'Connection test failed');
     }
+  };
+
+  const handleSwitchToSelfHost = () => {
+    setProvider('self');
+    setSshKey('');
+    setSshPassword('');
+    setSshPort(22);
+    setStandaloneAuthMethod('key');
+    resetConnectionTest();
   };
 
   const handleNameBlur = () => {
@@ -400,6 +421,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
                         connectionTestStatus={connectionTestStatus}
                         connectionTestMessage={connectionTestMessage}
                         onTestConnection={handleTestConnection}
+                        onSwitchToSelfHost={handleSwitchToSelfHost}
                         osInfo={selfHostOsInfo}
                       />
                     ) : (

--- a/frontend-react/src/components/hosts/StandaloneAuthSection.jsx
+++ b/frontend-react/src/components/hosts/StandaloneAuthSection.jsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { CheckCircle, Loader2, Upload, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle, Loader2, Upload, XCircle } from 'lucide-react';
 
 const inputClass = 'mt-1 block w-full px-3 py-2 rounded-lg text-sm text-theme-primary placeholder:text-theme-muted focus:outline-none focus:ring-1 transition-colors';
 const inputFocusRing = 'focus:ring-[var(--accent-primary)] focus:border-[var(--accent-primary)]';
@@ -44,6 +44,7 @@ function StandaloneAuthSection({
   connectionTestStatus,
   connectionTestMessage,
   onTestConnection,
+  onSwitchToSelfHost,
 }) {
   const fileInputRef = useRef(null);
   const isPasswordAuth = authMethod === 'password';
@@ -216,6 +217,44 @@ function StandaloneAuthSection({
 
         {connectionTestMessage && connectionTestStatus === 'failed' && (
           <p className="mt-2 text-xs" style={{ color: 'var(--accent-danger)' }}>{connectionTestMessage}</p>
+        )}
+
+        {connectionTestStatus === 'qlsm_redirect' && (
+          <div
+            className="mt-2 flex items-start gap-2.5 px-3.5 py-3 rounded-lg text-sm"
+            style={{
+              background: 'rgba(255, 184, 0, 0.08)',
+              border: '1px solid rgba(255, 184, 0, 0.2)',
+              color: 'var(--accent-warning, #ffb800)',
+            }}
+          >
+            <AlertTriangle size={16} className="flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <p>{connectionTestMessage}</p>
+              <button
+                type="button"
+                onClick={onSwitchToSelfHost}
+                className="mt-2 inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-semibold transition-all text-white dark:text-[#0A0E14]"
+                style={{ background: 'var(--accent-warning, #ffb800)' }}
+              >
+                Continue as self-host
+              </button>
+            </div>
+          </div>
+        )}
+
+        {connectionTestStatus === 'qlsm_blocked' && (
+          <div
+            className="mt-2 flex items-start gap-2.5 px-3.5 py-3 rounded-lg text-sm"
+            style={{
+              background: 'rgba(255, 51, 102, 0.08)',
+              border: '1px solid rgba(255, 51, 102, 0.2)',
+              color: 'var(--accent-danger)',
+            }}
+          >
+            <AlertTriangle size={16} className="flex-shrink-0 mt-0.5" />
+            <span>{connectionTestMessage}</span>
+          </div>
         )}
 
         {successMessage && connectionTestStatus === 'success' && (

--- a/frontend-react/src/components/hosts/__tests__/AddHostModal.test.jsx
+++ b/frontend-react/src/components/hosts/__tests__/AddHostModal.test.jsx
@@ -56,6 +56,7 @@ vi.mock('../AddHostFormFields', () => ({
       <div data-testid="connection-status">{props.connectionTestStatus}</div>
       <div data-testid="connection-message">{props.connectionTestMessage}</div>
       <button type="button" onClick={props.onTestConnection}>Test connection</button>
+      <button type="button" onClick={() => props.onSwitchToSelfHost?.()}>Switch to self-host</button>
     </div>
   ),
 }));
@@ -186,5 +187,112 @@ describe('AddHostModal self provider', () => {
 
     fireEvent.submit(screen.getByRole('button', { name: /add host/i }).closest('form'));
     expect(mocks.createHost).not.toHaveBeenCalled();
+  });
+});
+
+describe('AddHostModal — QLSM-detected redirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getHosts.mockResolvedValue([]);
+    mocks.getSelfHostDefaults.mockResolvedValue({
+      ssh_user: 'rage',
+      host_ip: '203.0.113.10',
+      provider_capabilities: { vultr: { configured: true } },
+    });
+  });
+
+  it('enters qlsm_redirect state when test detects QLSM and no self exists', async () => {
+    mocks.testHostConnection.mockResolvedValue({
+      success: true,
+      message: 'Connection successful',
+      qlsm_detected: true,
+    });
+
+    render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
+    const standaloneBtn = await screen.findByRole('button', { name: /choose standalone/i });
+    fireEvent.click(standaloneBtn);
+    fireEvent.change(screen.getByLabelText('Server address'), { target: { value: '203.0.113.50' } });
+    fireEvent.change(screen.getByLabelText('SSH Private Key'), { target: { value: 'fake-key' } });
+    fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connection-status')).toHaveTextContent('qlsm_redirect')
+    );
+    expect(screen.getByTestId('connection-message')).toHaveTextContent(
+      /add it as your self-host instead/i
+    );
+  });
+
+  it('enters qlsm_blocked state when test detects QLSM and self already exists', async () => {
+    mocks.getHosts.mockResolvedValue([
+      { id: 1, name: 'self-host', provider: 'self', ip_address: '203.0.113.10' },
+    ]);
+    mocks.testHostConnection.mockResolvedValue({
+      success: true,
+      message: 'Connection successful',
+      qlsm_detected: true,
+    });
+
+    render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('provider-value')).toHaveTextContent('standalone')
+    );
+    const ipField = screen.getByLabelText('Server address');
+    fireEvent.change(ipField, { target: { value: '203.0.113.10' } });
+    fireEvent.change(screen.getByLabelText('SSH Private Key'), { target: { value: 'fake-key' } });
+    fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connection-status')).toHaveTextContent('qlsm_blocked')
+    );
+    expect(screen.getByTestId('connection-message')).toHaveTextContent(
+      /already registered as a self-host/i
+    );
+  });
+
+  it('flips provider to self and clears standalone-only fields when switch button is clicked', async () => {
+    mocks.testHostConnection.mockResolvedValue({
+      success: true,
+      message: 'Connection successful',
+      qlsm_detected: true,
+    });
+
+    render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
+    const standaloneBtn = await screen.findByRole('button', { name: /choose standalone/i });
+    fireEvent.click(standaloneBtn);
+    fireEvent.change(screen.getByLabelText('Server address'), { target: { value: '203.0.113.50' } });
+    fireEvent.change(screen.getByLabelText('SSH User'), { target: { value: 'admin' } });
+    fireEvent.change(screen.getByLabelText('SSH Private Key'), { target: { value: 'fake-key' } });
+    fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId('connection-status')).toHaveTextContent('qlsm_redirect')
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /switch to self-host/i }));
+
+    await waitFor(() => expect(screen.getByTestId('provider-value')).toHaveTextContent('self'));
+    expect(screen.getByLabelText('Server address')).toHaveValue('203.0.113.50');
+    expect(screen.getByLabelText('SSH User')).toHaveValue('admin');
+    expect(screen.getByLabelText('SSH Private Key')).toHaveValue('');
+    expect(screen.getByTestId('connection-status')).toHaveTextContent('idle');
+  });
+
+  it('keeps existing flow when qlsm_detected is false', async () => {
+    mocks.testHostConnection.mockResolvedValue({
+      success: true,
+      message: 'Connection successful. Detected OS: Debian 12.',
+      qlsm_detected: false,
+    });
+
+    render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
+    const standaloneBtn = await screen.findByRole('button', { name: /choose standalone/i });
+    fireEvent.click(standaloneBtn);
+    fireEvent.change(screen.getByLabelText('Server address'), { target: { value: '203.0.113.60' } });
+    fireEvent.change(screen.getByLabelText('SSH Private Key'), { target: { value: 'fake-key' } });
+    fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('connection-status')).toHaveTextContent('success')
+    );
   });
 });

--- a/frontend-react/src/components/hosts/__tests__/StandaloneAuthSection.test.jsx
+++ b/frontend-react/src/components/hosts/__tests__/StandaloneAuthSection.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import StandaloneAuthSection from '../StandaloneAuthSection';
 
@@ -84,4 +84,64 @@ it('renders success details in green and the Ubuntu warning in red', () => {
 
   expect(screen.getByText(/Detected OS: Ubuntu 24\.04\.2 LTS/i)).toHaveStyle('color: #22d97f');
   expect(screen.getByText(/Warning: 99k LAN rate is not compatible with Ubuntu\./i)).toHaveStyle('color: var(--accent-danger)');
+});
+
+const renderSection = (overrides = {}) =>
+  render(
+    <StandaloneAuthSection
+      authMethod="key"
+      onAuthMethodChange={vi.fn()}
+      sshKey="abc"
+      onSshKeyChange={vi.fn()}
+      sshPassword=""
+      onSshPasswordChange={vi.fn()}
+      ipAddress="203.0.113.40"
+      sshUser="root"
+      connectionTestStatus="idle"
+      connectionTestMessage=""
+      onTestConnection={vi.fn()}
+      onSwitchToSelfHost={vi.fn()}
+      {...overrides}
+    />
+  );
+
+describe('StandaloneAuthSection — qlsm_redirect state', () => {
+  it('shows the redirect banner with a "Continue as self-host" button', () => {
+    renderSection({
+      connectionTestStatus: 'qlsm_redirect',
+      connectionTestMessage: 'This server is running QLSM. Add it as your self-host instead?',
+    });
+
+    expect(
+      screen.getByText(/This server is running QLSM\. Add it as your self-host instead\?/)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue as self-host/i })).toBeInTheDocument();
+  });
+
+  it('invokes onSwitchToSelfHost when the button is clicked', () => {
+    const onSwitchToSelfHost = vi.fn();
+    renderSection({
+      connectionTestStatus: 'qlsm_redirect',
+      connectionTestMessage: 'This server is running QLSM. Add it as your self-host instead?',
+      onSwitchToSelfHost,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /continue as self-host/i }));
+
+    expect(onSwitchToSelfHost).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('StandaloneAuthSection — qlsm_blocked state', () => {
+  it('shows the blocked banner with no action button', () => {
+    renderSection({
+      connectionTestStatus: 'qlsm_blocked',
+      connectionTestMessage: 'This server is your QLSM host and is already registered as a self-host.',
+    });
+
+    expect(
+      screen.getByText(/This server is your QLSM host and is already registered as a self-host\./)
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /continue as self-host/i })).not.toBeInTheDocument();
+  });
 });

--- a/tests/test_host_api_routes.py
+++ b/tests/test_host_api_routes.py
@@ -683,6 +683,115 @@ def test_test_connection_password_success(mock_test, mock_detect_os, client, app
 
 
 @patch('ui.routes.host_routes.detect_remote_os', return_value={
+    'id': 'debian',
+    'version_id': '12',
+    'pretty_name': 'Debian GNU/Linux 12 (bookworm)',
+    'os_type': 'debian',
+    'qlsm_detected': True,
+})
+@patch('ui.routes.host_routes.subprocess.run')
+def test_test_connection_key_returns_qlsm_detected_true(mock_run, mock_detect_os, client, app):
+    """Key-mode test surfaces qlsm_detected=True when detect_remote_os reports it."""
+    mock_run.return_value = MagicMock(returncode=0, stdout='pong', stderr='')
+    headers = auth_headers(app, DEFAULT_USER)
+
+    response = client.post('/api/hosts/test-connection', headers=headers, json={
+        'ip_address': '203.0.113.30',
+        'ssh_port': 22,
+        'ssh_user': 'root',
+        'ssh_auth_method': 'key',
+        'ssh_key': '-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----',
+    })
+
+    assert response.status_code == 200
+    body = response.get_json()['data']
+    assert body['success'] is True
+    assert body['qlsm_detected'] is True
+
+
+@patch('ui.routes.host_routes.detect_remote_os', return_value={
+    'id': 'debian',
+    'version_id': '12',
+    'pretty_name': 'Debian GNU/Linux 12 (bookworm)',
+    'os_type': 'debian',
+    'qlsm_detected': True,
+})
+@patch('ui.routes.host_routes.test_password_connection', return_value=(True, 'Connection successful'))
+def test_test_connection_password_returns_qlsm_detected_true(mock_test, mock_detect_os, client, app):
+    """Password-mode test surfaces qlsm_detected=True when detect_remote_os reports it."""
+    headers = auth_headers(app, DEFAULT_USER)
+
+    response = client.post('/api/hosts/test-connection', headers=headers, json={
+        'ip_address': '203.0.113.31',
+        'ssh_port': 22,
+        'ssh_user': 'root',
+        'ssh_auth_method': 'password',
+        'ssh_password': 'secret',
+    })
+
+    assert response.status_code == 200
+    body = response.get_json()['data']
+    assert body['success'] is True
+    assert body['qlsm_detected'] is True
+
+
+@patch('ui.routes.host_routes.detect_remote_os', return_value={
+    'id': 'debian',
+    'version_id': '12',
+    'pretty_name': 'Debian GNU/Linux 12 (bookworm)',
+    'os_type': 'debian',
+    'qlsm_detected': False,
+})
+@patch('ui.routes.host_routes.test_password_connection', return_value=(True, 'Connection successful'))
+def test_test_connection_password_returns_qlsm_detected_false(mock_test, mock_detect_os, client, app):
+    """Connection succeeds, no QLSM containers detected — qlsm_detected is False."""
+    headers = auth_headers(app, DEFAULT_USER)
+
+    response = client.post('/api/hosts/test-connection', headers=headers, json={
+        'ip_address': '203.0.113.32',
+        'ssh_port': 22,
+        'ssh_user': 'root',
+        'ssh_auth_method': 'password',
+        'ssh_password': 'secret',
+    })
+
+    assert response.status_code == 200
+    body = response.get_json()['data']
+    assert body['success'] is True
+    assert body['qlsm_detected'] is False
+
+
+@patch('ui.routes.host_routes.detect_remote_os', return_value={
+    'id': 'ubuntu',
+    'version_id': '18.04',
+    'pretty_name': 'Ubuntu 18.04.6 LTS',
+    'os_type': None,
+    'qlsm_detected': True,
+})
+@patch('ui.routes.host_routes.test_password_connection', return_value=(True, 'Connection successful'))
+def test_test_connection_qlsm_detected_false_when_os_unsupported(mock_test, mock_detect_os, client, app):
+    """When OS is unsupported (success=False), qlsm_detected must be False in the response.
+
+    Even though detect_remote_os returned qlsm_detected=True, the route must suppress
+    it when success=False — one issue at a time (spec edge-case row 9).
+    """
+    headers = auth_headers(app, DEFAULT_USER)
+
+    response = client.post('/api/hosts/test-connection', headers=headers, json={
+        'ip_address': '203.0.113.33',
+        'ssh_port': 22,
+        'ssh_user': 'root',
+        'ssh_auth_method': 'password',
+        'ssh_password': 'secret',
+    })
+
+    assert response.status_code == 200
+    body = response.get_json()['data']
+    assert body['success'] is False
+    assert body['qlsm_detected'] is False
+
+
+@patch('ui.routes.host_routes.detect_remote_os', return_value={
     'id': 'ubuntu',
     'version_id': '24.04',
     'pretty_name': 'Ubuntu 24.04.2 LTS',

--- a/tests/test_standalone_ssh.py
+++ b/tests/test_standalone_ssh.py
@@ -30,6 +30,21 @@ def _ssh_client(stdout_data=b"", stderr_data=b"", exit_status=0):
     return client
 
 
+def _ssh_client_multi(*responses):
+    """Mock SSH client where exec_command returns successive (stdout, exit_status) responses."""
+    client = MagicMock()
+    sides = []
+    for stdout_data, exit_status in responses:
+        stdout = MagicMock()
+        stdout.channel.recv_exit_status.return_value = exit_status
+        stdout.read.return_value = stdout_data
+        stderr = MagicMock()
+        stderr.read.return_value = b""
+        sides.append((MagicMock(), stdout, stderr))
+    client.exec_command.side_effect = sides
+    return client
+
+
 def test_load_managed_public_key_reads_sidecar(tmp_path):
     key_path = tmp_path / "host_id_rsa"
     pub_path = Path(f"{key_path}.pub")
@@ -176,14 +191,16 @@ def test_audited_auto_add_policy_logs_sha256_fingerprint(caplog):
 
 @patch("ui.standalone_ssh.paramiko.SSHClient")
 def test_detect_remote_os_maps_supported_release(mock_client_cls):
-    client = _ssh_client(
-        stdout_data=(
+    client = _ssh_client_multi(
+        (
             b'NAME="Ubuntu"\n'
             b'VERSION="24.04.2 LTS (Noble Numbat)"\n'
             b'ID=ubuntu\n'
             b'VERSION_ID="24.04"\n'
-            b'PRETTY_NAME="Ubuntu 24.04.2 LTS"\n'
+            b'PRETTY_NAME="Ubuntu 24.04.2 LTS"\n',
+            0,
         ),
+        (b"", 0),
     )
     mock_client_cls.return_value = client
 
@@ -199,17 +216,20 @@ def test_detect_remote_os_maps_supported_release(mock_client_cls):
         "version_id": "24.04",
         "pretty_name": "Ubuntu 24.04.2 LTS",
         "os_type": "ubuntu",
+        "qlsm_detected": False,
     }
 
 
 @patch("ui.standalone_ssh.paramiko.SSHClient")
 def test_detect_remote_os_marks_unsupported_release(mock_client_cls):
-    client = _ssh_client(
-        stdout_data=(
+    client = _ssh_client_multi(
+        (
             b'ID=ubuntu\n'
             b'VERSION_ID="18.04"\n'
-            b'PRETTY_NAME="Ubuntu 18.04.6 LTS"\n'
+            b'PRETTY_NAME="Ubuntu 18.04.6 LTS"\n',
+            0,
         ),
+        (b"", 0),
     )
     mock_client_cls.return_value = client
 
@@ -222,6 +242,81 @@ def test_detect_remote_os_marks_unsupported_release(mock_client_cls):
 
     assert detected["pretty_name"] == "Ubuntu 18.04.6 LTS"
     assert detected["os_type"] == "ubuntu"
+    assert detected["qlsm_detected"] is False
+
+
+@patch("ui.standalone_ssh.paramiko.SSHClient")
+def test_detect_remote_os_marks_qlsm_when_image_running(mock_client_cls):
+    client = _ssh_client_multi(
+        (
+            b'ID=debian\n'
+            b'VERSION_ID="12"\n'
+            b'PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"\n',
+            0,
+        ),
+        (b"ghcr.io/dngrtech/qlsm:latest\nredis:7-alpine\n", 0),
+    )
+    mock_client_cls.return_value = client
+
+    detected = detect_remote_os(
+        host="203.0.113.12",
+        port=22,
+        username="root",
+        password="secret",
+    )
+
+    assert detected["qlsm_detected"] is True
+
+
+@patch("ui.standalone_ssh.paramiko.SSHClient")
+def test_detect_remote_os_marks_no_qlsm_when_no_matching_image(mock_client_cls):
+    client = _ssh_client_multi(
+        (
+            b'ID=debian\n'
+            b'VERSION_ID="12"\n'
+            b'PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"\n',
+            0,
+        ),
+        (b"nginx:latest\nredis:7-alpine\n", 0),
+    )
+    mock_client_cls.return_value = client
+
+    detected = detect_remote_os(
+        host="203.0.113.13",
+        port=22,
+        username="root",
+        password="secret",
+    )
+
+    assert detected["qlsm_detected"] is False
+
+
+@patch("ui.standalone_ssh.paramiko.SSHClient")
+def test_detect_remote_os_marks_no_qlsm_when_docker_unavailable(mock_client_cls):
+    """If `docker ps` exits non-zero (docker missing, no permission), treat as no QLSM.
+
+    The stdout is intentionally non-empty (contains the image name substring) to
+    prove that the exit-status gate fires and the substring check is never reached.
+    """
+    client = _ssh_client_multi(
+        (
+            b'ID=debian\n'
+            b'VERSION_ID="12"\n'
+            b'PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"\n',
+            0,
+        ),
+        (b"dngrtech/qlsm:latest\n", 127),
+    )
+    mock_client_cls.return_value = client
+
+    detected = detect_remote_os(
+        host="203.0.113.14",
+        port=22,
+        username="root",
+        password="secret",
+    )
+
+    assert detected["qlsm_detected"] is False
 
 
 @patch("ui.standalone_ssh.paramiko.SSHClient")

--- a/ui/routes/host_routes.py
+++ b/ui/routes/host_routes.py
@@ -365,14 +365,15 @@ def _test_standalone_connection_with_key(validated_ip, ssh_port, ssh_user, ssh_k
 
         if result.returncode == 0:
             current_app.logger.info(f"Connection test successful for {validated_ip}")
-            success, message, _ = _detect_and_validate_remote_os(
+            success, message, detected_os = _detect_and_validate_remote_os(
                 host=validated_ip,
                 port=ssh_port,
                 username=ssh_user,
                 timeout=15,
                 key_filename=temp_key_path,
             )
-            return jsonify({"data": {"success": success, "message": message}}), 200
+            qlsm_detected = bool(success and detected_os and detected_os.get("qlsm_detected"))
+            return jsonify({"data": {"success": success, "message": message, "qlsm_detected": qlsm_detected}}), 200
 
         error_output = result.stderr or result.stdout or "Unknown error"
         current_app.logger.warning(f"Connection test failed for {validated_ip}: {error_output}")
@@ -1219,15 +1220,17 @@ def test_connection_api():
             ssh_user,
             credential,
         )
+        detected_os = None
         if success:
-            success, message, _ = _detect_and_validate_remote_os(
+            success, message, detected_os = _detect_and_validate_remote_os(
                 host=validated_ip,
                 port=ssh_port,
                 username=ssh_user,
                 timeout=15,
                 password=credential,
             )
-        return jsonify({"data": {"success": success, "message": message}}), 200
+        qlsm_detected = bool(success and detected_os and detected_os.get("qlsm_detected"))
+        return jsonify({"data": {"success": success, "message": message, "qlsm_detected": qlsm_detected}}), 200
 
     return _test_standalone_connection_with_key(
         validated_ip,

--- a/ui/standalone_ssh.py
+++ b/ui/standalone_ssh.py
@@ -157,14 +157,15 @@ def _run_checked_command(client, command):
 def _check_qlsm_running(client):
     """Best-effort detection of QLSM containers on a connected SSH client.
 
-    Returns False if docker is missing, the invoking user lacks permission, or
-    no QLSM-tagged container is running. The exit status of docker ps is
-    inspected: a non-zero exit is treated as "not detected" regardless of stdout
-    content. SSH-session failures (exec_command raising) propagate to detect_remote_os
-    and surface as StandaloneSSHError — they are not swallowed here.
+    Returns False if docker is missing, the invoking user lacks permission,
+    no QLSM-tagged container is running, or the SSH transport fails mid-session.
+    Never raises — callers should treat a False return as "not detected".
     """
-    _, stdout, _ = client.exec_command("docker ps --format '{{.Image}}' 2>/dev/null")
-    exit_status = stdout.channel.recv_exit_status()
+    try:
+        _, stdout, _ = client.exec_command("docker ps --format '{{.Image}}' 2>/dev/null")
+        exit_status = stdout.channel.recv_exit_status()
+    except (paramiko.SSHException, OSError):
+        return False
     if exit_status != 0:
         return False
     output = _decode_stream(stdout)

--- a/ui/standalone_ssh.py
+++ b/ui/standalone_ssh.py
@@ -154,8 +154,29 @@ def _run_checked_command(client, command):
     return stdout_text, stderr_text
 
 
+def _check_qlsm_running(client):
+    """Best-effort detection of QLSM containers on a connected SSH client.
+
+    Returns False if docker is missing, the invoking user lacks permission, or
+    no QLSM-tagged container is running. The exit status of docker ps is
+    inspected: a non-zero exit is treated as "not detected" regardless of stdout
+    content. SSH-session failures (exec_command raising) propagate to detect_remote_os
+    and surface as StandaloneSSHError — they are not swallowed here.
+    """
+    _, stdout, _ = client.exec_command("docker ps --format '{{.Image}}' 2>/dev/null")
+    exit_status = stdout.channel.recv_exit_status()
+    if exit_status != 0:
+        return False
+    output = _decode_stream(stdout)
+    return "dngrtech/qlsm" in output
+
+
 def detect_remote_os(*, host, port, username, timeout=30, password=None, key_filename=None):
-    """Read /etc/os-release over SSH and map it onto QLSM's supported standalone OS types."""
+    """Read /etc/os-release over SSH and map it onto QLSM's supported standalone OS types.
+
+    Also runs `docker ps` in the same SSH session to detect whether the host is
+    already running QLSM containers (so the UI can offer a self-host redirect).
+    """
     try:
         with _ssh_session(
             host=host,
@@ -167,6 +188,7 @@ def detect_remote_os(*, host, port, username, timeout=30, password=None, key_fil
             audit_new_host_keys=password is not None,
         ) as client:
             stdout_text, _ = _run_checked_command(client, "cat /etc/os-release")
+            qlsm_detected = _check_qlsm_running(client)
     except (paramiko.AuthenticationException, paramiko.SSHException, OSError, StandaloneSSHError) as exc:
         raise StandaloneSSHError(f"Unable to detect remote OS: {exc}") from exc
 
@@ -180,6 +202,7 @@ def detect_remote_os(*, host, port, username, timeout=30, password=None, key_fil
         "version_id": os_release_values.get("VERSION_ID", "").strip() or None,
         "pretty_name": detected_name,
         "os_type": _detect_supported_os_type(os_release_values),
+        "qlsm_detected": qlsm_detected,
     }
 
 


### PR DESCRIPTION
## Summary

- Extends `detect_remote_os` in `standalone_ssh.py` to run `docker ps` in the same paramiko session and return `qlsm_detected: bool`
- Both key-auth and password-auth paths of `POST /api/hosts/test-connection` now surface `qlsm_detected` in the response
- `AddHostModal.handleTestConnection` branches on `qlsm_detected` + `selfHostExists`:
  - No self-host exists → enters `qlsm_redirect` state: warning banner + "Continue as self-host" button
  - Self-host already exists → enters `qlsm_blocked` state: error banner, submit disabled
- `handleSwitchToSelfHost` flips provider to `self`, clears standalone-only fields, preserves IP / SSH user / timezone
- Self-defaults `useEffect` now guards `setIpAddress`/`setSshUser` calls so they don't clobber values already entered during a standalone redirect

## Test plan

- [ ] Backend: `pytest tests/test_standalone_ssh.py tests/test_host_api_routes.py -v` — all green
- [ ] Frontend: `pnpm exec vitest run src/components/hosts/__tests__/` — all green
- [ ] Manual Scenario A: standalone form pointed at QLSM machine, no self-host exists → redirect banner appears, clicking "Continue as self-host" flips form to self-host with IP/user preserved
- [ ] Manual Scenario B: self-host already registered, standalone test against same IP → blocked banner, submit disabled
- [ ] Manual Scenario C: non-QLSM host → normal success banner, no QLSM UI shown
- [ ] Manual Scenario D: change IP after seeing banner → banner disappears, retest required

---
Generated with [Claude Code](https://claude.com/claude-code)