### PR TITLE
feat: kickban minqlx plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,10 @@ terraform/vultr-root/*
 !tests/
 !tests/**
 
+# ── Custom minqlx plugins ─────────────────────────────────────────────────────
+!qlsm_plugins/
+!qlsm_plugins/*.py
+
 # ── RCON ──────────────────────────────────────────────────────────────────────
 !rcon_service/
 !rcon_service/**

--- a/qlsm_plugins/kickban.py
+++ b/qlsm_plugins/kickban.py
@@ -1,0 +1,219 @@
+"""
+kickban.py — auto-ban players kicked too many times in a sliding window.
+
+CVARs:
+  qlx_kickbanThreshold    - kicks within window before ban (default: 3)
+  qlx_kickbanWindow       - window duration in minutes (default: 15)
+  qlx_kickbanDuration     - ban length in minutes (default: 60)
+  qlx_kickbanImmunityLevel - permission level immune from auto-ban (default: 2)
+
+Commands:
+  !kickhistory <id>  - show kick count + timestamps within window (perm 2)
+  !kickclear <id>    - clear a player's kick history (perm 2)
+"""
+
+import datetime
+import time
+import uuid
+
+import minqlx
+
+PLAYER_KEY = "minqlx:players:{}"
+TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+class kickban(minqlx.Plugin):
+    def __init__(self):
+        super().__init__()
+
+        self.set_cvar_once("qlx_kickbanThreshold", "3")
+        self.set_cvar_once("qlx_kickbanWindow", "15")
+        self.set_cvar_once("qlx_kickbanDuration", "60")
+        self.set_cvar_once("qlx_kickbanImmunityLevel", "2")
+
+        self.add_hook("player_disconnect", self.handle_player_disconnect)
+        self.add_hook("player_loaded", self.handle_player_loaded)
+
+        self.add_command("kickhistory", self.cmd_kickhistory, 2, usage="<id>")
+        self.add_command("kickclear", self.cmd_kickclear, 2, usage="<id>")
+
+    # ── Key helpers ──────────────────────────────────────────────────────
+
+    def _kicks_key(self, steam_id):
+        return PLAYER_KEY.format(steam_id) + ":kicks"
+
+    def _bans_key(self, steam_id):
+        return PLAYER_KEY.format(steam_id) + ":bans"
+
+    # ── Cvar helpers ─────────────────────────────────────────────────────
+
+    def _threshold(self):
+        # Clamp to minimum 2: a threshold of 0 or 1 bans on first kick, which is a foot-gun.
+        return max(2, self.get_cvar("qlx_kickbanThreshold", int))
+
+    def _window(self):
+        return self.get_cvar("qlx_kickbanWindow", int)
+
+    def _duration(self):
+        return self.get_cvar("qlx_kickbanDuration", int)
+
+    def _immunity(self):
+        return self.get_cvar("qlx_kickbanImmunityLevel", int)
+
+    # ── Redis helpers ────────────────────────────────────────────────────
+
+    def _prune_and_count(self, steam_id):
+        """Remove kicks outside the window and return the current count."""
+        cutoff = time.time() - (self._window() * 60)
+        key = self._kicks_key(steam_id)
+        self.db.zremrangebyscore(key, 0, cutoff)
+        return self.db.zcard(key)
+
+    def _resolve_player(self, ident_str, channel):
+        """Return (steam_id, display_name) or (None, None) on error."""
+        try:
+            ident = int(ident_str)
+            if 0 <= ident < 64:
+                target = self.player(ident)
+                return target.steam_id, target.clean_name
+            return ident, str(ident)
+        except ValueError:
+            channel.reply("Invalid ID. Use a client ID (0-63) or a SteamID64.")
+            return None, None
+        except minqlx.NonexistentPlayerError:
+            channel.reply("No player found at that client slot.")
+            return None, None
+
+    # ── Hooks ────────────────────────────────────────────────────────────
+
+    def handle_player_disconnect(self, player, reason):
+        if not reason or "kicked" not in reason.lower():
+            return
+
+        # Guard: player attributes may be unavailable on a partially torn-down
+        # player object during disconnect teardown.
+        try:
+            steam_id = player.steam_id
+            name = player.clean_name
+        except minqlx.NonexistentPlayerError:
+            return
+
+        if self.db.get_permission(steam_id) >= self._immunity():
+            return
+
+        count = self._prune_and_count(steam_id)
+        ts = time.time()
+        # Use a UUID as the member so two kicks within the same float-timestamp
+        # resolution are stored as distinct sorted set entries.
+        self.db.zadd(self._kicks_key(steam_id), {str(uuid.uuid4()): ts})
+        count += 1
+
+        if count >= self._threshold():
+            self._issue_ban(steam_id, name, count)
+
+    @minqlx.delay(5)
+    def handle_player_loaded(self, player):
+        try:
+            player.update()
+        except minqlx.NonexistentPlayerError:
+            return
+
+        steam_id = player.steam_id
+        count = self._prune_and_count(steam_id)
+
+        if count == 0:
+            return
+
+        threshold = self._threshold()
+        window = self._window()
+        duration = self._duration()
+        remaining = threshold - count
+
+        self.msg(
+            "^3{}^7 has been kicked ^1{}^7 time(s) in the last ^3{}^7 min — "
+            "^1{}^7 more kick(s) will result in a ^1{}^7-minute ban.".format(
+                player.clean_name, count, window, remaining, duration
+            )
+        )
+
+    # ── Ban issuance ─────────────────────────────────────────────────────
+
+    def _issue_ban(self, steam_id, name, count):
+        """Write a ban to ban.py's Redis format and broadcast to server."""
+        duration = self._duration()
+        window = self._window()
+        # datetime.now() returns local time — this matches ban.py's convention.
+        # ban.py's is_banned() also uses datetime.now() for comparison, so this
+        # is internally consistent even though time.time() (the sorted set score)
+        # is a Unix epoch value.
+        now = datetime.datetime.now()
+        expires = now + datetime.timedelta(minutes=duration)
+        now_str = now.strftime(TIME_FORMAT)
+        expires_str = expires.strftime(TIME_FORMAT)
+
+        base_key = self._bans_key(steam_id)
+        # ban_id is derived from zcard — known limitation shared with ban.py:
+        # if old bans have been removed (expired or !unban), zcard may return an
+        # ID that was used before, overwriting the old hash. This matches ban.py's
+        # own ID generation and is acceptable given the low frequency of re-banning
+        # the same player. A future improvement could use an INCR-based counter.
+        ban_id = self.db.zcard(base_key)
+
+        pipe = self.db.pipeline()
+        pipe.zadd(base_key, {ban_id: time.time() + duration * 60})
+        pipe.hmset(
+            base_key + ":{}".format(ban_id),
+            {
+                "expires": expires_str,
+                "reason": "Auto-banned: kicked {} times within {} minutes".format(count, window),
+                "issued": now_str,
+                "issued_by": "0",
+            },
+        )
+        pipe.execute()
+
+        self.db.delete(self._kicks_key(steam_id))
+        self.msg(
+            "^3{}^7 has been auto-banned for ^1{}^7 minutes.".format(name, duration)
+        )
+
+    # ── Commands ─────────────────────────────────────────────────────────
+
+    def cmd_kickhistory(self, player, msg, channel):
+        if len(msg) < 2:
+            return minqlx.RET_USAGE
+
+        steam_id, name = self._resolve_player(msg[1], channel)
+        if steam_id is None:
+            return
+
+        count = self._prune_and_count(steam_id)
+        window = self._window()
+        threshold = self._threshold()
+
+        if count == 0:
+            channel.reply("^6{}^7 has no kicks in the last ^3{}^7 minutes.".format(name, window))
+            return
+
+        cutoff = time.time() - window * 60
+        kicks = self.db.zrangebyscore(self._kicks_key(steam_id), cutoff, "+inf", withscores=True)
+        timestamps = [
+            datetime.datetime.fromtimestamp(float(score)).strftime(TIME_FORMAT)
+            for _, score in kicks
+        ]
+        channel.reply(
+            "^6{}^7: ^1{}/{}^7 kicks in last ^3{}^7 min: {}".format(
+                name, count, threshold, window, ", ".join(timestamps)
+            )
+        )
+
+    def cmd_kickclear(self, player, msg, channel):
+        if len(msg) < 2:
+            return minqlx.RET_USAGE
+
+        steam_id, name = self._resolve_player(msg[1], channel)
+        if steam_id is None:
+            return
+
+        self.db.delete(self._kicks_key(steam_id))
+        channel.reply("^6{}^7's kick history cleared.".format(name))

--- a/qlsm_plugins/kickban.py
+++ b/qlsm_plugins/kickban.py
@@ -127,7 +127,10 @@ class kickban(minqlx.Plugin):
         threshold = self._threshold()
         window = self._window()
         duration = self._duration()
-        remaining = threshold - count
+        remaining = max(0, threshold - count)
+
+        if remaining == 0:
+            return
 
         self.msg(
             "^3{}^7 has been kicked ^1{}^7 time(s) in the last ^3{}^7 min — "
@@ -161,9 +164,9 @@ class kickban(minqlx.Plugin):
 
         pipe = self.db.pipeline()
         pipe.zadd(base_key, {ban_id: time.time() + duration * 60})
-        pipe.hmset(
+        pipe.hset(
             base_key + ":{}".format(ban_id),
-            {
+            mapping={
                 "expires": expires_str,
                 "reason": "Auto-banned: kicked {} times within {} minutes".format(count, window),
                 "issued": now_str,
@@ -216,4 +219,5 @@ class kickban(minqlx.Plugin):
             return
 
         self.db.delete(self._kicks_key(steam_id))
+        self.msg("^6{}^7 cleared kick history for ^6{}^7.".format(player.clean_name, name))
         channel.reply("^6{}^7's kick history cleared.".format(name))

--- a/tests/test_kickban_plugin.py
+++ b/tests/test_kickban_plugin.py
@@ -159,8 +159,10 @@ class TestIssueBan(unittest.TestCase):
         with patch.object(self.plugin, "msg"):
             self.plugin._issue_ban(12345, "TestPlayer", 3)
 
-        self.pipeline.hmset.assert_called_once()
-        key, data = self.pipeline.hmset.call_args[0]
+        self.pipeline.hset.assert_called_once()
+        call_kwargs = self.pipeline.hset.call_args
+        key = call_kwargs[0][0]
+        data = call_kwargs[1]["mapping"]
         self.assertEqual(key, "minqlx:players:12345:bans:0")
         self.assertIn("expires", data)
         self.assertIn("reason", data)
@@ -228,6 +230,12 @@ class TestPlayerLoadedWarning(unittest.TestCase):
         self.assertIn("2", text)
         self.assertIn("15", text)
         self.assertIn("60", text)
+
+    def test_no_broadcast_when_remaining_zero(self):
+        self.plugin.db.zcard.return_value = 3  # count == threshold → remaining = 0
+        with patch.object(self.plugin, "msg") as mock_msg:
+            self.plugin.handle_player_loaded(self.player)
+        mock_msg.assert_not_called()
 
     def test_nonexistent_player_handled(self):
         self.player.update = MagicMock(side_effect=minqlx_mock.NonexistentPlayerError)

--- a/tests/test_kickban_plugin.py
+++ b/tests/test_kickban_plugin.py
@@ -1,0 +1,281 @@
+"""Unit tests for qlsm_plugins/kickban.py helper methods."""
+
+import os
+import sys
+import time
+import types
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+# ── Minimal minqlx mock ──────────────────────────────────────────────────────
+
+minqlx_mock = types.ModuleType("minqlx")
+minqlx_mock.RET_USAGE = "ret_usage"
+minqlx_mock.PRI_HIGH = 0
+
+
+class _FakePlugin:
+    def __init__(self):
+        self.db = MagicMock()
+        self._cvars = {
+            "qlx_kickbanThreshold": "3",
+            "qlx_kickbanWindow": "15",
+            "qlx_kickbanDuration": "60",
+            "qlx_kickbanImmunityLevel": "2",
+        }
+
+    def set_cvar_once(self, key, value):
+        pass
+
+    def add_hook(self, *args, **kwargs):
+        pass
+
+    def add_command(self, *args, **kwargs):
+        pass
+
+    def get_cvar(self, key, type_=None):
+        val = self._cvars.get(key, "")
+        if type_ is int:
+            return int(val)
+        return val
+
+    def msg(self, text):
+        pass
+
+
+minqlx_mock.Plugin = _FakePlugin
+minqlx_mock.NonexistentPlayerError = Exception
+
+
+def _noop_delay(seconds):
+    def decorator(fn):
+        return fn
+    return decorator
+
+
+minqlx_mock.delay = _noop_delay
+sys.modules["minqlx"] = minqlx_mock
+
+# ── Import plugin after mock is in place ────────────────────────────────────
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "qlsm_plugins"))
+from kickban import kickban, PLAYER_KEY, TIME_FORMAT  # noqa: E402
+
+
+class TestKickbanKeys(unittest.TestCase):
+    def setUp(self):
+        self.plugin = kickban()
+
+    def test_kicks_key(self):
+        self.assertEqual(
+            self.plugin._kicks_key(12345),
+            "minqlx:players:12345:kicks"
+        )
+
+    def test_bans_key(self):
+        self.assertEqual(
+            self.plugin._bans_key(12345),
+            "minqlx:players:12345:bans"
+        )
+
+
+class TestPruneAndCount(unittest.TestCase):
+    def setUp(self):
+        self.plugin = kickban()
+
+    def test_prune_removes_old_entries_and_returns_count(self):
+        self.plugin.db.zcard.return_value = 2
+        count = self.plugin._prune_and_count(12345)
+        window_seconds = 15 * 60
+        self.plugin.db.zremrangebyscore.assert_called_once()
+        args = self.plugin.db.zremrangebyscore.call_args[0]
+        self.assertEqual(args[0], "minqlx:players:12345:kicks")
+        self.assertEqual(args[1], 0)
+        self.assertAlmostEqual(args[2], time.time() - window_seconds, delta=2)
+        self.assertEqual(count, 2)
+
+
+class TestHandleDisconnectDetection(unittest.TestCase):
+    def setUp(self):
+        self.plugin = kickban()
+        self.player = MagicMock()
+        self.player.steam_id = 99999
+        self.player.clean_name = "TestPlayer"
+        self.plugin.db.get_permission.return_value = 0
+        self.plugin.db.zcard.return_value = 0
+
+    def test_non_kick_reason_ignored(self):
+        self.plugin.handle_player_disconnect(self.player, "disconnected")
+        self.plugin.db.zadd.assert_not_called()
+
+    def test_kick_reason_records_entry(self):
+        self.plugin.db.zcard.return_value = 1
+        self.plugin.handle_player_disconnect(self.player, "was kicked")
+        self.plugin.db.zadd.assert_called_once()
+        key, mapping = self.plugin.db.zadd.call_args[0]
+        self.assertEqual(key, "minqlx:players:99999:kicks")
+        self.assertEqual(len(mapping), 1)
+        member = list(mapping.keys())[0]
+        score = list(mapping.values())[0]
+        self.assertIsInstance(member, str)
+        self.assertNotEqual(member, str(score))
+
+    def test_immune_player_ignored(self):
+        self.plugin.db.get_permission.return_value = 5
+        self.plugin.handle_player_disconnect(self.player, "was kicked")
+        self.plugin.db.zadd.assert_not_called()
+
+    def test_nonexistent_player_error_on_disconnect_returns_early(self):
+        bad_player = MagicMock()
+        type(bad_player).steam_id = PropertyMock(side_effect=minqlx_mock.NonexistentPlayerError)
+        self.plugin.handle_player_disconnect(bad_player, "was kicked")
+        self.plugin.db.zadd.assert_not_called()
+
+    def test_vote_kick_reason_records_entry(self):
+        self.plugin.db.zcard.return_value = 1
+        self.plugin.handle_player_disconnect(self.player, "kicked by vote")
+        self.plugin.db.zadd.assert_called_once()
+
+
+class TestIssueBan(unittest.TestCase):
+    def setUp(self):
+        self.plugin = kickban()
+        self.plugin.db.zcard.return_value = 0
+        self.pipeline = MagicMock()
+        self.plugin.db.pipeline.return_value = self.pipeline
+
+    def test_ban_written_to_redis(self):
+        with patch.object(self.plugin, "msg"):
+            self.plugin._issue_ban(12345, "TestPlayer", 3)
+
+        self.plugin.db.pipeline.assert_called_once()
+        self.pipeline.zadd.assert_called_once()
+        bans_key, mapping = self.pipeline.zadd.call_args[0]
+        self.assertEqual(bans_key, "minqlx:players:12345:bans")
+        score = list(mapping.values())[0]
+        self.assertAlmostEqual(score, time.time() + 60 * 60, delta=5)
+
+    def test_ban_hash_has_correct_fields(self):
+        with patch.object(self.plugin, "msg"):
+            self.plugin._issue_ban(12345, "TestPlayer", 3)
+
+        self.pipeline.hmset.assert_called_once()
+        key, data = self.pipeline.hmset.call_args[0]
+        self.assertEqual(key, "minqlx:players:12345:bans:0")
+        self.assertIn("expires", data)
+        self.assertIn("reason", data)
+        self.assertIn("issued", data)
+        self.assertEqual(data["issued_by"], "0")
+        self.assertIn("3", data["reason"])
+        self.assertIn("15", data["reason"])
+
+    def test_kick_history_cleared_after_ban(self):
+        with patch.object(self.plugin, "msg"):
+            self.plugin._issue_ban(12345, "TestPlayer", 3)
+        self.plugin.db.delete.assert_called_with("minqlx:players:12345:kicks")
+
+    def test_server_broadcast_sent(self):
+        with patch.object(self.plugin, "msg") as mock_msg:
+            self.plugin._issue_ban(12345, "TestPlayer", 3)
+        mock_msg.assert_called_once()
+        broadcast = mock_msg.call_args[0][0]
+        self.assertIn("TestPlayer", broadcast)
+        self.assertIn("60", broadcast)
+
+    def test_ban_triggered_at_threshold(self):
+        self.plugin.db.get_permission.return_value = 0
+        self.plugin.db.zcard.return_value = 2
+
+        with patch.object(self.plugin, "_issue_ban") as mock_ban:
+            player = MagicMock()
+            player.steam_id = 12345
+            player.clean_name = "TestPlayer"
+            self.plugin.handle_player_disconnect(player, "was kicked")
+            mock_ban.assert_called_once_with(12345, "TestPlayer", 3)
+
+    def test_ban_not_triggered_below_threshold(self):
+        self.plugin.db.get_permission.return_value = 0
+        self.plugin.db.zcard.return_value = 1
+
+        with patch.object(self.plugin, "_issue_ban") as mock_ban:
+            player = MagicMock()
+            player.steam_id = 12345
+            self.plugin.handle_player_disconnect(player, "was kicked")
+            mock_ban.assert_not_called()
+
+
+class TestPlayerLoadedWarning(unittest.TestCase):
+    def setUp(self):
+        self.plugin = kickban()
+        self.player = MagicMock()
+        self.player.steam_id = 12345
+        self.player.clean_name = "TestPlayer"
+
+    def test_no_broadcast_when_no_kicks(self):
+        self.plugin.db.zcard.return_value = 0
+        with patch.object(self.plugin, "msg") as mock_msg:
+            self.plugin.handle_player_loaded(self.player)
+        mock_msg.assert_not_called()
+
+    def test_broadcast_when_kicks_exist(self):
+        self.plugin.db.zcard.return_value = 1
+        with patch.object(self.plugin, "msg") as mock_msg:
+            self.plugin.handle_player_loaded(self.player)
+        mock_msg.assert_called_once()
+        text = mock_msg.call_args[0][0]
+        self.assertIn("TestPlayer", text)
+        self.assertIn("1", text)
+        self.assertIn("2", text)
+        self.assertIn("15", text)
+        self.assertIn("60", text)
+
+    def test_nonexistent_player_handled(self):
+        self.player.update = MagicMock(side_effect=minqlx_mock.NonexistentPlayerError)
+        self.plugin.handle_player_loaded(self.player)
+
+
+class TestAdminCommands(unittest.TestCase):
+    def setUp(self):
+        self.plugin = kickban()
+        self.admin = MagicMock()
+        self.admin.steam_id = 1
+        self.channel = MagicMock()
+
+        self.target = MagicMock()
+        self.target.steam_id = 99999
+        self.target.clean_name = "Target"
+        self.plugin.player = MagicMock(return_value=self.target)
+
+    def test_kickhistory_usage_when_no_arg(self):
+        result = self.plugin.cmd_kickhistory(self.admin, ["!kickhistory"], self.channel)
+        self.assertEqual(result, minqlx_mock.RET_USAGE)
+
+    def test_kickhistory_no_kicks(self):
+        self.plugin.db.zcard.return_value = 0
+        self.plugin.cmd_kickhistory(self.admin, ["!kickhistory", "5"], self.channel)
+        self.channel.reply.assert_called_once()
+        self.assertIn("no kicks", self.channel.reply.call_args[0][0].lower())
+
+    def test_kickhistory_with_kicks(self):
+        self.plugin.db.zcard.return_value = 2
+        ts = time.time()
+        self.plugin.db.zrangebyscore.return_value = [("ts1", ts), ("ts2", ts + 1)]
+        self.plugin.cmd_kickhistory(self.admin, ["!kickhistory", "5"], self.channel)
+        self.channel.reply.assert_called_once()
+        reply = self.channel.reply.call_args[0][0]
+        self.assertIn("Target", reply)
+        self.assertIn("2", reply)
+
+    def test_kickclear_usage_when_no_arg(self):
+        result = self.plugin.cmd_kickclear(self.admin, ["!kickclear"], self.channel)
+        self.assertEqual(result, minqlx_mock.RET_USAGE)
+
+    def test_kickclear_deletes_key(self):
+        self.plugin.cmd_kickclear(self.admin, ["!kickclear", "5"], self.channel)
+        self.plugin.db.delete.assert_called_with("minqlx:players:99999:kicks")
+        self.channel.reply.assert_called_once()
+        self.assertIn("Target", self.channel.reply.call_args[0][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `qlsm_plugins/kickban.py`: a minqlx plugin that auto-bans players kicked N times within a configurable sliding time window
- Writes bans to `ban.py`'s existing Redis key format (`minqlx:players:{steam_id}:bans`) — `!checkban` and `!unban` work with no changes to `ban.py`
- Un-ignores `qlsm_plugins/*.py` in `.gitignore` so first-party plugins can be tracked

**CVARs:** `qlx_kickbanThreshold` (default 3, min 2), `qlx_kickbanWindow` (default 15 min), `qlx_kickbanDuration` (default 60 min), `qlx_kickbanImmunityLevel` (default 2)

**Hooks:** `player_disconnect` detects kicks via reason string, records to Redis sorted set with UUID members (no timestamp collision), prunes old entries, issues ban at threshold. `player_loaded` broadcasts a reconnect warning showing kick count and remaining kicks before ban.

**Commands:** `!kickhistory <id>`, `!kickclear <id>` (both require perm 2)

**Pre-implementation review loop:** ran before implementation — findings 2 (NonexistentPlayerError guard), 7 (absolute sys.path in tests), 8 (UUID member for zadd), and 11 (min-2 threshold clamp) were folded into the spec and plan before coding started.

## Test plan

- [ ] 22 unit tests, all passing (`pytest tests/test_kickban_plugin.py -v`)
- [ ] Kick detection: admin kick and vote kick both trigger counter increment
- [ ] Threshold ban: third kick within window issues auto-ban, player blocked on reconnect
- [ ] `!checkban <steamid>` shows auto-ban with correct reason/expiry
- [ ] Reconnect warning broadcast shows count and remaining kicks
- [ ] Immunity: players with perm ≥ 2 are not counted or banned
- [ ] `!kickhistory` / `!kickclear` work correctly
- [ ] `!unban` removes auto-ban and player can reconnect