### PR TITLE
feat: add qlsm-uninstall.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !.dockerignore
 !setup-worktree.sh
 !qlsm-install.sh
+!qlsm-uninstall.sh
 !vultr-startup.sh
 !.github/
 !.github/**

--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ sudo bash -c '(crontab -l 2>/dev/null | grep -v "qlsm-install.sh"; echo "0 9 * *
 
 ---
 
+## Uninstall
+
+Stop containers and clean up SSH config (data is preserved):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-uninstall.sh | bash
+```
+
+Remove everything including Docker volumes and the install directory:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-uninstall.sh | bash -s -- --purge
+```
+
+Non-interactive (no prompts):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-uninstall.sh | bash -s -- --purge --yes
+```
+
+---
+
 Full installation guide: [docs/user/getting-started/installation.md](https://dngrtech.github.io/qlsm/getting-started/installation/)
 
 ## Development

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -75,6 +75,20 @@ curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-install.sh 
 
 Downloads the latest `docker-compose.yml`, pulls the new image, and restarts. Your `.env` and data are untouched.
 
+## Uninstall
+
+Stop containers and clean up SSH config (data is preserved):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-uninstall.sh | bash
+```
+
+Remove everything including Docker volumes and the install directory:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-uninstall.sh | bash -s -- --purge --yes
+```
+
 ## Services
 
 The Docker Compose stack runs the following containers:

--- a/docs/user/getting-started/installation.md
+++ b/docs/user/getting-started/installation.md
@@ -151,6 +151,34 @@ GRAFANA_PASSWORD=yourpassword docker compose --profile logging up -d
 Grafana listens on **port 3000** of the server. Because this port is typically not exposed to the internet, access it through a secure tunnel (VSCode port forwardingm Tailscale VPN, etc.) rather than opening it in a firewall.
 
 
+## Uninstall
+
+The uninstall script reverses what the install script did.
+
+**Default** — stops containers, removes the QLSM sshd config, and deletes `~/.qlsm-ssh/`. Your data (`~/qlsm/`) is preserved:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-uninstall.sh | bash
+```
+
+**`--purge`** — also removes named Docker volumes (Redis data, Caddy TLS certificates, Loki/Grafana data) and the install directory. Each destructive step prompts for confirmation:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-uninstall.sh | bash -s -- --purge
+```
+
+**Non-interactive** — skip all confirmation prompts (useful in scripts):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-uninstall.sh | bash -s -- --purge --yes
+```
+
+Custom install directory:
+
+```bash
+INSTALL_DIR=/opt/qlsm bash <(curl -fsSL https://raw.githubusercontent.com/dngrtech/qlsm/main/qlsm-uninstall.sh) --purge
+```
+
 ## Next Steps
 
 - [Add A Host (Cloud Or Standalone)](add-host.md)

--- a/qlsm-uninstall.sh
+++ b/qlsm-uninstall.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# QLSM — uninstaller
+#
+# Run from the QLSM install directory, or set INSTALL_DIR:
+#   bash qlsm-uninstall.sh
+#
+# Flags:
+#   --purge    Also remove named Docker volumes (Redis data, Caddy certs, etc.)
+#              and the install directory. Irreversible — data is lost.
+#   --yes, -y  Skip confirmation prompts (for automated/scripted use).
+#
+# Environment variables:
+#   INSTALL_DIR   Path to the QLSM install directory (default: ~/qlsm)
+#   NO_COLOR      Set to any value to disable colour output
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+# ── Flags ─────────────────────────────────────────────────────────────────────
+PURGE=0
+YES=0
+for arg in "$@"; do
+    case "$arg" in
+        --purge)    PURGE=1 ;;
+        --yes|-y)   YES=1 ;;
+        --help|-h)
+            sed -n '2,/^set/p' "$0" | grep '^#' | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; CYAN=''; BOLD=''; RESET=''
+fi
+info()    { echo -e "${CYAN}==>${RESET} ${BOLD}$*${RESET}"; }
+success() { echo -e "${GREEN}✓${RESET}  $*"; }
+warn()    { echo -e "${YELLOW}!${RESET}  $*"; }
+die()     { echo -e "${RED}✗${RESET}  $*" >&2; exit 1; }
+
+confirm() {
+    local prompt="$1"
+    if [[ $YES -eq 1 ]]; then return 0; fi
+    echo -e "${YELLOW}?${RESET}  ${BOLD}${prompt}${RESET} [y/N] " >&2
+    read -r ans </dev/tty
+    [[ "$ans" =~ ^[Yy]$ ]]
+}
+
+# ── Config ────────────────────────────────────────────────────────────────────
+INSTALL_DIR="${INSTALL_DIR:-$HOME/qlsm}"
+
+echo ""
+echo -e "${BOLD}  QLSM — Quake Live Server Manager — Uninstaller${RESET}"
+echo "  https://github.com/dngrtech/qlsm"
+echo ""
+
+if [[ ! -d "$INSTALL_DIR" ]]; then
+    die "Install directory not found: ${INSTALL_DIR}
+  Set INSTALL_DIR if you installed to a non-default location."
+fi
+
+# ── Detect compose command ────────────────────────────────────────────────────
+if docker compose version &>/dev/null 2>&1; then
+    COMPOSE="docker compose"
+elif command -v docker-compose &>/dev/null; then
+    COMPOSE="docker-compose"
+else
+    warn "Docker Compose not found — skipping container teardown."
+    COMPOSE=""
+fi
+
+# ── 1. Stop and remove containers ─────────────────────────────────────────────
+if [[ -n "$COMPOSE" ]]; then
+    if [[ -f "${INSTALL_DIR}/docker-compose.yml" ]]; then
+        info "Stopping QLSM containers..."
+        (cd "${INSTALL_DIR}" && ${COMPOSE} down --remove-orphans) \
+            && success "Containers stopped and removed" \
+            || warn "docker compose down reported an error (containers may already be stopped)"
+    else
+        warn "No docker-compose.yml found in ${INSTALL_DIR} — skipping container teardown."
+    fi
+fi
+
+# ── 2. Remove named Docker volumes (--purge only) ─────────────────────────────
+if [[ $PURGE -eq 1 ]]; then
+    if [[ -n "$COMPOSE" ]] && [[ -f "${INSTALL_DIR}/docker-compose.yml" ]]; then
+        echo ""
+        warn "This will permanently delete all QLSM Docker volumes:"
+        warn "  Redis data, Caddy TLS certificates and config, Loki/Grafana data."
+        if confirm "Remove Docker volumes?"; then
+            (cd "${INSTALL_DIR}" && ${COMPOSE} down --volumes) \
+                && success "Docker volumes removed" \
+                || warn "Volume removal reported an error (may already be gone)"
+        else
+            info "Skipping volume removal."
+        fi
+    fi
+fi
+
+# ── 3. Remove sshd config added by host-init ──────────────────────────────────
+SSHD_CONF="/etc/ssh/sshd_config.d/qlsm.conf"
+if [[ -f "$SSHD_CONF" ]]; then
+    info "Removing QLSM sshd config (${SSHD_CONF})..."
+    if sudo rm -f "$SSHD_CONF"; then
+        # Reload sshd — try both service names (Ubuntu: ssh, others: sshd)
+        sudo systemctl reload ssh 2>/dev/null \
+            || sudo systemctl reload sshd 2>/dev/null \
+            || warn "Could not reload sshd — reload manually if needed."
+        success "sshd config removed and sshd reloaded"
+    else
+        warn "Could not remove ${SSHD_CONF} — remove it manually with sudo."
+    fi
+else
+    info "No QLSM sshd config found at ${SSHD_CONF} — skipping."
+fi
+
+# ── 4. Remove ~/.qlsm-ssh ─────────────────────────────────────────────────────
+QLSM_SSH_DIR="${HOME}/.qlsm-ssh"
+if [[ -d "$QLSM_SSH_DIR" ]]; then
+    info "Removing ${QLSM_SSH_DIR}..."
+    rm -rf "$QLSM_SSH_DIR"
+    success "${QLSM_SSH_DIR} removed"
+else
+    info "${QLSM_SSH_DIR} not found — skipping."
+fi
+
+# ── 5. Remove install directory (--purge only) ────────────────────────────────
+if [[ $PURGE -eq 1 ]]; then
+    echo ""
+    warn "This will permanently delete ${INSTALL_DIR} and ALL of its contents:"
+    warn "  Database, server configs, Terraform state, Ansible inventory, logs, SSH keys."
+    warn "  This CANNOT be undone."
+    if confirm "Delete ${INSTALL_DIR}?"; then
+        rm -rf "${INSTALL_DIR}"
+        success "${INSTALL_DIR} deleted"
+    else
+        info "Skipping install directory removal."
+        info "You can delete it manually: rm -rf ${INSTALL_DIR}"
+    fi
+else
+    echo ""
+    warn "Install directory preserved: ${INSTALL_DIR}"
+    warn "  It contains your database, configs, SSH keys, and Terraform state."
+    warn "  To delete everything, re-run with: bash qlsm-uninstall.sh --purge"
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}  Uninstall complete.${RESET}"
+echo ""
+if [[ $PURGE -eq 0 ]]; then
+    echo "  Your data is still at: ${INSTALL_DIR}"
+    echo ""
+fi

--- a/qlsm-uninstall.sh
+++ b/qlsm-uninstall.sh
@@ -77,31 +77,29 @@ else
     COMPOSE=""
 fi
 
-# ── 1. Stop and remove containers ─────────────────────────────────────────────
+# ── 1. Stop containers (+ named volumes if --purge confirmed) ─────────────────
 if [[ -n "$COMPOSE" ]]; then
     if [[ -f "${INSTALL_DIR}/docker-compose.yml" ]]; then
+        DOWN_FLAGS="--remove-orphans"
+        if [[ $PURGE -eq 1 ]]; then
+            echo ""
+            warn "This will permanently delete all QLSM Docker volumes:"
+            warn "  Redis data, Caddy TLS certificates and config, Loki/Grafana data."
+            if confirm "Remove Docker volumes?"; then
+                DOWN_FLAGS="--remove-orphans --volumes"
+            else
+                info "Skipping volume removal."
+            fi
+        fi
         info "Stopping QLSM containers..."
-        (cd "${INSTALL_DIR}" && ${COMPOSE} down --remove-orphans) \
-            && success "Containers stopped and removed" \
+        DOWN_MSG="Containers stopped and removed"
+        [[ "$DOWN_FLAGS" == *"--volumes"* ]] && DOWN_MSG="Containers and volumes removed"
+        # shellcheck disable=SC2086
+        (cd "${INSTALL_DIR}" && ${COMPOSE} down ${DOWN_FLAGS}) \
+            && success "$DOWN_MSG" \
             || warn "docker compose down reported an error (containers may already be stopped)"
     else
         warn "No docker-compose.yml found in ${INSTALL_DIR} — skipping container teardown."
-    fi
-fi
-
-# ── 2. Remove named Docker volumes (--purge only) ─────────────────────────────
-if [[ $PURGE -eq 1 ]]; then
-    if [[ -n "$COMPOSE" ]] && [[ -f "${INSTALL_DIR}/docker-compose.yml" ]]; then
-        echo ""
-        warn "This will permanently delete all QLSM Docker volumes:"
-        warn "  Redis data, Caddy TLS certificates and config, Loki/Grafana data."
-        if confirm "Remove Docker volumes?"; then
-            (cd "${INSTALL_DIR}" && ${COMPOSE} down --volumes) \
-                && success "Docker volumes removed" \
-                || warn "Volume removal reported an error (may already be gone)"
-        else
-            info "Skipping volume removal."
-        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary

- Adds `qlsm-uninstall.sh` — a companion to `qlsm-install.sh` that cleanly tears down a QLSM installation
- Also adds `!qlsm-uninstall.sh` to `.gitignore` allowlist so the script is tracked

## Behaviour

**Default (no flags):** stops and removes containers/networks (`docker compose down`), removes `/etc/ssh/sshd_config.d/qlsm.conf` + reloads sshd, removes `~/.qlsm-ssh/`. Install directory is preserved so data isn't lost accidentally.

**`--purge`:** additionally prompts to remove named Docker volumes (Redis data, Caddy certs/config, Loki/Grafana data) and then the entire install directory. Each destructive step has a separate confirmation.

**`--yes` / `-y`:** skips all confirmation prompts for scripted/automated use.

Supports `INSTALL_DIR` and `NO_COLOR` env vars (matching the installer). Detects both `docker compose` and `docker-compose`. Style and colour output match `qlsm-install.sh`.

## Test plan

- [ ] Run without flags on a live install — verify containers stop, sshd config is removed, `~/.qlsm-ssh` is gone, install dir still present
- [ ] Run with `--purge --yes` — verify volumes and install dir are fully removed
- [ ] Run `--help` — verify usage text prints correctly
- [ ] Run against a non-existent `INSTALL_DIR` — verify it exits with a clear error