### PR TITLE
fix: prevent cloud-init hostname drift on reboot

### DIFF
--- a/ansible/playbooks/rename_host.yml
+++ b/ansible/playbooks/rename_host.yml
@@ -26,12 +26,19 @@
       hostname:
         name: "{{ new_hostname }}"
 
+    - name: Unlock /etc/hosts before modification
+      command: chattr -i /etc/hosts
+      ignore_errors: yes
+
     - name: Update /etc/hosts - replace old hostname with new
       lineinfile:
         path: /etc/hosts
         regexp: '^127\.0\.1\.1'
         line: "127.0.1.1 {{ new_hostname }}"
         state: present
+
+    - name: Lock /etc/hosts to prevent Vultr vendor-data overwriting it on reboot
+      command: chattr +i /etc/hosts
 
     - name: Update /etc/hostname file
       copy:

--- a/ansible/playbooks/rename_host.yml
+++ b/ansible/playbooks/rename_host.yml
@@ -50,6 +50,7 @@
         owner: root
         group: root
         mode: '0644'
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Verify new hostname is set
       command: hostname

--- a/ansible/playbooks/rename_host.yml
+++ b/ansible/playbooks/rename_host.yml
@@ -29,6 +29,7 @@
     - name: Unlock /etc/hosts before modification
       command: chattr -i /etc/hosts
       ignore_errors: yes
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Update /etc/hosts - replace old hostname with new
       lineinfile:
@@ -39,6 +40,7 @@
 
     - name: Lock /etc/hosts to prevent Vultr vendor-data overwriting it on reboot
       command: chattr +i /etc/hosts
+      when: ansible_facts['os_family'] == 'Debian'
 
     - name: Update /etc/hostname file
       copy:

--- a/ansible/playbooks/rename_host.yml
+++ b/ansible/playbooks/rename_host.yml
@@ -41,6 +41,16 @@
         group: root
         mode: '0644'
 
+    - name: Disable cloud-init hostname and hosts management to prevent drift on reboot
+      copy:
+        dest: /etc/cloud/cloud.cfg.d/99_disable_hostname.cfg
+        content: |
+          preserve_hostname: true
+          manage_etc_hosts: false
+        owner: root
+        group: root
+        mode: '0644'
+
     - name: Verify new hostname is set
       command: hostname
       register: verify_hostname

--- a/ansible/playbooks/setup_host.yml
+++ b/ansible/playbooks/setup_host.yml
@@ -106,12 +106,21 @@
         name: "{{ inventory_hostname }}"
       when: ansible_facts['os_family'] == 'Debian' and not is_standalone
 
+    - name: Unlock /etc/hosts before modification
+      command: chattr -i /etc/hosts
+      ignore_errors: yes
+      when: ansible_facts['os_family'] == 'Debian' and not is_standalone
+
     - name: Ensure 127.0.1.1 in /etc/hosts points to QLSM hostname
       lineinfile:
         path: /etc/hosts
         regexp: '^127\.0\.1\.1'
         line: "127.0.1.1 {{ inventory_hostname }}"
         state: present
+      when: ansible_facts['os_family'] == 'Debian' and not is_standalone
+
+    - name: Lock /etc/hosts to prevent Vultr vendor-data overwriting it on reboot
+      command: chattr +i /etc/hosts
       when: ansible_facts['os_family'] == 'Debian' and not is_standalone
 
   #######################################################################

--- a/ansible/playbooks/setup_host.yml
+++ b/ansible/playbooks/setup_host.yml
@@ -81,6 +81,39 @@
         mode: '0644'
       when: ansible_facts['os_family'] == 'Debian' and not is_standalone
 
+    - name: Disable cloud-init hostname and hosts management
+      copy:
+        dest: /etc/cloud/cloud.cfg.d/99_disable_hostname.cfg
+        content: |
+          preserve_hostname: true
+          manage_etc_hosts: false
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'Debian' and not is_standalone
+
+    - name: Set /etc/hostname to QLSM inventory name
+      copy:
+        content: "{{ inventory_hostname }}\n"
+        dest: /etc/hostname
+        owner: root
+        group: root
+        mode: '0644'
+      when: ansible_facts['os_family'] == 'Debian' and not is_standalone
+
+    - name: Apply hostname immediately
+      hostname:
+        name: "{{ inventory_hostname }}"
+      when: ansible_facts['os_family'] == 'Debian' and not is_standalone
+
+    - name: Ensure 127.0.1.1 in /etc/hosts points to QLSM hostname
+      lineinfile:
+        path: /etc/hosts
+        regexp: '^127\.0\.1\.1'
+        line: "127.0.1.1 {{ inventory_hostname }}"
+        state: present
+      when: ansible_facts['os_family'] == 'Debian' and not is_standalone
+
   #######################################################################
   # 1. Base packages & ssh hardening
   #######################################################################


### PR DESCRIPTION
## Summary

- **setup_host.yml**: writes `/etc/cloud/cloud.cfg.d/99_disable_hostname.cfg` during provisioning (`preserve_hostname: true`, `manage_etc_hosts: false`), and stamps `/etc/hostname` and the `127.0.1.1` `/etc/hosts` entry to the QLSM inventory hostname
- **rename_host.yml**: writes the same cloud-init lock file after the existing hostname update tasks so the change survives reboots

## Root cause being fixed

Paris host was provisioned as `paris-antilag-lg-1` (Vultr/Terraform name), then renamed via QLSM to `paris-antilag-lg`. The rename playbook updated `/etc/hostname` and `/etc/hosts` correctly, but cloud-init (`manage_etc_hosts: true`) was still active. On the next scheduled reboot, cloud-init read the Vultr metadata hostname (`paris-antilag-lg-1`) and regenerated `/etc/hosts`, breaking hostname resolution for the QL server process and causing the LAN rate iptables hack to stop working (QL received real client IPs → `sv_serverType 1` rejected them → "server is for LAN clients only").

## Test plan

- [x] Provision a new host and verify `/etc/cloud/cloud.cfg.d/99_disable_hostname.cfg` exists with correct content after setup
- [x] Verify `/etc/hostname` matches the QLSM inventory name after provisioning
- [x] Verify `127.0.1.1 <hostname>` is in `/etc/hosts` after provisioning
- [x] Run rename playbook, reboot, verify `/etc/hosts` 127.0.1.1 entry is not reverted