### PR TITLE
Unmanage qlx_serverBrandName

### DIFF
--- a/docs/user/operations/edit-configs.md
+++ b/docs/user/operations/edit-configs.md
@@ -53,7 +53,6 @@ These cvars are ignored by QLSM regardless of whether they are present in `serve
 | `sv_serverType` | Controlled by the 99k LAN rate toggle. | Ignored. QLSM injects `1` when 99k LAN rate is enabled, otherwise `2`. |
 | `sv_lanForceRate` | Controlled by the 99k LAN rate toggle. | Ignored. QLSM injects `1` when 99k LAN rate is enabled, otherwise `0`. |
 | `net_strict` | Forced by QLSM. | Ignored. QLSM always injects `1`. |
-| `qlx_serverBrandName` | Derived from the instance hostname. | Ignored. QLSM overwrites it to match `sv_hostname`. |
 | `qlx_redisAddress` | Forced by QLSM. | Ignored. QLSM injects the local Redis address. |
 | `qlx_redisPassword` | Forced by QLSM. | Ignored. QLSM injects the backend Redis password. |
 | `qlx_redisDatabase` | Derived from the instance port. | Ignored. QLSM injects `port - 27959`. |
@@ -79,7 +78,6 @@ QLSM assembles all managed cvars into a single argument string that is passed to
   +set net_strict 1
   +set net_port $port
   +set sv_hostname "$hostname"
-  +set qlx_serverBrandName "$hostname"
   +set qlx_redisAddress "127.0.0.1:6379"
   +set qlx_redisPassword "$redis_password"
   +set qlx_redisDatabase $redis_db_index

--- a/frontend-react/src/codemirror-lang-qlcfg.js
+++ b/frontend-react/src/codemirror-lang-qlcfg.js
@@ -58,7 +58,6 @@ const MANAGED_CVARS = {
   sv_lanforcerate: 'Managed by the 99k LAN rate toggle. Default: 0 (99k LAN rate OFF).',
   net_ip: 'Forced to "" by the app (binds all interfaces, required for 99k LAN rate).',
   net_strict: 'Forced to 1 by the app.',
-  qlx_serverbrandname: 'Derived from the sv_hostname value.',
   qlx_redisdatabase: 'Managed by the app.',
   fs_homepath: 'Managed by the app.',
   qlx_pluginspath: 'Managed by the app.',

--- a/frontend-react/src/codemirror-lang-qlcfg.test.js
+++ b/frontend-react/src/codemirror-lang-qlcfg.test.js
@@ -1,0 +1,47 @@
+import { EditorState } from '@codemirror/state';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createQlCfgLinter, stripManagedCvars } from './codemirror-lang-qlcfg';
+
+function lint(doc) {
+  const onLintResults = vi.fn();
+  const diagnostics = createQlCfgLinter([], onLintResults)({
+    state: EditorState.create({ doc }),
+  });
+
+  return { diagnostics, onLintResults };
+}
+
+describe('createQlCfgLinter', () => {
+  it('does not report qlx_serverBrandName as managed', () => {
+    const { diagnostics, onLintResults } = lint('set qlx_serverBrandName "Custom Brand"');
+
+    expect(diagnostics).toEqual([]);
+    expect(onLintResults).toHaveBeenCalledWith(false);
+  });
+
+  it('still reports managed cvars as ignored', () => {
+    const { diagnostics } = lint('set net_ip "192.0.2.1"');
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        severity: 'info',
+        message: 'This cvar will be ignored. Forced to "" by the app (binds all interfaces, required for 99k LAN rate).',
+      }),
+    ]);
+  });
+});
+
+describe('stripManagedCvars', () => {
+  it('preserves qlx_serverBrandName values', () => {
+    const cfg = [
+      'set qlx_serverBrandName "Custom Brand"',
+      'set net_ip "192.0.2.1"',
+    ].join('\n');
+
+    expect(stripManagedCvars(cfg)).toBe([
+      'set qlx_serverBrandName "Custom Brand"',
+      'set net_ip ""',
+    ].join('\n'));
+  });
+});

--- a/tests/test_task_deploy_instance.py
+++ b/tests/test_task_deploy_instance.py
@@ -275,6 +275,16 @@ def test_build_qlds_args_serverchecker_not_duplicated(test_app):
         assert '+set qlx_plugins "serverchecker, balance"' in result
 
 
+def test_build_qlds_args_does_not_inject_server_brand_name(test_app):
+    """qlx_serverBrandName is configured by server.cfg when branding.py is used."""
+    with test_app.app_context():
+        inst = _make_instance_for_args(hostname='Test Server')
+
+        result = _build_qlds_args_string(inst)
+
+        assert 'qlx_serverBrandName' not in result
+
+
 def test_build_qlds_args_self_host_includes_shared_redis_runtime(test_app, monkeypatch):
     with test_app.app_context():
         monkeypatch.setenv("REDIS_PASSWORD", "shared-secret")

--- a/ui/task_logic/ansible_instance_mgmt.py
+++ b/ui/task_logic/ansible_instance_mgmt.py
@@ -91,7 +91,6 @@ def _build_qlds_args_string(instance):
         '+set net_strict 1',
         f'+set net_port {instance.port}',
         f'+set sv_hostname "{instance.hostname}"',
-        f'+set qlx_serverBrandName "{instance.hostname}"',
     ]
     parts += _self_host_redis_args(instance)
     parts += [


### PR DESCRIPTION
## Summary
- stop injecting `qlx_serverBrandName` into generated QLDS launch args
- remove `qlx_serverBrandName` from CodeMirror managed-cvar diagnostics and value stripping
- update the managed server.cfg cvar documentation by removing the managed brand-name entry and command-line example line

## Validation
- `SECRET_KEY=test FLASK_ENV=testing PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider tests/test_task_deploy_instance.py -v`
- `pnpm exec vitest run src/codemirror-lang-qlcfg.test.js`
- `pnpm exec eslint src/codemirror-lang-qlcfg.js src/codemirror-lang-qlcfg.test.js`

Note: whole-project `pnpm lint` still fails on existing unrelated lint errors outside the touched files.