### PR TITLE
feat: Redis Unix socket support for cloud and standalone hosts

### DIFF
--- a/ansible/playbooks/setup_host.yml
+++ b/ansible/playbooks/setup_host.yml
@@ -478,6 +478,34 @@
         executable: pip3
         extra_args: "{{ '--break-system-packages' if (pip3_version_output.stdout.split()[1] is version('22.1', '>=')) else '' }}"
 
+  #######################################################################
+  # 6a. Configure Redis Unix Socket
+  #######################################################################
+    - name: Configure Redis Unix socket path
+      lineinfile:
+        path: /etc/redis/redis.conf
+        regexp: '^#?\s*unixsocket\s'
+        line: 'unixsocket /var/run/redis/redis.sock'
+        state: present
+      when: use_host_redis | bool
+      notify: restart redis
+
+    - name: Configure Redis Unix socket permissions
+      lineinfile:
+        path: /etc/redis/redis.conf
+        regexp: '^#?\s*unixsocketperm\s'
+        line: 'unixsocketperm 770'
+        state: present
+      when: use_host_redis | bool
+      notify: restart redis
+
+    - name: Add ql user to redis group for socket access
+      user:
+        name: ql
+        groups: redis
+        append: true
+      when: use_host_redis | bool
+
     # Optional: Check for a common requirements file for plugins
     # - name: Check if common requirements.txt exists
     #   stat:
@@ -555,6 +583,10 @@
         - "{{ qlds_base_dir }}/steamapps" # Specifically ensure steamapps ownership
 
   handlers:
+    - name: restart redis
+      service:
+        name: redis-server
+        state: restarted
     - name: restart networking
       service: { name: networking, state: restarted }
       when: not is_standalone

--- a/docs/user/operations/edit-configs.md
+++ b/docs/user/operations/edit-configs.md
@@ -53,8 +53,9 @@ These cvars are ignored by QLSM regardless of whether they are present in `serve
 | `sv_serverType` | Controlled by the 99k LAN rate toggle. | Ignored. QLSM injects `1` when 99k LAN rate is enabled, otherwise `2`. |
 | `sv_lanForceRate` | Controlled by the 99k LAN rate toggle. | Ignored. QLSM injects `1` when 99k LAN rate is enabled, otherwise `0`. |
 | `net_strict` | Forced by QLSM. | Ignored. QLSM always injects `1`. |
-| `qlx_redisAddress` | Forced by QLSM. | Ignored. QLSM injects the local Redis address. |
-| `qlx_redisPassword` | Forced by QLSM. | Ignored. QLSM injects the backend Redis password. |
+| `qlx_redisAddress` | Forced by QLSM. | Ignored. TCP hosts: `127.0.0.1:6379`. Socket-enabled hosts: `/var/run/redis/redis.sock`. |
+| `qlx_redisUnixSocket` | Forced by QLSM. | Ignored. Set to `1` on socket-enabled hosts; omitted on TCP hosts. |
+| `qlx_redisPassword` | Forced by QLSM. | Ignored. QLSM injects the backend Redis password (self-host only). |
 | `qlx_redisDatabase` | Derived from the instance port. | Ignored. QLSM injects `port - 27959`. |
 | `fs_homepath` | Derived from the instance port. | Ignored. QLSM injects `/home/ql/qlds-<port>`. |
 | `qlx_pluginsPath` | Derived from `fs_homepath`. | Ignored. QLSM injects the instance minqlx plugin path. |
@@ -89,6 +90,14 @@ QLSM assembles all managed cvars into a single argument string that is passed to
   +set zmq_stats_port $zmq_stats_port
   +set zmq_stats_password "$zmq_stats_password"
   +set qlx_plugins "names of plugins from the Plugins tab selection"
+```
+
+**Socket-enabled host — Redis-specific args only** (cloud or standalone after Re-run Host Setup). All other managed cvars are the same as the example above; only the Redis lines differ:
+
+```
++set qlx_redisAddress "/var/run/redis/redis.sock"
++set qlx_redisUnixSocket 1
++set qlx_redisDatabase $redis_db_index
 ```
 
 ## Plugins

--- a/frontend-react/src/components/HostActionsMenu.jsx
+++ b/frontend-react/src/components/HostActionsMenu.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useState } from 'react';
 import { Menu, Transition, Portal } from '@headlessui/react';
 import { useFloating, shift, offset, autoUpdate, flip } from '@floating-ui/react-dom';
-import { Trash2, RefreshCw, ShieldCheck, ShieldOff, Loader2, Eye, PowerIcon, ArrowUpCircle } from 'lucide-react';
+import { Trash2, RefreshCw, ShieldCheck, ShieldOff, Loader2, Eye, PowerIcon, ArrowUpCircle, RotateCcw } from 'lucide-react';
 import { HostStatus, QLFILTER_STATUS } from '../utils/statusEnums';
 import ConfirmationModal from './ConfirmationModal';
 
@@ -14,10 +14,12 @@ function HostActionsMenu({
   onRequestRestart,
   onOpenUpdateWorkshop,
   onOpenAutoRestart,
-  onOpenResize
+  onOpenResize,
+  onRerunSetup
 }) {
   const [isInstallQlFilterModalOpen, setIsInstallQlFilterModalOpen] = useState(false);
   const [isUninstallQlFilterModalOpen, setIsUninstallQlFilterModalOpen] = useState(false);
+  const [isRerunSetupModalOpen, setIsRerunSetupModalOpen] = useState(false);
 
   const { x, y, refs, strategy } = useFloating({
     placement: 'bottom-end',
@@ -55,6 +57,18 @@ function HostActionsMenu({
       message="Uninstalling QLFilter will remove packet filtering from this host and reconfigure it. Any running instances will be temporarily unavailable during the process."
       confirmButtonText="Uninstall"
       confirmButtonVariant="danger"
+    />
+    <ConfirmationModal
+      isOpen={isRerunSetupModalOpen}
+      onClose={() => setIsRerunSetupModalOpen(false)}
+      onConfirm={() => {
+        if (typeof onRerunSetup === 'function') onRerunSetup(host.id);
+        setIsRerunSetupModalOpen(false);
+      }}
+      title="Re-run Host Setup"
+      message="This will re-apply host configuration. Redis will briefly restart — running instances may lose their Redis connection momentarily but will reconnect automatically."
+      confirmButtonText="Re-run Setup"
+      confirmButtonVariant="primary"
     />
     <Menu as="div" className="relative inline-block text-left ml-2">
       {({ open, close: closeMenu }) => (
@@ -158,6 +172,20 @@ function HostActionsMenu({
                       >
                         <RefreshCw size={15} className="mr-3 flex-shrink-0 text-theme-muted" />
                         Update Workshop Item
+                      </button>
+                    )}
+                  </Menu.Item>
+
+                  <Menu.Item>
+                    {({ active }) => (
+                      <button
+                        type="button"
+                        onClick={() => { closeMenu(); setIsRerunSetupModalOpen(true); }}
+                        disabled={!isHostActive || isQlFilterBusy || isHostBusy}
+                        className={`group flex rounded-md items-center w-full px-3 py-2 text-sm transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${active ? 'bg-black/[0.04] dark:bg-white/[0.06] text-theme-primary' : 'text-theme-secondary'}`}
+                      >
+                        <RotateCcw size={15} className="mr-3 flex-shrink-0 text-theme-muted" />
+                        Re-run Host Setup
                       </button>
                     )}
                   </Menu.Item>

--- a/frontend-react/src/components/hosts/HostDetailDrawer.jsx
+++ b/frontend-react/src/components/hosts/HostDetailDrawer.jsx
@@ -302,6 +302,23 @@ export default function HostDetailDrawer({
                           </span>
                         </Field>
                         <Field label="Status"><StatusIndicator status={internalHost.status} /></Field>
+                        <Field label="Redis">
+                          {internalHost.redis_unix_socket ? (
+                            <span
+                              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded text-emerald-400 bg-emerald-500/10 dark:bg-emerald-500/15"
+                              title="Low-latency local IPC via Unix socket"
+                            >
+                              Unix Socket
+                            </span>
+                          ) : (
+                            <span
+                              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded text-theme-muted bg-black/5 dark:bg-white/5"
+                              title="TCP — upgrade via Re-run Host Setup"
+                            >
+                              TCP
+                            </span>
+                          )}
+                        </Field>
                         <Field label="Created">{formatDateTime(internalHost.created_at)}</Field>
                       </div>
 

--- a/frontend-react/src/components/hosts/HostsTableRow.jsx
+++ b/frontend-react/src/components/hosts/HostsTableRow.jsx
@@ -33,7 +33,28 @@ function HostsTableRow({
         </button>
       </td>
       {/* Adjusted dark text color to slate-300 */}
-      <td className="py-2 px-2 whitespace-nowrap text-sm text-gray-700 dark:text-slate-300">{host.provider}</td>
+      <td className="py-2 px-2 whitespace-nowrap text-sm text-gray-700 dark:text-slate-300">
+        <div className="flex flex-col gap-1">
+          <span>{host.provider}</span>
+          {host.redis_unix_socket ? (
+            <span
+              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded text-emerald-400"
+              style={{ background: 'rgba(34,217,127,0.12)' }}
+              title="Redis Unix Socket — low-latency local IPC"
+            >
+              Redis: Socket
+            </span>
+          ) : (
+            <span
+              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded"
+              style={{ color: 'var(--text-muted)', background: 'rgba(128,128,128,0.10)' }}
+              title="Redis TCP — upgrade via Re-run Host Setup"
+            >
+              Redis: TCP
+            </span>
+          )}
+        </div>
+      </td>
       {/* Adjusted dark text color to slate-300 */}
       <td className="py-2 px-2 text-sm text-gray-700 dark:text-slate-300" title={formatVultrRegion(host.region)}>
         <div className="truncate max-w-[150px] lg:max-w-none">

--- a/frontend-react/src/components/hosts/HostsTableRow.jsx
+++ b/frontend-react/src/components/hosts/HostsTableRow.jsx
@@ -34,24 +34,7 @@ function HostsTableRow({
       </td>
       {/* Adjusted dark text color to slate-300 */}
       <td className="py-2 px-2 whitespace-nowrap text-sm text-gray-700 dark:text-slate-300">
-        <div className="flex flex-col gap-1">
-          <span>{host.provider}</span>
-          {host.redis_unix_socket ? (
-            <span
-              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded text-emerald-400 bg-emerald-500/10 dark:bg-emerald-500/15"
-              title="Redis Unix Socket — low-latency local IPC"
-            >
-              Redis: Socket
-            </span>
-          ) : (
-            <span
-              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded text-theme-muted bg-black/5 dark:bg-white/5"
-              title="Redis TCP — upgrade via Re-run Host Setup"
-            >
-              Redis: TCP
-            </span>
-          )}
-        </div>
+        {host.provider}
       </td>
       {/* Adjusted dark text color to slate-300 */}
       <td className="py-2 px-2 text-sm text-gray-700 dark:text-slate-300" title={formatVultrRegion(host.region)}>

--- a/frontend-react/src/components/hosts/HostsTableRow.jsx
+++ b/frontend-react/src/components/hosts/HostsTableRow.jsx
@@ -38,16 +38,14 @@ function HostsTableRow({
           <span>{host.provider}</span>
           {host.redis_unix_socket ? (
             <span
-              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded text-emerald-400"
-              style={{ background: 'rgba(34,217,127,0.12)' }}
+              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded text-emerald-400 bg-emerald-500/10 dark:bg-emerald-500/15"
               title="Redis Unix Socket — low-latency local IPC"
             >
               Redis: Socket
             </span>
           ) : (
             <span
-              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded"
-              style={{ color: 'var(--text-muted)', background: 'rgba(128,128,128,0.10)' }}
+              className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded text-theme-muted bg-black/5 dark:bg-white/5"
               title="Redis TCP — upgrade via Re-run Host Setup"
             >
               Redis: TCP

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -34,6 +34,7 @@ import SortableHostList from '../components/hosts/SortableHostList';
 import { useWorkshopUpdate } from '../hooks/useWorkshopUpdate';
 import { useHostAutoRestart } from '../hooks/useHostAutoRestart';
 import { useHostResize } from '../hooks/useHostResize';
+import { rerunHostSetup } from '../services/api';
 import ForceUpdateWorkshopModal from '../components/hosts/ForceUpdateWorkshopModal';
 import HostAutoRestartScheduleModal from '../components/hosts/HostAutoRestartScheduleModal';
 import ResizeHostModal from '../components/hosts/ResizeHostModal';
@@ -73,6 +74,16 @@ export default function ServersPage() {
     const { isAutoRestartModalOpen, hostForAutoRestart, openAutoRestartModal, closeAutoRestartModal, handleAutoRestartSubmit } = useHostAutoRestart(showSuccess, showError, () => refreshData(false));
     const { isResizeModalOpen, isResizeSubmitting, resizeError, hostForResize, openResizeModal, closeResizeModal, handleResizeSubmit } = useHostResize(showSuccess, showError, () => refreshData(false));
     const serverStatusMap = useServerStatus();
+
+    const handleRerunSetup = async (hostId) => {
+      try {
+        await rerunHostSetup(hostId);
+        showSuccess('Host re-setup queued. Redis socket will be configured.');
+        refreshData(false);
+      } catch (err) {
+        showError(err?.error?.message || 'Failed to queue re-run setup.');
+      }
+    };
 
     // RCON Console state — store ID + host_id, re-derive from live data
     const [rconKey, setRconKey] = useState(null); // { instanceId, hostId }
@@ -272,7 +283,7 @@ export default function ServersPage() {
                                     <QLFilterIndicator qlfilterStatus={host.qlfilter_status} />
                                 </div>
                                 <div className="host-actions-cell flex justify-end" onClick={(e) => e.stopPropagation()}>
-                                    <HostActionsMenu host={host} handleDelete={(id, name) => requestDeleteHost(id, name)} onOpenDrawer={handleOpenHostDrawer} onInstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'install')} onUninstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'uninstall')} onRequestRestart={handleRequestHostRestart} onOpenUpdateWorkshop={openWorkshopModal} onOpenAutoRestart={openAutoRestartModal} onOpenResize={openResizeModal} />
+                                    <HostActionsMenu host={host} handleDelete={(id, name) => requestDeleteHost(id, name)} onOpenDrawer={handleOpenHostDrawer} onInstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'install')} onUninstallQlfilter={(hostId) => handleQlfilterAction(hostId, 'uninstall')} onRequestRestart={handleRequestHostRestart} onOpenUpdateWorkshop={openWorkshopModal} onOpenAutoRestart={openAutoRestartModal} onOpenResize={openResizeModal} onRerunSetup={handleRerunSetup} />
                                 </div>
                             </div>
 

--- a/frontend-react/src/services/api.js
+++ b/frontend-react/src/services/api.js
@@ -147,6 +147,16 @@ export const resizeHost = async (hostId, newPlan) => {
   }
 };
 
+export const rerunHostSetup = async (hostId) => {
+  try {
+    const response = await apiClient.post(`/hosts/${hostId}/rerun-setup`);
+    return response.data;
+  } catch (error) {
+    console.error(`Failed to rerun setup for host ${hostId}:`, error.response ? error.response.data : error.message);
+    throw error.response ? error.response.data : new Error(`Failed to rerun setup for host ${hostId}`);
+  }
+};
+
 export const updateWorkshopItem = async (hostId, data) => {
   try {
     const response = await apiClient.post(`/hosts/${hostId}/update-workshop`, data);

--- a/migrations/versions/741ab13ff3a5_add_redis_unix_socket_to_host.py
+++ b/migrations/versions/741ab13ff3a5_add_redis_unix_socket_to_host.py
@@ -1,0 +1,26 @@
+"""add redis_unix_socket to host
+
+Revision ID: 741ab13ff3a5
+Revises: 20260502000000
+Create Date: 2026-05-21
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '741ab13ff3a5'
+down_revision = '20260502000000'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('host') as batch_op:
+        batch_op.add_column(
+            sa.Column('redis_unix_socket', sa.Boolean(), nullable=False, server_default='0')
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('host') as batch_op:
+        batch_op.drop_column('redis_unix_socket')

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -320,3 +320,16 @@ def test_delete_preset(app_context):
 
     deleted = get_preset(preset_id)
     assert deleted is None
+
+
+def test_host_has_redis_unix_socket_field(app_context):
+    host = create_host(
+        name='sock-test',
+        provider='vultr',
+        region='ewr',
+        machine_size='vhf-2c-2gb',
+        status=HostStatus.ACTIVE,
+    )
+    assert host.redis_unix_socket is False
+    assert 'redis_unix_socket' in host.to_dict()
+    assert host.to_dict()['redis_unix_socket'] is False

--- a/tests/test_host_rerun_setup_route.py
+++ b/tests/test_host_rerun_setup_route.py
@@ -1,0 +1,95 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from tests.helpers import make_user, auth_headers
+from ui.models import Host, HostStatus
+from ui import db
+from ui.database import create_host
+
+DEFAULT_USER = 'setupadmin'
+DEFAULT_PASS = 'setupadminp1'
+
+
+@pytest.fixture(autouse=True)
+def setup_user(app):
+    make_user(app, DEFAULT_USER, DEFAULT_PASS)
+
+
+@patch('ui.routes.host_routes.enqueue_task')
+@patch('ui.routes.host_routes.acquire_lock', return_value=True)
+def test_rerun_setup_cloud_host_success(mock_lock, mock_enqueue, client, app):
+    with app.app_context():
+        host = create_host(name='rerun-cloud', provider='vultr', status=HostStatus.ACTIVE)
+        host_id = host.id
+
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.post(f'/api/hosts/{host_id}/rerun-setup', headers=headers)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['data']['status'] == 'configuring'
+    mock_enqueue.assert_called_once()
+
+    with app.app_context():
+        h = db.session.get(Host, host_id)
+        assert h.status == HostStatus.CONFIGURING
+
+
+@patch('ui.routes.host_routes.enqueue_task')
+@patch('ui.routes.host_routes.acquire_lock', return_value=True)
+def test_rerun_setup_standalone_host_success(mock_lock, mock_enqueue, client, app):
+    with app.app_context():
+        host = create_host(name='rerun-sa', provider='standalone', status=HostStatus.ACTIVE,
+                           is_standalone=True)
+        host_id = host.id
+
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.post(f'/api/hosts/{host_id}/rerun-setup', headers=headers)
+
+    assert response.status_code == 200
+    mock_enqueue.assert_called_once()
+
+
+def test_rerun_setup_rejects_non_active_host(client, app):
+    with app.app_context():
+        host = create_host(name='rerun-busy', provider='vultr', status=HostStatus.CONFIGURING)
+        host_id = host.id
+
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.post(f'/api/hosts/{host_id}/rerun-setup', headers=headers)
+
+    assert response.status_code == 409
+    assert 'ACTIVE' in response.get_json()['error']['message']
+
+
+def test_rerun_setup_rejects_unauthenticated(client, app):
+    with app.app_context():
+        host = create_host(name='rerun-unauth', provider='vultr', status=HostStatus.ACTIVE)
+        host_id = host.id
+
+    response = client.post(f'/api/hosts/{host_id}/rerun-setup')
+    assert response.status_code == 401
+
+
+def test_rerun_setup_404_for_missing_host(client, app):
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.post('/api/hosts/99999/rerun-setup', headers=headers)
+    assert response.status_code == 404
+
+
+@patch('ui.routes.host_routes.release_lock')
+@patch('ui.routes.host_routes.enqueue_task', side_effect=RuntimeError('redis down'))
+@patch('ui.routes.host_routes.acquire_lock', return_value=True)
+def test_rerun_setup_reverts_status_on_enqueue_failure(mock_lock, mock_enqueue, mock_release, client, app):
+    """On enqueue failure the host must revert from CONFIGURING back to ACTIVE
+    so it isn't stuck waiting for the lock TTL."""
+    with app.app_context():
+        host = create_host(name='rerun-fail', provider='vultr', status=HostStatus.ACTIVE)
+        host_id = host.id
+
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.post(f'/api/hosts/{host_id}/rerun-setup', headers=headers)
+
+    assert response.status_code == 500
+    with app.app_context():
+        h = db.session.get(Host, host_id)
+        assert h.status == HostStatus.ACTIVE

--- a/tests/test_host_rerun_setup_route.py
+++ b/tests/test_host_rerun_setup_route.py
@@ -24,7 +24,7 @@ def test_rerun_setup_cloud_host_success(mock_lock, mock_enqueue, client, app):
     headers = auth_headers(app, DEFAULT_USER)
     response = client.post(f'/api/hosts/{host_id}/rerun-setup', headers=headers)
 
-    assert response.status_code == 200
+    assert response.status_code == 202
     data = response.get_json()
     assert data['data']['status'] == 'configuring'
     mock_enqueue.assert_called_once()
@@ -45,7 +45,7 @@ def test_rerun_setup_standalone_host_success(mock_lock, mock_enqueue, client, ap
     headers = auth_headers(app, DEFAULT_USER)
     response = client.post(f'/api/hosts/{host_id}/rerun-setup', headers=headers)
 
-    assert response.status_code == 200
+    assert response.status_code == 202
     mock_enqueue.assert_called_once()
 
 

--- a/tests/test_host_setup_sets_socket_flag.py
+++ b/tests/test_host_setup_sets_socket_flag.py
@@ -1,0 +1,95 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from ui.models import Host, HostStatus, QLFilterStatus
+
+CLOUD_MODULE = 'ui.task_logic.ansible_host_setup'
+STANDALONE_MODULE = 'ui.task_logic.standalone_host_setup'
+
+
+@patch(f'{CLOUD_MODULE}.db.session')
+@patch(f'{CLOUD_MODULE}.get_current_job')
+@patch(f'{CLOUD_MODULE}.append_log')
+@patch('ui.task_logic.ansible_runner._stream_output', return_value=('stdout ok', ''))
+@patch(f'{CLOUD_MODULE}.subprocess.Popen')
+@patch(f'{CLOUD_MODULE}.subprocess.run')
+@patch(f'{CLOUD_MODULE}.os.path.exists', return_value=True)
+def test_cloud_setup_sets_redis_unix_socket(
+    mock_exists, mock_run, mock_popen, mock_stream, mock_append_log, mock_job, mock_session
+):
+    mock_job.return_value = MagicMock(id='job-1')
+    host = MagicMock(spec=Host)
+    host.id = 1
+    host.name = 'testhost'
+    host.ip_address = '1.2.3.4'
+    host.ssh_key_path = '/key'
+    host.ssh_user = 'ansible'
+    host.provider = 'vultr'
+    host.status = HostStatus.PROVISIONED_PENDING_SETUP
+    host.timezone = None
+    mock_session.get.return_value = host
+
+    proc = MagicMock()
+    proc.returncode = 0
+    mock_popen.return_value = proc
+    mock_run.return_value = MagicMock(stdout='ok', stderr='', returncode=0)
+
+    from ui.task_logic.ansible_host_setup import setup_host_ansible_logic
+    setup_host_ansible_logic(1)
+
+    assert host.redis_unix_socket is True
+    assert host.status == HostStatus.ACTIVE
+
+
+@patch(f'{STANDALONE_MODULE}.db.session')
+@patch(f'{STANDALONE_MODULE}.get_current_job')
+@patch(f'{STANDALONE_MODULE}.append_log')
+@patch(f'{STANDALONE_MODULE}._generate_standalone_inventory')
+@patch(f'{STANDALONE_MODULE}._wait_for_ssh', return_value=True)
+@patch(f'{STANDALONE_MODULE}._run_setup_playbook', return_value=True)
+def test_standalone_setup_sets_redis_unix_socket(
+    mock_playbook, mock_ssh, mock_inventory, mock_append_log, mock_job, mock_session
+):
+    mock_job.return_value = MagicMock(id='job-2')
+    host = MagicMock(spec=Host)
+    host.id = 2
+    host.ip_address = '5.6.7.8'
+    host.ssh_key_path = '/key'
+    host.ssh_user = 'ansible'
+    host.provider = 'vultr'
+    host.status = HostStatus.PROVISIONED_PENDING_SETUP
+    mock_session.get.return_value = host
+    mock_inventory.return_value = ('/tmp/inv.yml', '5.6.7.8')
+
+    from ui.task_logic.standalone_host_setup import setup_standalone_host_logic
+    setup_standalone_host_logic(2)
+
+    assert host.redis_unix_socket is True
+    assert host.status == HostStatus.ACTIVE
+
+
+@patch(f'{STANDALONE_MODULE}.db.session')
+@patch(f'{STANDALONE_MODULE}.get_current_job')
+@patch(f'{STANDALONE_MODULE}.append_log')
+@patch(f'{STANDALONE_MODULE}._generate_standalone_inventory')
+@patch(f'{STANDALONE_MODULE}._wait_for_ssh', return_value=True)
+@patch(f'{STANDALONE_MODULE}._run_setup_playbook', return_value=True)
+def test_self_host_setup_does_not_set_redis_unix_socket(
+    mock_playbook, mock_ssh, mock_inventory, mock_append_log, mock_job, mock_session
+):
+    """Self-host provider must NOT flip the flag — Docker Redis has no socket."""
+    mock_job.return_value = MagicMock(id='job-3')
+    host = MagicMock(spec=Host)
+    host.id = 3
+    host.ip_address = '127.0.0.1'
+    host.ssh_key_path = '/key'
+    host.ssh_user = 'ansible'
+    host.provider = 'self'
+    host.status = HostStatus.PROVISIONED_PENDING_SETUP
+    host.redis_unix_socket = False
+    mock_session.get.return_value = host
+    mock_inventory.return_value = ('/tmp/inv.yml', 'host.docker.internal')
+
+    from ui.task_logic.standalone_host_setup import setup_standalone_host_logic
+    setup_standalone_host_logic(3)
+
+    assert host.redis_unix_socket is False

--- a/tests/test_redis_args.py
+++ b/tests/test_redis_args.py
@@ -1,0 +1,91 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from ui import create_app
+from ui.models import Host, QLInstance
+from ui.task_logic.ansible_instance_mgmt import REDIS_UNIX_SOCKET_PATH
+
+
+@pytest.fixture(scope='module')
+def test_app():
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+    with app.app_context():
+        yield app
+
+
+def _make_instance(provider='vultr', redis_unix_socket=False):
+    host = MagicMock(spec=Host)
+    host.provider = provider
+    host.redis_unix_socket = redis_unix_socket
+    instance = MagicMock(spec=QLInstance)
+    instance.host = host
+    return instance
+
+
+# --- Cloud / Standalone: TCP (flag False) ---
+
+def test_cloud_tcp_injects_nothing(test_app):
+    """Cloud host with TCP flag: no redis args (minqlx default works)."""
+    from ui.task_logic.ansible_instance_mgmt import _redis_args
+    instance = _make_instance(provider='vultr', redis_unix_socket=False)
+    assert _redis_args(instance) == []
+
+
+def test_standalone_tcp_injects_nothing(test_app):
+    """Standalone host with TCP flag: no redis args."""
+    from ui.task_logic.ansible_instance_mgmt import _redis_args
+    instance = _make_instance(provider='standalone', redis_unix_socket=False)
+    assert _redis_args(instance) == []
+
+
+# --- Cloud / Standalone: Socket (flag True) ---
+
+def test_cloud_socket_injects_socket_args(test_app):
+    """Cloud host with socket flag: socket path + unix socket flag, no password."""
+    from ui.task_logic.ansible_instance_mgmt import _redis_args
+    instance = _make_instance(provider='vultr', redis_unix_socket=True)
+    args = _redis_args(instance)
+    assert f'+set qlx_redisAddress "{REDIS_UNIX_SOCKET_PATH}"' in args
+    assert '+set qlx_redisUnixSocket 1' in args
+    assert not any('redisPassword' in a for a in args)
+
+
+def test_standalone_socket_injects_socket_args(test_app):
+    """Standalone host with socket flag: socket path + unix socket flag, no password."""
+    from ui.task_logic.ansible_instance_mgmt import _redis_args
+    instance = _make_instance(provider='standalone', redis_unix_socket=True)
+    args = _redis_args(instance)
+    assert f'+set qlx_redisAddress "{REDIS_UNIX_SOCKET_PATH}"' in args
+    assert '+set qlx_redisUnixSocket 1' in args
+    assert not any('redisPassword' in a for a in args)
+
+
+# --- Self-host: always TCP + password ---
+
+@patch.dict('os.environ', {'REDIS_PASSWORD': 'secretpass'})
+def test_self_host_tcp_injects_address_and_password(test_app):
+    """Self-host always injects TCP address + password regardless of flag."""
+    from ui.task_logic.ansible_instance_mgmt import _redis_args
+    instance = _make_instance(provider='self', redis_unix_socket=False)
+    args = _redis_args(instance)
+    assert '+set qlx_redisAddress "127.0.0.1:6379"' in args
+    assert '+set qlx_redisPassword "secretpass"' in args
+
+
+@patch.dict('os.environ', {'REDIS_PASSWORD': 'secretpass'})
+def test_self_host_socket_flag_true_still_uses_tcp(test_app):
+    """Self-host with socket flag True: still uses TCP (Docker Redis, no socket possible)."""
+    from ui.task_logic.ansible_instance_mgmt import _redis_args
+    instance = _make_instance(provider='self', redis_unix_socket=True)
+    args = _redis_args(instance)
+    assert '+set qlx_redisAddress "127.0.0.1:6379"' in args
+    assert '+set qlx_redisPassword "secretpass"' in args
+    assert not any('UnixSocket' in a for a in args)
+
+
+@patch.dict('os.environ', {}, clear=True)
+def test_self_host_missing_password_raises(test_app):
+    """Self-host with no REDIS_PASSWORD raises ValueError."""
+    from ui.task_logic.ansible_instance_mgmt import _redis_args
+    instance = _make_instance(provider='self', redis_unix_socket=False)
+    with pytest.raises(ValueError, match="Redis password"):
+        _redis_args(instance)

--- a/ui/models.py
+++ b/ui/models.py
@@ -57,6 +57,7 @@ class Host(db.Model):
     is_standalone = db.Column(db.Boolean, default=False, nullable=False) # True for user-provided servers
     timezone = db.Column(db.String(50), nullable=True) # IANA timezone name (e.g., 'America/New_York')
     cpu_count = db.Column(db.Integer, nullable=True) # Detected/inferred Linux CPU count for affinity assignment
+    redis_unix_socket = db.Column(db.Boolean, default=False, nullable=False, server_default='0')
     status = db.Column(db.Enum(HostStatus), default=HostStatus.PENDING, nullable=False)
     qlfilter_status = db.Column(db.Enum(QLFilterStatus), default=QLFilterStatus.UNKNOWN, nullable=True) # New field for QLFilter
     auto_restart_schedule = db.Column(db.String(100), nullable=True) # Cron expression for auto-restart
@@ -91,6 +92,7 @@ class Host(db.Model):
             'is_standalone': self.is_standalone,
             'timezone': self.timezone,
             'cpu_count': self.cpu_count,
+            'redis_unix_socket': bool(self.redis_unix_socket),
             'status': self.status.value if self.status else None,
             'qlfilter_status': self.qlfilter_status.value if self.qlfilter_status else QLFilterStatus.UNKNOWN.value, # Include QLFilter status
             'auto_restart_schedule': self.auto_restart_schedule,

--- a/ui/routes/host_routes.py
+++ b/ui/routes/host_routes.py
@@ -97,6 +97,7 @@ from ui.tasks import provision_host, destroy_host, \
     setup_standalone_host_ansible, remove_standalone_host, \
     force_update_workshop_task, configure_host_auto_restart_task, \
     resize_host_task, \
+    rerun_host_setup_ansible, rerun_standalone_host_setup, \
     enqueue_task
 from ui.task_logic.job_failure_handlers import host_job_failure_handler
 from ui.routes.self_host_helpers import (
@@ -1072,6 +1073,43 @@ def resize_host_api(host_id):
         "message": f"Host resize task queued: {current_plan} -> {new_plan}.",
         "data": {"new_plan": new_plan, "current_plan": current_plan},
     }), 202
+
+@host_api_bp.route('/<int:host_id>/rerun-setup', methods=['POST'], endpoint='rerun_setup_api')
+@jwt_required()
+def rerun_setup_api(host_id):
+    """Re-run Ansible host setup on an already-ACTIVE host."""
+    host = get_host(host_id)
+    if not host:
+        return jsonify({"error": {"message": "Host not found."}}), 404
+
+    if host.status != HostStatus.ACTIVE:
+        return jsonify({"error": {"message": f"Host must be ACTIVE to re-run setup. Current status: {host.status.value}"}}), 409
+
+    lock_token = str(uuid.uuid4())
+    if not acquire_lock('host', host.id, lock_token, ttl=1260):
+        return jsonify({"error": {"message": "Host is currently locked by another operation."}}), 409
+
+    try:
+        update_host(host.id, status=HostStatus.CONFIGURING)
+
+        if host.is_standalone or host.provider == 'self':
+            task_fn = rerun_standalone_host_setup
+        else:
+            task_fn = rerun_host_setup_ansible
+
+        enqueue_task(task_fn, host.id, lock_token=lock_token,
+                     on_failure=host_job_failure_handler)
+    except Exception as e:
+        try:
+            update_host(host.id, status=HostStatus.ACTIVE)
+        except Exception:
+            current_app.logger.error(f"Failed to revert host {host.id} status after enqueue failure", exc_info=True)
+        release_lock('host', host.id, lock_token)
+        current_app.logger.error(f"Error queuing rerun-setup for host {host.id}: {e}", exc_info=True)
+        return jsonify({"error": {"message": f"Failed to queue re-run setup: {str(e)}"}}), 500
+
+    return jsonify({"data": {"status": "configuring"}, "message": "Host re-setup queued."}), 200
+
 
 @host_api_bp.route('/<int:host_id>/update-workshop', methods=['POST'], endpoint='force_update_workshop_api')
 @jwt_required()

--- a/ui/routes/host_routes.py
+++ b/ui/routes/host_routes.py
@@ -1108,7 +1108,7 @@ def rerun_setup_api(host_id):
         current_app.logger.error(f"Error queuing rerun-setup for host {host.id}: {e}", exc_info=True)
         return jsonify({"error": {"message": f"Failed to queue re-run setup: {str(e)}"}}), 500
 
-    return jsonify({"data": {"status": "configuring"}, "message": "Host re-setup queued."}), 200
+    return jsonify({"data": {"status": "configuring"}, "message": "Host re-setup queued."}), 202
 
 
 @host_api_bp.route('/<int:host_id>/update-workshop', methods=['POST'], endpoint='force_update_workshop_api')

--- a/ui/task_logic/ansible_host_setup.py
+++ b/ui/task_logic/ansible_host_setup.py
@@ -11,9 +11,10 @@ from .common import append_log # Import from the common module
 
 log = logging.getLogger(__name__)
 
-def setup_host_ansible_logic(host_id):
+def setup_host_ansible_logic(host_id, rerun=False):
     """
     Task logic to perform initial host setup using Ansible after Terraform provisioning.
+    When rerun=True, also accepts CONFIGURING status (set by rerun-setup route).
     """
     job = get_current_job()
     log.info(f"Starting task setup_host_ansible for host_id: {host_id} (Job ID: {job.id})")
@@ -27,9 +28,13 @@ def setup_host_ansible_logic(host_id):
             return f"Error: Host {host_id} not found."
 
         # Verify host is in the expected state
-        if host.status != HostStatus.PROVISIONED_PENDING_SETUP:
-            log.warning(f"Host {host_id} is not in PROVISIONED_PENDING_SETUP state (current: {host.status.value}). Skipping Ansible setup.")
-            append_log(host, f"Task skipped: Host status is {host.status.value}, expected PROVISIONED_PENDING_SETUP.")
+        allowed = {HostStatus.PROVISIONED_PENDING_SETUP}
+        if rerun:
+            allowed.add(HostStatus.CONFIGURING)
+        if host.status not in allowed:
+            allowed_names = '/'.join(s.value for s in allowed)
+            log.warning(f"Host {host_id} is not in an allowed state (current: {host.status.value}, allowed: {allowed_names}). Skipping Ansible setup.")
+            append_log(host, f"Task skipped: Host status is {host.status.value}, expected one of: {allowed_names}.")
             # Commit log? Or just return? Let's commit the log.
             db.session.commit()
             return f"Task skipped: Host {host_id} status is {host.status.value}."

--- a/ui/task_logic/ansible_host_setup.py
+++ b/ui/task_logic/ansible_host_setup.py
@@ -164,6 +164,7 @@ def setup_host_ansible_logic(host_id):
             # --- Final Success ---
             host.status = HostStatus.ACTIVE
             host.qlfilter_status = QLFilterStatus.NOT_INSTALLED
+            host.redis_unix_socket = True
             append_log(host, f"Task finished successfully. Host is ACTIVE.")
             db.session.commit()
             log.info(f"Finished task setup_host_ansible for host_id: {host_id}. Status: ACTIVE")

--- a/ui/task_logic/ansible_instance_mgmt.py
+++ b/ui/task_logic/ansible_instance_mgmt.py
@@ -55,18 +55,31 @@ def _prepare_instance_zmq(instance):
         db.session.commit()
 
 
-def _self_host_redis_args(instance):
-    if not is_self_host(getattr(instance, "host", None)):
-        return []
+REDIS_UNIX_SOCKET_PATH = '/var/run/redis/redis.sock'
 
-    redis_password = (os.environ.get("REDIS_PASSWORD") or "").strip()
-    if not redis_password:
-        raise ValueError("Self-host instance Redis password is not configured.")
 
-    return [
-        '+set qlx_redisAddress "127.0.0.1:6379"',
-        f'+set qlx_redisPassword "{_escape_qlds_quoted_value(redis_password)}"',
-    ]
+def _redis_args(instance):
+    host = getattr(instance, 'host', None)
+    is_self = is_self_host(host)
+
+    if is_self:
+        # Self-host always uses TCP — its Redis runs in the QLSM Docker
+        # container and a Unix socket cannot cross that boundary.
+        redis_password = (os.environ.get('REDIS_PASSWORD') or '').strip()
+        if not redis_password:
+            raise ValueError("Self-host instance Redis password is not configured.")
+        return [
+            '+set qlx_redisAddress "127.0.0.1:6379"',
+            f'+set qlx_redisPassword "{_escape_qlds_quoted_value(redis_password)}"',
+        ]
+
+    if host and getattr(host, 'redis_unix_socket', False):
+        return [
+            f'+set qlx_redisAddress "{REDIS_UNIX_SOCKET_PATH}"',
+            '+set qlx_redisUnixSocket 1',
+        ]
+
+    return []
 
 
 def _escape_qlds_quoted_value(value):
@@ -92,7 +105,7 @@ def _build_qlds_args_string(instance):
         f'+set net_port {instance.port}',
         f'+set sv_hostname "{instance.hostname}"',
     ]
-    parts += _self_host_redis_args(instance)
+    parts += _redis_args(instance)
     parts += [
         f'+set qlx_redisDatabase {redis_db_index}',
         f'+set fs_homepath {homepath}',

--- a/ui/task_logic/standalone_host_setup.py
+++ b/ui/task_logic/standalone_host_setup.py
@@ -26,9 +26,10 @@ def _extract_inventory_mismatch_detail(stdout_content="", stderr_content=""):
     return None
 
 
-def setup_standalone_host_logic(host_id):
+def setup_standalone_host_logic(host_id, rerun=False):
     """
     Task logic to set up a standalone host via Ansible (no Terraform provisioning).
+    When rerun=True, also accepts CONFIGURING status (set by rerun-setup route).
     """
     job = get_current_job()
     log.info(f"Starting task setup_standalone_host for host_id: {host_id} (Job ID: {job.id})")
@@ -41,9 +42,13 @@ def setup_standalone_host_logic(host_id):
             return f"Error: Host {host_id} not found."
 
         # Verify host is in the expected state
-        if host.status != HostStatus.PROVISIONED_PENDING_SETUP:
-            log.warning(f"Host {host_id} is not in PROVISIONED_PENDING_SETUP state (current: {host.status.value}).")
-            append_log(host, f"Task skipped: Host status is {host.status.value}, expected PROVISIONED_PENDING_SETUP.")
+        allowed = {HostStatus.PROVISIONED_PENDING_SETUP}
+        if rerun:
+            allowed.add(HostStatus.CONFIGURING)
+        if host.status not in allowed:
+            allowed_names = '/'.join(s.value for s in allowed)
+            log.warning(f"Host {host_id} is not in an allowed state (current: {host.status.value}, allowed: {allowed_names}).")
+            append_log(host, f"Task skipped: Host status is {host.status.value}, expected one of: {allowed_names}.")
             db.session.commit()
             return f"Task skipped: Host {host_id} status is {host.status.value}."
 

--- a/ui/task_logic/standalone_host_setup.py
+++ b/ui/task_logic/standalone_host_setup.py
@@ -99,6 +99,8 @@ def setup_standalone_host_logic(host_id):
 
         # Success
         host.status = HostStatus.ACTIVE
+        if host.provider != 'self':
+            host.redis_unix_socket = True
         append_log(host, "Task finished successfully. Host is ACTIVE.")
         db.session.commit()
         log.info(f"Finished task setup_standalone_host for host_id: {host_id}. Status: ACTIVE")

--- a/ui/tasks.py
+++ b/ui/tasks.py
@@ -332,5 +332,29 @@ def remove_standalone_host(host_id, lock_token=None):
             release_lock('host', host_id, lock_token)
 
 
+@rq.job(timeout=3600)
+@with_app_context
+def rerun_host_setup_ansible(host_id, lock_token=None):
+    """RQ task entry point for re-running Ansible host setup on a cloud host."""
+    try:
+        return setup_host_ansible_logic(host_id, rerun=True)
+    finally:
+        if lock_token:
+            from ui.task_lock import release_lock
+            release_lock('host', host_id, lock_token)
+
+
+@rq.job(timeout=1200)
+@with_app_context
+def rerun_standalone_host_setup(host_id, lock_token=None):
+    """RQ task entry point for re-running Ansible host setup on a standalone host."""
+    try:
+        return setup_standalone_host_logic(host_id, rerun=True)
+    finally:
+        if lock_token:
+            from ui.task_lock import release_lock
+            release_lock('host', host_id, lock_token)
+
+
 # Note: The app context for database access is now provided by the with_app_context
 # decorator, which creates a Flask application context for each task execution.


### PR DESCRIPTION
## Summary

- Adds `redis_unix_socket` boolean field to `Host` (Alembic migration included) — tracks whether a host has been set up with Unix socket Redis support
- `setup_host.yml` now configures the Redis Unix socket path (`/var/run/redis/redis.sock`), permissions (`770`), and adds the `ql` user to the `redis` group when `use_host_redis` is true; host setup logic sets `redis_unix_socket = True` on success (cloud + standalone only — self-host stays on TCP)
- `_redis_args()` replaces `_self_host_redis_args()` in `ansible_instance_mgmt.py`: socket-enabled hosts get `qlx_redisAddress` + `qlx_redisUnixSocket 1`; TCP hosts get nothing (minqlx default); self-host always gets TCP + password
- New `POST /api/hosts/<id>/rerun-setup` endpoint lets admins re-run host setup on existing ACTIVE hosts to migrate them to Unix socket Redis without reprovisioning; uses the standard lock/status-revert pattern
- Frontend: "Re-run Host Setup" action added to `HostActionsMenu` with confirmation dialog; Redis Socket/TCP badge added to host cards in `HostsTableRow`
- Documentation updated: forced cvars table in `edit-configs.md` now includes `qlx_redisUnixSocket` and distinguishes TCP vs socket-enabled address values

## Test Plan

- [x] All 796 tests pass (`pytest tests/`)
- [ ] `POST /api/hosts/<id>/rerun-setup` returns 200 for ACTIVE hosts, 409 for non-ACTIVE, 401 unauthenticated, 404 for missing
- [ ] On enqueue failure the host status reverts from CONFIGURING back to ACTIVE
- [ ] `_redis_args()` returns correct args for all 3 host/flag combinations (covered by `tests/test_redis_args.py`)
- [ ] After successful host setup, `redis_unix_socket` is `True` in the DB for cloud/standalone hosts and remains `False` for self-host
- [ ] "Re-run Host Setup" button appears in the actions menu, is disabled when host is not ACTIVE, and shows the Redis restart confirmation dialog
- [ ] Redis Socket/TCP badge renders correctly on host cards