### PR TITLE
Add LD_PRELOAD hook management

### DIFF
--- a/ansible/playbooks/update_instance_hooks.yml
+++ b/ansible/playbooks/update_instance_hooks.yml
@@ -1,0 +1,33 @@
+---
+- name: Update QLDS Instance LD_PRELOAD Hooks
+  hosts: all
+  become: yes
+  gather_facts: false
+
+  vars:
+    game_port: "{{ port }}"
+
+  tasks:
+    - name: Render QLDS systemd service file with updated LD_PRELOAD
+      ansible.builtin.template:
+        src: ../templates/qlds@.service.j2
+        dest: /etc/systemd/system/qlds@{{ game_port }}.service
+        owner: root
+        group: root
+        mode: '0644'
+      notify: reload systemd daemon
+
+    - name: Flush handlers so daemon-reload runs before restart
+      ansible.builtin.meta: flush_handlers
+
+    - name: Restart QLDS service
+      ansible.builtin.systemd:
+        name: qlds@{{ game_port }}
+        state: restarted
+        enabled: yes
+      when: restart_service | default(true) | bool
+
+  handlers:
+    - name: reload systemd daemon
+      ansible.builtin.systemd:
+        daemon_reload: yes

--- a/ansible/playbooks/update_instance_hooks.yml
+++ b/ansible/playbooks/update_instance_hooks.yml
@@ -8,6 +8,15 @@
     game_port: "{{ port }}"
 
   tasks:
+    - name: Sync .so hooks from UI server to instance minqlx-plugins
+      ansible.builtin.synchronize:
+        src: "../../configs/{{ host_name }}/{{ instance_id }}/scripts/"
+        dest: "/home/ql/qlds-{{ game_port }}/minqlx-plugins/"
+        rsync_opts:
+          - "--include=*.so"
+          - "--exclude=*"
+      when: host_name is defined and instance_id is defined
+
     - name: Render QLDS systemd service file with updated LD_PRELOAD
       ansible.builtin.template:
         src: ../templates/qlds@.service.j2

--- a/ansible/templates/qlds@.service.j2
+++ b/ansible/templates/qlds@.service.j2
@@ -9,6 +9,9 @@ WorkingDirectory=/home/ql/qlds-%i
 {% if cpu_affinity is defined and cpu_affinity is not none %}
 CPUAffinity={{ cpu_affinity }}
 {% endif %}
+{% if ld_preload_paths | default('') %}
+Environment=LD_PRELOAD={{ ld_preload_paths }}
+{% endif %}
 # The ExecStart line will include the script and the dynamic arguments passed from Ansible
 # Wrap the entire command in quotes to handle spaces/quotes in qlds_args
 ExecStart=/home/ql/qlds-%i/run_server_x64_minqlx.sh {{ qlds_args | default('') }} 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -240,6 +240,8 @@ Example success response:
 | `/instances/<id>/stop` | POST | Stop instance service |
 | `/instances/<id>/config` | GET | Get instance config files |
 | `/instances/<id>/config` | PUT | Update config and apply (triggers Ansible sync) |
+| `/instances/<id>/hooks` | GET | List available LD_PRELOAD hook shared objects |
+| `/instances/<id>/hooks` | PUT | Replace enabled LD_PRELOAD hook list and queue apply |
 | `/instances/<id>/lan-rate` | PUT | Toggle 99k LAN rate mode |
 | `/instances/<id>/logs` | GET | Get instance task logs |
 | `/instances/<id>/remote-logs` | GET | Fetch live logs via Ansible (`?filter_mode=`, `?since=`, `?lines=`) |
@@ -314,6 +316,7 @@ Example success response:
     "hostname": "My Duel Server",
     "lan_rate_enabled": false,
     "qlx_plugins": "plugin1,plugin2",
+    "ld_preload_hooks": "highfps_hook.so,timer_hook.so",
     "zmq_rcon_port": 27961,
     "zmq_rcon_password": "...",
     "zmq_stats_port": 27962,
@@ -348,6 +351,65 @@ Example success response:
 `config_folders` is returned alongside the flat `configs` map. It lists every top-level subfolder present in the instance config directory (excluding the reserved `scripts` and `factories` folders).
 
 `PUT /instances/<id>/config` accepts the same generic `configs` map plus optional top-level `name`, `hostname`, `lan_rate_enabled`, `checked_plugins`, `draft_id`, `factories`, `config_folders`, and `restart`. When `configs` is present, QLSM syncs the managed config set and removes unprotected `.cfg`/`.txt` files omitted from the map. When `config_folders` is present, QLSM reconciles top-level subfolders: creating any listed that are missing, and removing any that are no longer listed (provided they contain only managed `.ent`/`.cfg`/`.txt` files — folders with unmanaged content are preserved). When `config_folders` is omitted entirely, existing subfolders are left untouched. When `factories` is omitted, existing factories are preserved; when it is present, omitted `.factories` files are removed.
+
+### LD_PRELOAD Hooks
+
+```
+GET /api/instances/<id>/hooks
+```
+
+Returns `.so` files in the instance `scripts/` directory with enabled state,
+order, file metadata, BinaryMetadata description, and active system hooks.
+
+```json
+{
+  "data": {
+    "available": [
+      {
+        "filename": "highfps_hook.so",
+        "size": 16384,
+        "modified": 1716300000,
+        "enabled": true,
+        "order": 1,
+        "description": "High FPS timing hook"
+      }
+    ],
+    "system_hooks_active": []
+  }
+}
+```
+
+```
+PUT /api/instances/<id>/hooks
+```
+
+Replaces the ordered LD_PRELOAD hook list. Files in `scripts/` that are absent
+from `enabled` are disabled.
+
+```json
+{
+  "enabled": ["highfps_hook.so", "timer_hook.so"]
+}
+```
+
+Validation requires each filename to be a unique `.so` basename with no path
+separators, no `..`, not reserved for a system hook, present under `scripts/`,
+and an ELF file. Validation failures return `400`; held instance locks return
+`409`.
+
+Success returns `202 Accepted` and queues `apply_instance_hooks`.
+
+```json
+{
+  "data": {
+    "task_id": "rq-job-id"
+  }
+}
+```
+
+Running instances restart after the unit is re-rendered with
+`Environment=LD_PRELOAD=...`; stopped instances update the unit and remain
+stopped.
 
 ## Server Status
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -99,6 +99,7 @@ The Flask application follows the application factory pattern, which provides se
     -   `index_routes.py`: Handles the main index page.
     *   `host_routes.py`: Handles CRUD operations for Hosts, protected by `@jwt_required()`.
     *   `instance_routes.py`: Handles CRUD operations for QLInstances, protected by `@jwt_required()`.
+    *   `instance_hooks_routes.py`: Lists and updates per-instance LD_PRELOAD hook selections from uploaded `.so` files.
     *   `preset_api_routes.py`: Handles CRUD operations for ConfigPresets, protected by `@jwt_required()`. Preset writes accept generic config and factory maps, plugin draft IDs, checked plugin lists, and checked factory lists. Mutating operations (rename, content update, delete) are rejected with `403` for any preset where `is_builtin = True`.
     *   `server_status_routes.py`: Handles live status retrieval (`GET /api/server-status`) and workshop preview lookup (`GET /api/server-status/workshop-preview/<workshop_id>`).
     *   `settings_routes.py`: Handles application settings management (API keys, rate limit config).
@@ -176,6 +177,7 @@ class QLInstance(db.Model):
     hostname = db.Column(db.String(255), nullable=False)  # sv_hostname
     lan_rate_enabled = db.Column(db.Boolean, default=False, nullable=False)
     qlx_plugins = db.Column(db.Text, nullable=True)  # comma-separated plugin list
+    ld_preload_hooks = db.Column(db.Text, nullable=True)  # comma-separated .so list
     cpu_affinity = db.Column(db.Integer, nullable=True)
     zmq_rcon_port = db.Column(db.Integer, nullable=True)
     zmq_rcon_password = db.Column(db.String(255), nullable=True)
@@ -230,6 +232,7 @@ The project uses pytest for testing, with fixtures defined in `tests/conftest.py
 -   **Playbook Structure:**
     -   **`ansible/playbooks/setup_host.yml`:** Performs the initial one-time setup on a newly provisioned host. Installs prerequisites (including `iptables-persistent`, and `redis-server` only when the host runtime needs its own Redis), configures the firewall using a template (`ansible/templates/iptables.rules.j2`) that defines both filter and NAT rules which are applied atomically via `iptables-restore` and persisted, creates the `ql` user, installs base SteamCMD/QLDS/minqlx to shared locations (`/home/ql/qlds-base`, `/home/ql/minqlx-shared`), and syncs common assets (`/home/ql/assets/common`).
     -   **`ansible/playbooks/add_qlds_instance.yml`:** Adds a new QLDS instance to a pre-configured host. Creates the instance directory (`/home/ql/qlds-{id}`), copies shared resources (QLDS base, minqlx, common assets) into the instance directory, syncs instance-specific configuration files from the UI server (`configs/<host>/<id>/`), installs instance-specific Python dependencies, and manages the systemd service.
+    -   **`ansible/playbooks/update_instance_hooks.yml`:** Re-renders a QLDS instance systemd unit with the current LD_PRELOAD value and daemon-reloads systemd. It restarts the service only when the accepted hook update came from a non-stopped instance.
     -   **`ansible/playbooks/manage_qlds_service.yml`:** Manages the `qlds@<id>.service` systemd service (start, stop, restart, delete service file).
     -   **`ansible/playbooks/get_qlds_logs.yml`:** Retrieves logs for a specific instance service.
     -   **`ansible/playbooks/setup_qlfilter.yml`:** Installs QLFilter (eBPF/XDP packet filter) on a target host.
@@ -253,6 +256,26 @@ The project uses pytest for testing, with fixtures defined in `tests/conftest.py
     *   Detailed stdout and stderr from Ansible playbook executions (triggered by tasks in `ui/task_logic/ansible_instance_mgmt.py`) are no longer stored directly in the `QLInstance.logs` database field.
     *   Instead, these verbose logs are saved to individual files within the `logs/ansible_runs/` directory (e.g., `logs/ansible_runs/instance_<instance_id>_<task_name>_<job_id>_<timestamp>.log`). This is managed by the `save_ansible_run_log` function in `ui/task_logic/file_logger.py`.
     *   The `QLInstance.logs` database field now stores concise, timestamped status messages, including a reference to the path of the detailed log file.
+
+### LD_PRELOAD Hooks
+
+Per-instance LD_PRELOAD hooks are stored on `QLInstance.ld_preload_hooks` as a
+comma-separated list of uploaded `.so` filenames. `_build_ld_preload_paths()` in
+`ui/task_logic/ansible_instance_mgmt.py` converts that list into a colon-joined
+path string, prepending any active system hooks. The system hook registry is
+empty today; `force_rate.so` is reserved so a future built-in hook cannot be
+shadowed by a user upload.
+
+The `qlds@.service.j2` template emits `Environment=LD_PRELOAD=...` only when
+the computed value is non-empty. Existing deploy, restart, config apply, and
+LAN-rate reconfigure flows pass the same `ld_preload_paths` extra-var so later
+unit re-renders preserve hook state.
+
+The `apply_instance_hooks` RQ task delegates to
+`ui/task_logic/ansible_instance_hooks.py`. It re-validates enabled hooks with a
+pre-flight existence and ELF-magic check, preserves CPU affinity while
+re-rendering the unit, and leaves stopped instances stopped by passing
+`restart_service=false` to `update_instance_hooks.yml`.
 -   **Terraform Run Logging:**
     *   Detailed stdout and stderr from Terraform CLI executions (triggered by tasks in `ui/task_logic/terraform_provision.py` and `ui/task_logic/terraform_destroy.py`) are no longer stored directly in the `Host.logs` database field.
     *   Instead, these verbose logs are saved to individual files within the `logs/terraform_runs/` directory (e.g., `logs/terraform_runs/host_<host_id>_<task_name>_<command>_<job_id>_<timestamp>.log`). This is managed by the `save_terraform_run_log` function in `ui/task_logic/file_logger.py`.

--- a/frontend-react/src/codemirror-lang-qlaccess.js
+++ b/frontend-react/src/codemirror-lang-qlaccess.js
@@ -26,7 +26,7 @@ export const qlaccessLanguage = StreamLanguage.define({
     }
 
     switch (state.stage) {
-      case "init":
+      case "init": {
         if (stream.sol() && stream.peek() === " ") {
           const lineContent = stream.string.slice(stream.pos);
           if (lineContent.trim() !== "" && lineContent[0] === " ") {
@@ -64,6 +64,7 @@ export const qlaccessLanguage = StreamLanguage.define({
         state.stage = "line_error";
         stream.next();
         return "invalid";
+      }
 
       case "expecting_pipe":
         stream.eatSpace();
@@ -81,7 +82,7 @@ export const qlaccessLanguage = StreamLanguage.define({
         stream.next();
         return "invalid";
 
-      case "after_pipe":
+      case "after_pipe": {
         stream.eatSpace();
         if (stream.match("#")) {
             stream.skipToEnd();
@@ -110,6 +111,7 @@ export const qlaccessLanguage = StreamLanguage.define({
         state.stage = "line_error";
         stream.next();
         return "invalid";
+      }
         
       case "after_level":
         stream.eatSpace();

--- a/frontend-react/src/codemirror-lang-qlmappool.js
+++ b/frontend-react/src/codemirror-lang-qlmappool.js
@@ -19,7 +19,7 @@ export const qlmappoolLanguage = StreamLanguage.define({
     }
 
     switch (state.stage) {
-      case "init":
+      case "init": {
         // Check for lines starting with a space that are not entirely spaces
         if (stream.sol() && stream.peek() === " ") {
           const lineContent = stream.string.slice(stream.pos);
@@ -64,6 +64,7 @@ export const qlmappoolLanguage = StreamLanguage.define({
         state.stage = "line_error";
         stream.next(); // Consume one char
         return "error"; // Use string token
+      }
 
       case "expecting_pipe":
         stream.eatSpace(); // Allow spaces between map name and pipe
@@ -82,7 +83,7 @@ export const qlmappoolLanguage = StreamLanguage.define({
         stream.next();
         return "error"; // Use string token
 
-      case "after_pipe":
+      case "after_pipe": {
         stream.eatSpace(); // Allow spaces between pipe and factory
         if (stream.peek() === "#") {
             stream.skipToEnd();
@@ -103,6 +104,7 @@ export const qlmappoolLanguage = StreamLanguage.define({
         state.stage = "line_error";
         stream.next();
         return "error"; // Use string token
+      }
         
       case "after_factory":
         stream.eatSpace(); // Consume spaces after factory ID

--- a/frontend-react/src/components/FileUploadButton.jsx
+++ b/frontend-react/src/components/FileUploadButton.jsx
@@ -92,7 +92,7 @@ function FileUploadButton({
         {label && <span className="ml-2">{label}</span>} {/* Conditionally add margin if label exists */}
       </button>
       {/* Display error message directly below the button if needed, or parent can handle it */}
-      {/* {error && <p className="text-xs text-red-500 mt-1">{error}</p>} */}
+      {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
     </>
   );
 }

--- a/frontend-react/src/components/hosts/ForceUpdateWorkshopModal.jsx
+++ b/frontend-react/src/components/hosts/ForceUpdateWorkshopModal.jsx
@@ -30,7 +30,7 @@ function ForceUpdateWorkshopModal({ isOpen, onClose, onSubmit, host }) {
 
         // Get list of instance IDs that were toggled on
         const restartInstanceIds = Object.entries(selectedInstances)
-            .filter(([_, isSelected]) => isSelected)
+            .filter(([, isSelected]) => isSelected)
             .map(([id]) => parseInt(id, 10));
 
         onSubmit(workshopId.trim(), restartInstanceIds);

--- a/frontend-react/src/components/hosts/HostAutoRestartScheduleModal.jsx
+++ b/frontend-react/src/components/hosts/HostAutoRestartScheduleModal.jsx
@@ -5,6 +5,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { WheelPicker, WheelPickerWrapper } from '@ncdai/react-wheel-picker';
 import '../../ncdai-wheel-picker.css';
 
+const MotionDiv = motion.div;
+
 const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 const HOUR_OPTIONS = Array.from({ length: 12 }, (_, i) => {
@@ -199,7 +201,7 @@ function HostAutoRestartScheduleModal({ isOpen, onClose, onSubmit, host }) {
                                         <div className="overflow-hidden">
                                             <AnimatePresence mode="popLayout" initial={false}>
                                                 {scheduleMode !== 'none' && (
-                                                    <motion.div
+                                                    <MotionDiv
                                                         key={`mode-${scheduleMode}`}
                                                         variants={contentVariants}
                                                         initial="initial"
@@ -297,11 +299,11 @@ function HostAutoRestartScheduleModal({ isOpen, onClose, onSubmit, host }) {
                                                                 </span>
                                                             </p>
                                                         </div>
-                                                    </motion.div>
+                                                    </MotionDiv>
                                                 )}
 
                                                 {scheduleMode === 'none' && (
-                                                    <motion.div
+                                                    <MotionDiv
                                                         key="none"
                                                         variants={contentVariants}
                                                         initial="initial"
@@ -312,7 +314,7 @@ function HostAutoRestartScheduleModal({ isOpen, onClose, onSubmit, host }) {
                                                         <p className="text-sm text-[var(--text-muted)] text-center">
                                                             Auto-restart is disabled. Select a schedule type above to configure.
                                                         </p>
-                                                    </motion.div>
+                                                    </MotionDiv>
                                                 )}
                                             </AnimatePresence>
                                         </div>

--- a/frontend-react/src/components/hosts/SortableHostCard.jsx
+++ b/frontend-react/src/components/hosts/SortableHostCard.jsx
@@ -4,6 +4,8 @@ import { CSS } from '@dnd-kit/utilities';
 import { motion } from 'framer-motion';
 import { GripVertical } from 'lucide-react';
 
+const MotionDiv = motion.div;
+
 export default function SortableHostCard({ id, children }) {
     const {
         attributes,
@@ -20,7 +22,7 @@ export default function SortableHostCard({ id, children }) {
     };
 
     return (
-        <motion.div
+        <MotionDiv
             ref={setNodeRef}
             style={style}
             layout={!isDragging}
@@ -28,7 +30,7 @@ export default function SortableHostCard({ id, children }) {
             className={isDragging ? 'host-card-dragging' : ''}
         >
             {children({ dragHandleProps: { attributes, listeners } })}
-        </motion.div>
+        </MotionDiv>
     );
 }
 

--- a/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
+++ b/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Dialog, DialogBackdrop } from '@headlessui/react';
-import { X, LoaderCircle, Zap, AlertTriangle, Settings, Code2, LayoutGrid, Save, FolderOpen, RotateCw } from 'lucide-react';
+import { X, LoaderCircle, Zap, AlertTriangle, Settings, Code2, LayoutGrid, Save, FolderOpen, RotateCw, Webhook } from 'lucide-react';
 import { json, jsonParseLinter } from '@codemirror/lang-json';
 import { python } from '@codemirror/lang-python';
 import { getInstanceConfig, updateInstanceConfig, getInstanceById, getPresets, getPresetById, createPreset, getFactoryTree, getFactoryContent } from '../../services/api';
@@ -17,6 +17,7 @@ import { qlmappoolLanguage } from '../../codemirror-lang-qlmappool';
 import { qlaccessLanguage } from '../../codemirror-lang-qlaccess';
 import { qlworkshopLanguage } from '../../codemirror-lang-qlworkshop';
 import { qlentLanguage, qlentLinter } from '../../codemirror-lang-qlent';
+import HooksTab from './HooksTab';
 import {
   canEnableLanRate,
   getLanRateUnsupportedReason,
@@ -64,6 +65,7 @@ function EditInstanceConfigModal({
   instanceId,
   instanceName: initialInstanceName, // Rename prop to avoid conflict
   onConfigSaved,
+  initialTab = 'config',
 }) {
   const [currentInstanceName, setCurrentInstanceName] = useState(initialInstanceName || '');
   const [originalInstanceName, setOriginalInstanceName] = useState(initialInstanceName || '');
@@ -118,7 +120,7 @@ function EditInstanceConfigModal({
   const [isSavingPreset, setIsSavingPreset] = useState(false);
 
   // Scripts tab state
-  const [activeMainTab, setActiveMainTab] = useState('config'); // 'config' | 'scripts' | 'factories'
+  const [activeMainTab, setActiveMainTab] = useState(initialTab); // 'config' | 'scripts' | 'factories' | 'hooks'
   const [checkedPlugins, setCheckedPlugins] = useState(new Set());
   const [initialCheckedPlugins, setInitialCheckedPlugins] = useState(new Set());
   const [scriptHostName, setScriptHostName] = useState(null);
@@ -253,7 +255,7 @@ function EditInstanceConfigModal({
         setSaveError(null);
         setSelectedPresetId(''); // Reset preset selection
         // Reset scripts state
-        setActiveMainTab('config');
+        setActiveMainTab(initialTab);
         setScriptHostName(null);
         setDraftPreset(null);
         pluginsSyncedRef.current = false;
@@ -327,7 +329,7 @@ function EditInstanceConfigModal({
       };
       fetchInitialData();
     }
-  }, [isOpen, instanceId, initialInstanceName, resetConfigs, resetFactories]);
+  }, [isOpen, instanceId, initialInstanceName, initialTab, resetConfigs, resetFactories]);
 
   // Sync effect: Update serverHostname when server.cfg changes (unless it's an internal update)
   useEffect(() => {
@@ -565,6 +567,13 @@ function EditInstanceConfigModal({
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleHooksApplied = () => {
+    showSuccess('LD_PRELOAD hooks saved. Apply task queued.');
+    onConfigSaved?.();
+    setIsDirty(false);
+    onClose();
   };
 
   const handleExpandEditor = (selectedFile, content = '') => {
@@ -821,6 +830,7 @@ function EditInstanceConfigModal({
                             { key: 'config', icon: Settings, label: 'Configuration Files' },
                             { key: 'scripts', icon: Code2, label: 'Plugins' },
                             { key: 'factories', icon: LayoutGrid, label: 'Factories' },
+                            { key: 'hooks', icon: Webhook, label: 'Hooks' },
                           ].map((tab) => (
                             <button
                               key={tab.key}
@@ -879,8 +889,12 @@ function EditInstanceConfigModal({
                               getLinterSourceForFile={getFactoryLinterSource}
                             />
                           </div>
+                          <div className={activeMainTab === 'hooks' ? 'flex-1 min-h-0' : 'hidden'}>
+                            <HooksTab instanceId={instanceId} onApplied={handleHooksApplied} />
+                          </div>
                         </div>
 
+                        {activeMainTab !== 'hooks' && (
                         <div className="mt-4 flex justify-between items-center flex-shrink-0">
                           {/* Left side - Preset management buttons */}
                           <div className="flex gap-2">
@@ -917,6 +931,7 @@ function EditInstanceConfigModal({
                             </button>
                           </div>
                         </div>
+                        )}
                       </form>
                     )}
                   </div>

--- a/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
+++ b/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
@@ -890,7 +890,7 @@ function EditInstanceConfigModal({
                             />
                           </div>
                           <div className={activeMainTab === 'hooks' ? 'flex-1 min-h-0' : 'hidden'}>
-                            <HooksTab instanceId={instanceId} onApplied={handleHooksApplied} />
+                            <HooksTab instanceId={instanceId} draftId={pluginDraftId} onApplied={handleHooksApplied} />
                           </div>
                         </div>
 

--- a/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
+++ b/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
@@ -889,9 +889,11 @@ function EditInstanceConfigModal({
                               getLinterSourceForFile={getFactoryLinterSource}
                             />
                           </div>
-                          <div className={activeMainTab === 'hooks' ? 'flex-1 min-h-0' : 'hidden'}>
-                            <HooksTab instanceId={instanceId} draftId={pluginDraftId} onApplied={handleHooksApplied} />
-                          </div>
+                          {activeMainTab === 'hooks' && (
+                            <div className="flex-1 min-h-0">
+                              <HooksTab instanceId={instanceId} draftId={pluginDraftId} onApplied={handleHooksApplied} />
+                            </div>
+                          )}
                         </div>
 
                         {activeMainTab !== 'hooks' && (

--- a/frontend-react/src/components/instances/HookRow.jsx
+++ b/frontend-react/src/components/instances/HookRow.jsx
@@ -32,16 +32,11 @@ function HookRowContent({ hook, onToggle, dragHandleProps = null, style = undefi
         type="checkbox"
         checked={hook.enabled}
         onChange={() => onToggle(hook.filename)}
-        disabled={hook.committed === false}
-        className="h-4 w-4 cursor-pointer disabled:cursor-not-allowed disabled:opacity-40"
+        className="h-4 w-4 cursor-pointer"
         aria-label={`Enable ${hook.filename}`}
-        title={hook.committed === false ? 'Save your configuration first to enable this file' : undefined}
       />
-      <span className={`min-w-0 flex-1 truncate font-mono text-sm ${hook.committed === false ? 'text-[var(--text-muted)]' : 'text-[var(--text-primary)]'}`}>
+      <span className="min-w-0 flex-1 truncate font-mono text-sm text-[var(--text-primary)]">
         {hook.filename}
-        {hook.committed === false && (
-          <span className="ml-2 font-sans text-[10px] font-medium uppercase tracking-wide text-[var(--text-muted)]">unsaved</span>
-        )}
       </span>
       <span className="w-20 text-right font-mono text-xs text-[var(--text-muted)]">
         {formatSize(hook.size)}

--- a/frontend-react/src/components/instances/HookRow.jsx
+++ b/frontend-react/src/components/instances/HookRow.jsx
@@ -1,0 +1,78 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical, Info } from 'lucide-react';
+
+function formatSize(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function HookRowContent({ hook, onToggle, dragHandleProps = null, style = undefined }) {
+  return (
+    <div
+      style={style}
+      className="flex min-h-10 items-center gap-3 border-b border-[var(--surface-border)] px-3 py-2 hover:bg-[var(--surface-hover)]"
+      data-testid={`hook-row-${hook.filename}`}
+    >
+      {dragHandleProps ? (
+        <button
+          type="button"
+          {...dragHandleProps.attributes}
+          {...dragHandleProps.listeners}
+          className="flex h-7 w-7 items-center justify-center rounded text-[var(--text-muted)] hover:bg-[var(--surface-elevated)]"
+          aria-label={`Reorder ${hook.filename}`}
+        >
+          <GripVertical size={16} />
+        </button>
+      ) : (
+        <span className="h-7 w-7" />
+      )}
+      <input
+        type="checkbox"
+        checked={hook.enabled}
+        onChange={() => onToggle(hook.filename)}
+        className="h-4 w-4 cursor-pointer"
+        aria-label={`Enable ${hook.filename}`}
+      />
+      <span className="min-w-0 flex-1 truncate font-mono text-sm text-[var(--text-primary)]">
+        {hook.filename}
+      </span>
+      <span className="w-20 text-right font-mono text-xs text-[var(--text-muted)]">
+        {formatSize(hook.size)}
+      </span>
+      {hook.description ? (
+        <span title={hook.description} className="text-[var(--text-muted)]">
+          <Info size={14} />
+        </span>
+      ) : (
+        <span className="w-3.5" />
+      )}
+    </div>
+  );
+}
+
+export function SortableHookRow({ hook, onToggle }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: hook.filename,
+  });
+  const style = {
+    opacity: isDragging ? 0.6 : 1,
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div ref={setNodeRef}>
+      <HookRowContent
+        hook={hook}
+        onToggle={onToggle}
+        dragHandleProps={{ attributes, listeners }}
+        style={style}
+      />
+    </div>
+  );
+}
+
+export default function HookRow({ hook, onToggle }) {
+  return <HookRowContent hook={hook} onToggle={onToggle} />;
+}

--- a/frontend-react/src/components/instances/HookRow.jsx
+++ b/frontend-react/src/components/instances/HookRow.jsx
@@ -32,11 +32,16 @@ function HookRowContent({ hook, onToggle, dragHandleProps = null, style = undefi
         type="checkbox"
         checked={hook.enabled}
         onChange={() => onToggle(hook.filename)}
-        className="h-4 w-4 cursor-pointer"
+        disabled={hook.committed === false}
+        className="h-4 w-4 cursor-pointer disabled:cursor-not-allowed disabled:opacity-40"
         aria-label={`Enable ${hook.filename}`}
+        title={hook.committed === false ? 'Save your configuration first to enable this file' : undefined}
       />
-      <span className="min-w-0 flex-1 truncate font-mono text-sm text-[var(--text-primary)]">
+      <span className={`min-w-0 flex-1 truncate font-mono text-sm ${hook.committed === false ? 'text-[var(--text-muted)]' : 'text-[var(--text-primary)]'}`}>
         {hook.filename}
+        {hook.committed === false && (
+          <span className="ml-2 font-sans text-[10px] font-medium uppercase tracking-wide text-[var(--text-muted)]">unsaved</span>
+        )}
       </span>
       <span className="w-20 text-right font-mono text-xs text-[var(--text-muted)]">
         {formatSize(hook.size)}

--- a/frontend-react/src/components/instances/HooksTab.jsx
+++ b/frontend-react/src/components/instances/HooksTab.jsx
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useState } from 'react';
+import { closestCenter, DndContext } from '@dnd-kit/core';
+import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { fetchInstanceHooks, saveInstanceHooks } from '../../services/api';
+import HookRow, { SortableHookRow } from './HookRow';
+
+function errorMessage(error, fallback) {
+  return error?.error?.message || error?.message || fallback;
+}
+
+export default function HooksTab({ instanceId, onApplied }) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [available, setAvailable] = useState([]);
+  const [enabledOrder, setEnabledOrder] = useState([]);
+  const [initialEnabled, setInitialEnabled] = useState([]);
+  const [systemHooks, setSystemHooks] = useState([]);
+  const [applying, setApplying] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchInstanceHooks(instanceId)
+      .then((data) => {
+        if (cancelled) return;
+        const enabled = [...(data.available || [])]
+          .filter((hook) => hook.enabled)
+          .sort((a, b) => a.order - b.order)
+          .map((hook) => hook.filename);
+        setAvailable(data.available || []);
+        setEnabledOrder(enabled);
+        setInitialEnabled(enabled);
+        setSystemHooks(data.system_hooks_active || []);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(errorMessage(err, 'Failed to load hooks.'));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [instanceId]);
+
+  const enabledSet = useMemo(() => new Set(enabledOrder), [enabledOrder]);
+  const enabledRows = useMemo(
+    () => enabledOrder
+      .map((filename) => available.find((hook) => hook.filename === filename))
+      .filter(Boolean)
+      .map((hook) => ({ ...hook, enabled: true })),
+    [available, enabledOrder],
+  );
+  const disabledRows = useMemo(
+    () => available
+      .filter((hook) => !enabledSet.has(hook.filename))
+      .map((hook) => ({ ...hook, enabled: false, order: null }))
+      .sort((a, b) => a.filename.localeCompare(b.filename)),
+    [available, enabledSet],
+  );
+  const dirty = useMemo(
+    () => enabledOrder.length !== initialEnabled.length
+      || enabledOrder.some((filename, index) => initialEnabled[index] !== filename),
+    [enabledOrder, initialEnabled],
+  );
+
+  const toggleHook = (filename) => {
+    setEnabledOrder((current) => (
+      current.includes(filename)
+        ? current.filter((item) => item !== filename)
+        : [...current, filename]
+    ));
+  };
+
+  const handleDragEnd = ({ active, over }) => {
+    if (!over || active.id === over.id) return;
+    setEnabledOrder((current) => {
+      const oldIndex = current.indexOf(active.id);
+      const newIndex = current.indexOf(over.id);
+      if (oldIndex === -1 || newIndex === -1) return current;
+      return arrayMove(current, oldIndex, newIndex);
+    });
+  };
+
+  const handleCancel = () => {
+    setEnabledOrder(initialEnabled);
+    setError(null);
+  };
+
+  const handleApply = async () => {
+    setApplying(true);
+    setError(null);
+    try {
+      await saveInstanceHooks(instanceId, enabledOrder);
+      setInitialEnabled(enabledOrder);
+      onApplied?.();
+    } catch (err) {
+      setError(errorMessage(err, 'Failed to save hooks.'));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="p-4 text-sm text-[var(--text-muted)]">Loading hooks...</div>;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {error && (
+        <div className="border-b border-[var(--surface-border)] px-4 py-2 text-sm text-theme-danger">
+          {error}
+        </div>
+      )}
+      {systemHooks.length > 0 && (
+        <div className="border-b border-[var(--surface-border)] px-4 py-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+            System hooks
+          </h3>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {systemHooks.map((name) => (
+              <span key={name} className="rounded border border-[var(--surface-border)] px-2 py-1 font-mono text-xs">
+                {name}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="border-b border-[var(--surface-border)] px-4 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+          User hooks
+        </div>
+        <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={enabledOrder} strategy={verticalListSortingStrategy}>
+            {enabledRows.map((hook) => (
+              <SortableHookRow key={hook.filename} hook={hook} onToggle={toggleHook} />
+            ))}
+          </SortableContext>
+        </DndContext>
+        {disabledRows.map((hook) => (
+          <HookRow key={hook.filename} hook={hook} onToggle={toggleHook} />
+        ))}
+        {available.length === 0 && (
+          <div className="px-4 py-8 text-sm text-[var(--text-muted)]">
+            No shared objects found in scripts.
+          </div>
+        )}
+      </div>
+      <div className="flex justify-end gap-2 border-t border-[var(--surface-border)] px-4 py-3">
+        <button
+          type="button"
+          onClick={handleCancel}
+          disabled={!dirty || applying}
+          className="btn btn-secondary"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleApply}
+          disabled={!dirty || applying}
+          className="btn btn-primary"
+        >
+          {applying ? 'Applying...' : 'Apply & Restart'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend-react/src/components/instances/HooksTab.jsx
+++ b/frontend-react/src/components/instances/HooksTab.jsx
@@ -8,7 +8,7 @@ function errorMessage(error, fallback) {
   return error?.error?.message || error?.message || fallback;
 }
 
-export default function HooksTab({ instanceId, onApplied }) {
+export default function HooksTab({ instanceId, draftId, onApplied }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [available, setAvailable] = useState([]);
@@ -21,7 +21,7 @@ export default function HooksTab({ instanceId, onApplied }) {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    fetchInstanceHooks(instanceId)
+    fetchInstanceHooks(instanceId, draftId)
       .then((data) => {
         if (cancelled) return;
         const enabled = [...(data.available || [])]
@@ -42,7 +42,7 @@ export default function HooksTab({ instanceId, onApplied }) {
     return () => {
       cancelled = true;
     };
-  }, [instanceId]);
+  }, [instanceId, draftId]);
 
   const enabledSet = useMemo(() => new Set(enabledOrder), [enabledOrder]);
   const enabledRows = useMemo(

--- a/frontend-react/src/components/instances/HooksTab.jsx
+++ b/frontend-react/src/components/instances/HooksTab.jsx
@@ -92,7 +92,7 @@ export default function HooksTab({ instanceId, draftId, onApplied }) {
     setApplying(true);
     setError(null);
     try {
-      await saveInstanceHooks(instanceId, enabledOrder);
+      await saveInstanceHooks(instanceId, enabledOrder, draftId);
       setInitialEnabled(enabledOrder);
       onApplied?.();
     } catch (err) {

--- a/frontend-react/src/components/instances/InstanceDetailsModal.jsx
+++ b/frontend-react/src/components/instances/InstanceDetailsModal.jsx
@@ -357,15 +357,18 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
                             const hooks = instance.ld_preload_hooks
                               ?.split(',').map(h => h.trim()).filter(Boolean) ?? [];
                             return hooks.length > 0 ? (
-                              <span className="flex items-center gap-2 flex-wrap">
-                                <span className="flex items-center gap-1 font-mono text-xs text-theme-secondary">
-                                  <Webhook size={12} className="shrink-0" />
-                                  {hooks.join(', ')}
-                                </span>
+                              <span className="flex flex-col gap-1">
+                                {hooks.map((hook, i) => (
+                                  <span key={hook} className="flex items-center gap-1.5 font-mono text-xs text-theme-secondary">
+                                    <span className="text-[var(--text-muted)] w-4 text-right shrink-0">{i + 1}.</span>
+                                    <Webhook size={12} className="shrink-0" />
+                                    {hook}
+                                  </span>
+                                ))}
                                 <button
                                   type="button"
                                   onClick={() => { onOpenEditConfig(instance, 'hooks'); onClose(); }}
-                                  className="text-[11px] text-[var(--accent-primary)] hover:underline"
+                                  className="text-[11px] text-[var(--accent-primary)] hover:underline self-start mt-0.5"
                                 >
                                   Manage
                                 </button>

--- a/frontend-react/src/components/instances/InstanceDetailsModal.jsx
+++ b/frontend-react/src/components/instances/InstanceDetailsModal.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useState, useEffect, useCallback, useRef } from 'react';
 import { getInstanceById, restartInstance, stopInstance, startInstance, deleteInstance, updateInstanceLanRate, updateInstance } from '../../services/api';
 import { Transition } from '@headlessui/react';
-import { X, RefreshCw, Trash2, Edit3, Play, Square, Copy, Check, Pencil, LoaderCircle, Users } from 'lucide-react';
+import { X, RefreshCw, Trash2, Edit3, Play, Square, Copy, Check, Pencil, LoaderCircle, Users, Webhook } from 'lucide-react';
 import ConfirmationModal from '../ConfirmationModal';
 import { useNotification } from '../NotificationProvider';
 import { formatDateTime } from '../../utils/uiUtils';
@@ -351,6 +351,38 @@ function InstanceDetailsModal({ instanceId, isOpen, onClose, onInstanceDeleted, 
                               </span>
                             </div>
                           </div>
+                        </Field>
+                        <Field label="LD_PRELOAD Hooks">
+                          {(() => {
+                            const hooks = instance.ld_preload_hooks
+                              ?.split(',').map(h => h.trim()).filter(Boolean) ?? [];
+                            return hooks.length > 0 ? (
+                              <span className="flex items-center gap-2 flex-wrap">
+                                <span className="flex items-center gap-1 font-mono text-xs text-theme-secondary">
+                                  <Webhook size={12} className="shrink-0" />
+                                  {hooks.join(', ')}
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={() => { onOpenEditConfig(instance, 'hooks'); onClose(); }}
+                                  className="text-[11px] text-[var(--accent-primary)] hover:underline"
+                                >
+                                  Manage
+                                </button>
+                              </span>
+                            ) : (
+                              <span className="flex items-center gap-2">
+                                <span className="text-theme-muted">None</span>
+                                <button
+                                  type="button"
+                                  onClick={() => { onOpenEditConfig(instance, 'hooks'); onClose(); }}
+                                  className="text-[11px] text-[var(--accent-primary)] hover:underline"
+                                >
+                                  Manage
+                                </button>
+                              </span>
+                            );
+                          })()}
                         </Field>
                         <Field label="Created">{formatDateTime(instance.created_at)}</Field>
                         {instance.updated_at && <Field label="Updated">{formatDateTime(instance.updated_at)}</Field>}

--- a/frontend-react/src/components/instances/InstanceRowContent.jsx
+++ b/frontend-react/src/components/instances/InstanceRowContent.jsx
@@ -1,4 +1,4 @@
-import { Webhook, Zap, Users } from 'lucide-react';
+import { Zap, Users } from 'lucide-react';
 import StatusIndicator from '../StatusIndicator';
 import InstanceActionsMenu from '../InstanceActionsMenu';
 
@@ -15,16 +15,10 @@ export default function InstanceRowContent({
     onStart,
     onToggleLanRate,
     onEditConfig,
-    onOpenHooks,
     onViewLogs,
     onViewChatLogs,
     onOpenRcon,
 }) {
-    const hookCount = inst.ld_preload_hooks
-        ?.split(',')
-        .map((name) => name.trim())
-        .filter(Boolean).length || 0;
-
     return (
         <>
             <button
@@ -75,18 +69,6 @@ export default function InstanceRowContent({
                     status={inst.status}
                     pollableStatuses={pollableStatuses}
                 />
-                {hookCount > 0 && (
-                    <button
-                        type="button"
-                        onClick={() => onOpenHooks(inst)}
-                        className="inline-flex items-center gap-1 rounded border border-theme-strong bg-theme-elevated px-1.5 py-0.5 text-[10px] font-semibold text-theme-secondary hover:text-theme-primary"
-                        title="LD_PRELOAD hooks enabled"
-                        aria-label="Open LD_PRELOAD hooks"
-                    >
-                        <Webhook size={12} />
-                        {hookCount}
-                    </button>
-                )}
                 {['running', 'updated'].includes(
                     inst.status?.toLowerCase()
                 ) &&

--- a/frontend-react/src/components/instances/InstanceRowContent.jsx
+++ b/frontend-react/src/components/instances/InstanceRowContent.jsx
@@ -1,4 +1,4 @@
-import { Zap, Users } from 'lucide-react';
+import { Webhook, Zap, Users } from 'lucide-react';
 import StatusIndicator from '../StatusIndicator';
 import InstanceActionsMenu from '../InstanceActionsMenu';
 
@@ -15,10 +15,16 @@ export default function InstanceRowContent({
     onStart,
     onToggleLanRate,
     onEditConfig,
+    onOpenHooks,
     onViewLogs,
     onViewChatLogs,
     onOpenRcon,
 }) {
+    const hookCount = inst.ld_preload_hooks
+        ?.split(',')
+        .map((name) => name.trim())
+        .filter(Boolean).length || 0;
+
     return (
         <>
             <button
@@ -69,6 +75,18 @@ export default function InstanceRowContent({
                     status={inst.status}
                     pollableStatuses={pollableStatuses}
                 />
+                {hookCount > 0 && (
+                    <button
+                        type="button"
+                        onClick={() => onOpenHooks(inst)}
+                        className="inline-flex items-center gap-1 rounded border border-theme-strong bg-theme-elevated px-1.5 py-0.5 text-[10px] font-semibold text-theme-secondary hover:text-theme-primary"
+                        title="LD_PRELOAD hooks enabled"
+                        aria-label="Open LD_PRELOAD hooks"
+                    >
+                        <Webhook size={12} />
+                        {hookCount}
+                    </button>
+                )}
                 {['running', 'updated'].includes(
                     inst.status?.toLowerCase()
                 ) &&

--- a/frontend-react/src/components/instances/SortableInstanceRow.jsx
+++ b/frontend-react/src/components/instances/SortableInstanceRow.jsx
@@ -3,6 +3,8 @@ import { CSS } from '@dnd-kit/utilities';
 import { motion } from 'framer-motion';
 import { GripVertical } from 'lucide-react';
 
+const MotionDiv = motion.div;
+
 export default function SortableInstanceRow({ id, children }) {
     const {
         attributes,
@@ -19,7 +21,7 @@ export default function SortableInstanceRow({ id, children }) {
     };
 
     return (
-        <motion.div
+        <MotionDiv
             ref={setNodeRef}
             style={style}
             layout
@@ -36,7 +38,7 @@ export default function SortableInstanceRow({ id, children }) {
                 </div>
                 {children}
             </div>
-        </motion.div>
+        </MotionDiv>
     );
 }
 

--- a/frontend-react/src/components/instances/ViewChatLogsModal.jsx
+++ b/frontend-react/src/components/instances/ViewChatLogsModal.jsx
@@ -1,6 +1,6 @@
-import React, { Fragment, useState, useEffect, useRef } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 import { Dialog, DialogBackdrop, Transition, Listbox } from '@headlessui/react';
-import { X, RefreshCw, Download, Search, Settings, ChevronDown, Check, FileText, Terminal, AlertCircle } from 'lucide-react';
+import { X, RefreshCw, ChevronDown, Check, FileText, Terminal, AlertCircle } from 'lucide-react';
 import CodeMirrorEditor from '../CodeMirrorEditor';
 import { chatLogLanguage } from '../../utils/chatLogLanguage';
 import { fetchInstanceChatLogs, listInstanceChatLogs } from '../../services/api';
@@ -19,18 +19,12 @@ function ViewChatLogsModal({ isOpen, onClose, instance }) {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState(null);
 
-    // Filter state
     const [lineCount, setLineCount] = useState(500);
-    const [searchTerm, setSearchTerm] = useState('');
-    const [searchMatches, setSearchMatches] = useState([]);
-    const [currentMatchIndex, setCurrentMatchIndex] = useState(-1);
 
     // Archived logs state
     const [availableFiles, setAvailableFiles] = useState(['chat.log']);
     const [selectedFile, setSelectedFile] = useState('chat.log');
     const [isLoadingFiles, setIsLoadingFiles] = useState(false);
-
-    const editorRef = useRef(null);
 
     // Fetch logs when modal opens or filter changes
     const fetchLogs = async () => {
@@ -101,9 +95,6 @@ function ViewChatLogsModal({ isOpen, onClose, instance }) {
         if (isOpen && instance?.id) {
             setLogs('');
             setError(null);
-            setSearchTerm('');
-            setSearchMatches([]);
-            setCurrentMatchIndex(-1);
             fetchLogFiles();
         } else {
             // Reset state when modal closes

--- a/frontend-react/src/components/instances/__tests__/EditInstanceConfigModal.test.jsx
+++ b/frontend-react/src/components/instances/__tests__/EditInstanceConfigModal.test.jsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   saveBinaryMeta: vi.fn(),
   showError: vi.fn(),
   showSuccess: vi.fn(),
+  hooksTabProps: [],
   updateInstance: vi.fn(),
   updateInstanceConfig: vi.fn(),
   fileManagerProps: [],
@@ -94,6 +95,20 @@ vi.mock('../../common/InfoTooltip', () => ({
   default: ({ text }) => <span data-testid="info-tooltip">{text}</span>,
 }));
 
+vi.mock('../HooksTab', () => ({
+  default: (props) => {
+    mocks.hooksTabProps.push(props);
+    return (
+      <div>
+        <div>hooks-tab</div>
+        <button type="button" onClick={() => props.onApplied?.()}>
+          Mock Apply Hooks
+        </button>
+      </div>
+    );
+  },
+}));
+
 vi.mock('../../fileManager', () => ({
   CONFIG_CAPS: {
     allowedExtensions: ['.cfg', '.txt', '.ent'],
@@ -170,6 +185,7 @@ describe('EditInstanceConfigModal preset saving', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mocks.fileManagerProps = [];
+    mocks.hooksTabProps = [];
     if (!EditInstanceConfigModal) {
       ({ default: EditInstanceConfigModal } = await import('../EditInstanceConfigModal'));
     }
@@ -436,5 +452,31 @@ describe('EditInstanceConfigModal preset saving', () => {
     expect(factoryManagerProps.getLanguageForFile('readme.txt')).toBeNull();
     expect(factoryManagerProps.getLinterSourceForFile('readme.txt')).toBeNull();
     expect(factoryManagerProps.onExpandEditor).toEqual(expect.any(Function));
+  });
+
+  it('opens on the hooks tab and closes after hook apply', async () => {
+    const onClose = vi.fn();
+    const onConfigSaved = vi.fn();
+
+    render(
+      <EditInstanceConfigModal
+        isOpen={true}
+        onClose={onClose}
+        instanceId={1}
+        instanceName="Test123"
+        onConfigSaved={onConfigSaved}
+        initialTab="hooks"
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText('hooks-tab')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /^hooks$/i })).toHaveClass('text-[var(--accent-primary)]');
+
+    fireEvent.click(screen.getByRole('button', { name: /mock apply hooks/i }));
+
+    expect(mocks.showSuccess).toHaveBeenCalledWith('LD_PRELOAD hooks saved. Apply task queued.');
+    expect(onConfigSaved).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+    expect(mocks.hooksTabProps.at(-1).instanceId).toBe(1);
   });
 });

--- a/frontend-react/src/components/instances/__tests__/HooksTab.test.jsx
+++ b/frontend-react/src/components/instances/__tests__/HooksTab.test.jsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import HooksTab from '../HooksTab';
+import * as api from '../../../services/api';
+
+vi.mock('../../../services/api');
+
+function hooksResponse(overrides = {}) {
+  return {
+    available: [
+      { filename: 'a.so', size: 1024, modified: 1, enabled: true, order: 1, description: 'Speed hook' },
+      { filename: 'b.so', size: 2048, modified: 1, enabled: true, order: 2, description: '' },
+      { filename: 'c.so', size: 3072, modified: 1, enabled: false, order: null, description: '' },
+    ],
+    system_hooks_active: [],
+    ...overrides,
+  };
+}
+
+describe('HooksTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.fetchInstanceHooks.mockResolvedValue(hooksResponse());
+    api.saveInstanceHooks.mockResolvedValue({ task_id: 't1' });
+  });
+
+  it('renders user hooks with enabled state and order', async () => {
+    render(<HooksTab instanceId={1} />);
+
+    await waitFor(() => expect(screen.getByTestId('hook-row-a.so')).toBeInTheDocument());
+    expect(screen.getByRole('checkbox', { name: /enable a.so/i })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /enable c.so/i })).not.toBeChecked();
+  });
+
+  it('hides system hooks section when system_hooks_active is empty', async () => {
+    render(<HooksTab instanceId={1} />);
+
+    await waitFor(() => screen.getByTestId('hook-row-a.so'));
+    expect(screen.queryByText(/system hooks/i)).not.toBeInTheDocument();
+  });
+
+  it('shows system hooks section when non-empty', async () => {
+    api.fetchInstanceHooks.mockResolvedValueOnce(hooksResponse({
+      system_hooks_active: ['force_rate.so'],
+    }));
+
+    render(<HooksTab instanceId={1} />);
+
+    await waitFor(() => expect(screen.getByText(/system hooks/i)).toBeInTheDocument());
+    expect(screen.getByText('force_rate.so')).toBeInTheDocument();
+  });
+
+  it('toggling a checkbox marks the form dirty and enables Apply', async () => {
+    render(<HooksTab instanceId={1} />);
+
+    await waitFor(() => screen.getByTestId('hook-row-a.so'));
+    const apply = screen.getByRole('button', { name: /apply.*restart/i });
+    expect(apply).toBeDisabled();
+    fireEvent.click(screen.getByRole('checkbox', { name: /enable c.so/i }));
+    expect(apply).toBeEnabled();
+  });
+
+  it('Apply sends the enabled list in display order', async () => {
+    render(<HooksTab instanceId={1} />);
+
+    await waitFor(() => screen.getByTestId('hook-row-a.so'));
+    fireEvent.click(screen.getByRole('checkbox', { name: /enable c.so/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply.*restart/i }));
+
+    await waitFor(() => expect(api.saveInstanceHooks).toHaveBeenCalled());
+    expect(api.saveInstanceHooks).toHaveBeenCalledWith(1, ['a.so', 'b.so', 'c.so']);
+  });
+
+  it('renders hook descriptions from GET data as tooltips', async () => {
+    render(<HooksTab instanceId={1} />);
+
+    await waitFor(() => screen.getByTestId('hook-row-a.so'));
+    expect(screen.getByTitle('Speed hook')).toBeInTheDocument();
+  });
+
+  it('calls onApplied after a successful save', async () => {
+    const onApplied = vi.fn();
+    render(<HooksTab instanceId={1} onApplied={onApplied} />);
+
+    await waitFor(() => screen.getByTestId('hook-row-a.so'));
+    fireEvent.click(screen.getByRole('checkbox', { name: /enable c.so/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply.*restart/i }));
+
+    await waitFor(() => expect(onApplied).toHaveBeenCalled());
+  });
+});

--- a/frontend-react/src/components/instances/__tests__/InstanceRowContent.test.jsx
+++ b/frontend-react/src/components/instances/__tests__/InstanceRowContent.test.jsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import InstanceRowContent from '../InstanceRowContent';
+
+vi.mock('../../StatusIndicator', () => ({
+  default: ({ status }) => <span>{status}</span>,
+}));
+
+vi.mock('../../InstanceActionsMenu', () => ({
+  default: () => <button type="button">Actions</button>,
+}));
+
+function renderRow(overrides = {}) {
+  const props = {
+    inst: {
+      id: 1,
+      name: 'Inst',
+      hostname: 'Host',
+      port: 27960,
+      status: 'running',
+      lan_rate_enabled: false,
+      ld_preload_hooks: 'a.so,b.so',
+      ...overrides.inst,
+    },
+    host: { id: 1, ip_address: '203.0.113.1', os_type: 'debian' },
+    pollableStatuses: [],
+    serverStatus: null,
+    onOpenDetails: vi.fn(),
+    onOpenLiveStatus: vi.fn(),
+    onRestart: vi.fn(),
+    onDelete: vi.fn(),
+    onStop: vi.fn(),
+    onStart: vi.fn(),
+    onToggleLanRate: vi.fn(),
+    onEditConfig: vi.fn(),
+    onOpenHooks: vi.fn(),
+    onViewLogs: vi.fn(),
+    onViewChatLogs: vi.fn(),
+    onOpenRcon: vi.fn(),
+  };
+  render(<InstanceRowContent {...props} />);
+  return props;
+}
+
+describe('InstanceRowContent', () => {
+  it('opens Hooks from the hook badge', () => {
+    const props = renderRow();
+
+    fireEvent.click(screen.getByRole('button', { name: /open ld_preload hooks/i }));
+
+    expect(props.onOpenHooks).toHaveBeenCalledWith(props.inst);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('hides the hook badge when no hooks are enabled', () => {
+    renderRow({ inst: { ld_preload_hooks: null } });
+
+    expect(screen.queryByRole('button', { name: /open ld_preload hooks/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend-react/src/hooks/useHostAutoRestart.js
+++ b/frontend-react/src/hooks/useHostAutoRestart.js
@@ -12,6 +12,7 @@ export function useHostAutoRestart(showSuccess, showError, onSuccess) {
 
     const closeAutoRestartModal = useCallback(() => {
         setIsAutoRestartModalOpen(false);
+        setHostForAutoRestart(null);
     }, []);
 
     const handleAutoRestartSubmit = useCallback(async (hostId, scheduleStr) => {

--- a/frontend-react/src/hooks/useServers.js
+++ b/frontend-react/src/hooks/useServers.js
@@ -17,8 +17,6 @@ export function useServers() {
         isDeleteModalOpen: isHostDeleteModalOpen,
         selectedHost,
         closeDeleteModal: closeHostDeleteModal,
-        // Host specific actions
-        handleDeleteRequest: requestDeleteHostAction,
     } = useHosts();
 
     const {

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -141,7 +141,6 @@ export default function ServersPage() {
         setEditConfigInitialTab(initialTab);
         setIsEditConfigOpen(true);
     };
-    const handleOpenInstanceHooks = (instance) => handleOpenEditConfig(instance, 'hooks');
     const handleOpenLiveStatus = (instanceId) => {
         const host = serversData.find(h => h.instances.some(i => i.id === instanceId));
         if (host) {
@@ -326,7 +325,6 @@ export default function ServersPage() {
                                                 onStart={requestStart}
                                                 onToggleLanRate={requestToggleLanRate}
                                                 onEditConfig={handleOpenEditConfig}
-                                                onOpenHooks={handleOpenInstanceHooks}
                                                 onViewLogs={handleViewLogs}
                                                 onViewChatLogs={handleViewChatLogs}
                                                 onOpenRcon={handleOpenRconConsole}

--- a/frontend-react/src/pages/ServersPage.jsx
+++ b/frontend-react/src/pages/ServersPage.jsx
@@ -60,6 +60,7 @@ export default function ServersPage() {
     const [isInstanceDetailsOpen, setIsInstanceDetailsOpen] = useState(false);
     const [isEditConfigOpen, setIsEditConfigOpen] = useState(false);
     const [selectedInstanceForConfig, setSelectedInstanceForConfig] = useState(null);
+    const [editConfigInitialTab, setEditConfigInitialTab] = useState('config');
     const [copiedIp, setCopiedIp] = useState(null);
     const [isLiveStatusOpen, setIsLiveStatusOpen] = useState(false);
     const [selectedLiveStatusInstance, setSelectedLiveStatusInstance] = useState(null);
@@ -135,7 +136,12 @@ export default function ServersPage() {
 
     const handleOpenHostDrawer = (hostId) => { setIsInstanceDetailsOpen(false); setSelectedInstanceId(null); setSelectedHostId(hostId); setIsHostDrawerOpen(true); };
     const handleOpenInstanceDetails = (instanceId) => { setIsHostDrawerOpen(false); setSelectedHostId(null); setSelectedInstanceId(instanceId); setIsInstanceDetailsOpen(true); };
-    const handleOpenEditConfig = (instance) => { setSelectedInstanceForConfig(instance); setIsEditConfigOpen(true); };
+    const handleOpenEditConfig = (instance, initialTab = 'config') => {
+        setSelectedInstanceForConfig(instance);
+        setEditConfigInitialTab(initialTab);
+        setIsEditConfigOpen(true);
+    };
+    const handleOpenInstanceHooks = (instance) => handleOpenEditConfig(instance, 'hooks');
     const handleOpenLiveStatus = (instanceId) => {
         const host = serversData.find(h => h.instances.some(i => i.id === instanceId));
         if (host) {
@@ -320,6 +326,7 @@ export default function ServersPage() {
                                                 onStart={requestStart}
                                                 onToggleLanRate={requestToggleLanRate}
                                                 onEditConfig={handleOpenEditConfig}
+                                                onOpenHooks={handleOpenInstanceHooks}
                                                 onViewLogs={handleViewLogs}
                                                 onViewChatLogs={handleViewChatLogs}
                                                 onOpenRcon={handleOpenRconConsole}
@@ -357,7 +364,7 @@ export default function ServersPage() {
             <AddInstanceModal isOpen={isAddInstanceModalOpen} onClose={() => { setIsAddInstanceModalOpen(false); setAddInstanceModalHostId(null); }} onInstanceAdded={() => { setAddInstanceModalHostId(null); refreshData(false); }} initialHostId={addInstanceModalHostId} />
             <HostDetailDrawer host={currentHostForDrawer || selectedHostId} open={isHostDrawerOpen} onClose={() => setIsHostDrawerOpen(false)} onHostUpdated={() => refreshData(false)} onHostDeleted={() => refreshData(false)} onDeleteHost={(host) => requestDeleteHost({ id: host.id, name: host.name })} onRequestRestart={handleRequestHostRestart} onQlfilterAction={handleQlfilterAction} onSwitchToInstanceDrawer={(instanceId) => { setIsHostDrawerOpen(false); handleOpenInstanceDetails(instanceId); }} />
             <InstanceDetailsModal isOpen={isInstanceDetailsOpen} onClose={() => setIsInstanceDetailsOpen(false)} instanceId={selectedInstanceId} onInstanceDeleted={() => refreshData(false)} onInstanceUpdated={() => refreshData(false)} onOpenEditConfig={handleOpenEditConfig} onOpenHostDrawer={(hostId) => { setIsInstanceDetailsOpen(false); handleOpenHostDrawer(hostId); }} serverStatus={selectedInstanceId ? serverStatusMap[String(selectedInstanceId)] : null} />
-            <EditInstanceConfigModal isOpen={isEditConfigOpen} onClose={() => { setIsEditConfigOpen(false); setSelectedInstanceForConfig(null); }} instanceId={selectedInstanceForConfig?.id} instanceName={selectedInstanceForConfig?.name} onConfigSaved={() => { refreshData(false); setIsEditConfigOpen(false); setSelectedInstanceForConfig(null); }} />
+            <EditInstanceConfigModal isOpen={isEditConfigOpen} onClose={() => { setIsEditConfigOpen(false); setSelectedInstanceForConfig(null); setEditConfigInitialTab('config'); }} instanceId={selectedInstanceForConfig?.id} instanceName={selectedInstanceForConfig?.name} initialTab={editConfigInitialTab} onConfigSaved={() => { refreshData(false); setIsEditConfigOpen(false); setSelectedInstanceForConfig(null); setEditConfigInitialTab('config'); }} />
             <ConfirmationModal isOpen={isHostRestartModalOpen} onClose={closeHostRestartModal} onConfirm={confirmHostRestart} title={`Restart Host "${hostForRestart?.name}"`} message={`Are you sure you want to restart host "${hostForRestart?.name}"? This will temporarily make the host and its instances unavailable.`} confirmButtonText="Restart" confirmButtonVariant="warning" />
             <ViewLogsModal isOpen={isViewLogsModalOpen} onClose={closeViewLogsModal} instance={selectedInstanceForLogs} />
             <ViewChatLogsModal isOpen={isViewChatLogsModalOpen} onClose={closeViewChatLogsModal} instance={selectedInstanceForChatLogs} />

--- a/frontend-react/src/pages/__tests__/ServersPage.test.jsx
+++ b/frontend-react/src/pages/__tests__/ServersPage.test.jsx
@@ -1,39 +1,28 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ServersPage from '../ServersPage';
 
 const mocks = vi.hoisted(() => ({
   addNotification: vi.fn(),
+  EditConfigModal: vi.fn(() => null),
   showSuccess: vi.fn(),
   showError: vi.fn(),
   toggleExpand: vi.fn(),
   noop: vi.fn(),
   NullComponent: () => null,
   RconConsole: vi.fn(() => null),
+  serversData: [],
+  stats: { totalHosts: 1, totalInstances: 0, runningInstances: 0 },
 }));
 
 vi.mock('../../hooks/useServers', () => ({
   POLLABLE_HOST_STATUSES: ['provisioning', 'configuring'],
   POLLABLE_INSTANCE_STATUSES: ['deploying'],
   useServers: () => ({
-    serversData: [
-      {
-        id: 1,
-        name: 'Arena Host',
-        provider: 'standalone',
-        region: null,
-        ip_address: '203.0.113.10',
-        status: 'active',
-        qlfilter_status: 'active',
-        timezone: 'UTC',
-        is_standalone: true,
-        expanded: false,
-        instances: [],
-      },
-    ],
-    stats: { totalHosts: 1, totalInstances: 0, runningInstances: 0 },
+    serversData: mocks.serversData,
+    stats: mocks.stats,
     loading: false,
     error: null,
     toggleExpand: mocks.toggleExpand,
@@ -59,6 +48,16 @@ vi.mock('../../components/hosts/SortableHostList', () => ({
         <div key={host.id}>
           {renderHostCard(host, { attributes: {}, listeners: {} })}
         </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../../components/instances/SortableInstanceList', () => ({
+  default: ({ instances, renderInstanceContent }) => (
+    <div>
+      {instances.map((instance) => (
+        <div key={instance.id}>{renderInstanceContent(instance)}</div>
       ))}
     </div>
   ),
@@ -176,7 +175,12 @@ vi.mock('../../components/hosts/HostDetailDrawer', () => ({ default: mocks.NullC
 vi.mock('../../components/hosts/AddHostModal', () => ({ default: mocks.NullComponent }));
 vi.mock('../../components/instances/AddInstanceModal', () => ({ default: mocks.NullComponent }));
 vi.mock('../../components/instances/InstanceDetailsModal', () => ({ default: mocks.NullComponent }));
-vi.mock('../../components/instances/EditInstanceConfigModal', () => ({ default: mocks.NullComponent }));
+vi.mock('../../components/instances/EditInstanceConfigModal', () => ({
+  default: (props) => {
+    mocks.EditConfigModal(props);
+    return props.isOpen ? <div>edit-config-modal</div> : null;
+  },
+}));
 vi.mock('../../components/instances/ViewLogsModal', () => ({ default: mocks.NullComponent }));
 vi.mock('../../components/instances/ViewChatLogsModal', () => ({ default: mocks.NullComponent }));
 vi.mock('../../components/RconConsoleModal', () => ({ default: mocks.RconConsole }));
@@ -187,6 +191,22 @@ vi.mock('../../components/hosts/HostAutoRestartScheduleModal', () => ({ default:
 describe('ServersPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.serversData = [
+      {
+        id: 1,
+        name: 'Arena Host',
+        provider: 'standalone',
+        region: null,
+        ip_address: '203.0.113.10',
+        status: 'active',
+        qlfilter_status: 'active',
+        timezone: 'UTC',
+        is_standalone: true,
+        expanded: false,
+        instances: [],
+      },
+    ];
+    mocks.stats = { totalHosts: 1, totalInstances: 0, runningInstances: 0 };
   });
 
   it('renders the QLFilter column in the active host-card layout', () => {
@@ -211,5 +231,51 @@ describe('ServersPage', () => {
     );
 
     expect(mocks.RconConsole).not.toHaveBeenCalled();
+  });
+
+  it('opens the edit modal on the Hooks tab from the hook badge', () => {
+    mocks.serversData = [
+      {
+        id: 1,
+        name: 'Arena Host',
+        provider: 'standalone',
+        region: null,
+        ip_address: '203.0.113.10',
+        status: 'active',
+        qlfilter_status: 'active',
+        timezone: 'UTC',
+        is_standalone: true,
+        expanded: true,
+        instances: [
+          {
+            id: 22,
+            name: 'Arena 22',
+            hostname: 'Arena Hostname',
+            port: 27960,
+            status: 'running',
+            lan_rate_enabled: false,
+            ld_preload_hooks: 'a.so,b.so',
+          },
+        ],
+      },
+    ];
+    mocks.stats = { totalHosts: 1, totalInstances: 1, runningInstances: 1 };
+
+    render(
+      <MemoryRouter>
+        <ServersPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /open ld_preload hooks/i }));
+
+    expect(mocks.EditConfigModal).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        initialTab: 'hooks',
+        instanceId: 22,
+        instanceName: 'Arena 22',
+      })
+    );
   });
 });

--- a/frontend-react/src/services/__tests__/api.test.js
+++ b/frontend-react/src/services/__tests__/api.test.js
@@ -23,7 +23,13 @@ vi.mock('axios', () => ({
   },
 }));
 
-import { getSelfHostDefaults, resizeHost, updateInstanceConfig } from '../api';
+import {
+  fetchInstanceHooks,
+  getSelfHostDefaults,
+  resizeHost,
+  saveInstanceHooks,
+  updateInstanceConfig,
+} from '../api';
 
 describe('getSelfHostDefaults', () => {
   beforeEach(() => {
@@ -126,5 +132,31 @@ describe('resizeHost', () => {
 
     await expect(resizeHost(4, 'vc2-2c-4gb')).resolves.toEqual({ message: 'queued' });
     expect(mocks.post).toHaveBeenCalledWith('/hosts/4/resize', { new_plan: 'vc2-2c-4gb' });
+  });
+});
+
+describe('instance hook API helpers', () => {
+  beforeEach(() => {
+    mocks.get.mockReset();
+    mocks.put.mockReset();
+  });
+
+  it('fetchInstanceHooks uses the shared api client', async () => {
+    mocks.get.mockResolvedValueOnce({
+      data: { data: { available: [], system_hooks_active: [] } },
+    });
+
+    await expect(fetchInstanceHooks(12)).resolves.toEqual({
+      available: [],
+      system_hooks_active: [],
+    });
+    expect(mocks.get).toHaveBeenCalledWith('/instances/12/hooks');
+  });
+
+  it('saveInstanceHooks uses the shared api client for PUT', async () => {
+    mocks.put.mockResolvedValueOnce({ data: { data: { task_id: 'job-1' } } });
+
+    await expect(saveInstanceHooks(12, ['a.so'])).resolves.toEqual({ task_id: 'job-1' });
+    expect(mocks.put).toHaveBeenCalledWith('/instances/12/hooks', { enabled: ['a.so'] });
   });
 });

--- a/frontend-react/src/services/api.js
+++ b/frontend-react/src/services/api.js
@@ -364,6 +364,29 @@ export const updateInstanceLanRate = async (instanceId, lanRateEnabled) => {
   }
 };
 
+export const fetchInstanceHooks = async (instanceId) => {
+  try {
+    const response = await apiClient.get(`/instances/${instanceId}/hooks`);
+    return response.data.data;
+  } catch (error) {
+    console.error(`Failed to fetch hooks for instance ${instanceId}:`, error.response ? error.response.data : error.message);
+    throw error.response ? error.response.data : new Error(`Failed to fetch hooks for instance ${instanceId}`);
+  }
+};
+
+export const saveInstanceHooks = async (instanceId, enabledFilenames) => {
+  try {
+    const response = await apiClient.put(
+      `/instances/${instanceId}/hooks`,
+      { enabled: enabledFilenames },
+    );
+    return response.data.data;
+  } catch (error) {
+    console.error(`Failed to save hooks for instance ${instanceId}:`, error.response ? error.response.data : error.message);
+    throw error.response ? error.response.data : new Error(`Failed to save hooks for instance ${instanceId}`);
+  }
+};
+
 export const fetchInstanceRemoteLogs = async (instanceId, options = {}) => {
   try {
     const { filterMode = 'lines', since = '1 hour ago', lines = 500 } = options;

--- a/frontend-react/src/services/api.js
+++ b/frontend-react/src/services/api.js
@@ -364,9 +364,12 @@ export const updateInstanceLanRate = async (instanceId, lanRateEnabled) => {
   }
 };
 
-export const fetchInstanceHooks = async (instanceId) => {
+export const fetchInstanceHooks = async (instanceId, draftId) => {
   try {
-    const response = await apiClient.get(`/instances/${instanceId}/hooks`);
+    const url = draftId
+      ? `/instances/${instanceId}/hooks?draft_id=${encodeURIComponent(draftId)}`
+      : `/instances/${instanceId}/hooks`;
+    const response = await apiClient.get(url);
     return response.data.data;
   } catch (error) {
     console.error(`Failed to fetch hooks for instance ${instanceId}:`, error.response ? error.response.data : error.message);

--- a/frontend-react/src/services/api.js
+++ b/frontend-react/src/services/api.js
@@ -377,11 +377,13 @@ export const fetchInstanceHooks = async (instanceId, draftId) => {
   }
 };
 
-export const saveInstanceHooks = async (instanceId, enabledFilenames) => {
+export const saveInstanceHooks = async (instanceId, enabledFilenames, draftId) => {
   try {
+    const body = { enabled: enabledFilenames };
+    if (draftId) body.draft_id = draftId;
     const response = await apiClient.put(
       `/instances/${instanceId}/hooks`,
-      { enabled: enabledFilenames },
+      body,
     );
     return response.data.data;
   } catch (error) {

--- a/frontend-react/src/utils/quakeColorExtension.js
+++ b/frontend-react/src/utils/quakeColorExtension.js
@@ -39,7 +39,7 @@ const TIMESTAMP_RE = /\[[\d:]+\s*[AP]M\]/g;
 const COMMAND_LINE_RE = /^(\[[\d:]+\s*[AP]M\]\s*)(> .+)$/;
 const STEAMID_RE = /\b(7656\d{13,})\b/g;
 const IP_PORT_RE = /\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d+)\b/g;
-const SEPARATOR_RE = /^(\[[\d:]+\s*[AP]M\]\s*)(---[\s\-]+.*)$/;
+const SEPARATOR_RE = /^(\[[\d:]+\s*[AP]M\]\s*)(---[\s-]+.*)$/;
 const QUAKE_CODE_RE = /\^([0-9])/g;
 
 /**

--- a/frontend-react/vite.config.js
+++ b/frontend-react/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import process from 'node:process'
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/migrations/versions/d4ddc1b30d85_add_ld_preload_hooks_to_qlinstance.py
+++ b/migrations/versions/d4ddc1b30d85_add_ld_preload_hooks_to_qlinstance.py
@@ -1,0 +1,26 @@
+"""add ld_preload_hooks to qlinstance
+
+Revision ID: d4ddc1b30d85
+Revises: 741ab13ff3a5
+Create Date: 2026-05-22 20:30:07.434142
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd4ddc1b30d85'
+down_revision = '741ab13ff3a5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('ql_instance', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('ld_preload_hooks', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('ql_instance', schema=None) as batch_op:
+        batch_op.drop_column('ld_preload_hooks')

--- a/tests/test_apply_instance_hooks.py
+++ b/tests/test_apply_instance_hooks.py
@@ -1,0 +1,124 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from ui import db
+from ui.models import Host, InstanceStatus, QLInstance
+from ui.task_logic import ansible_instance_hooks as mod
+
+
+@pytest.fixture
+def instance_with_so(app, tmp_path, monkeypatch):
+    with app.app_context():
+        host = Host(name="h", provider="vultr", ip_address="1.2.3.4")
+        db.session.add(host)
+        db.session.flush()
+        inst = QLInstance(
+            name="i",
+            port=27960,
+            hostname="hn",
+            host_id=host.id,
+            qlx_plugins="",
+            ld_preload_hooks="ok.so",
+            zmq_rcon_port=28888,
+            zmq_rcon_password="x",
+            zmq_stats_port=29999,
+            zmq_stats_password="y",
+        )
+        db.session.add(inst)
+        db.session.commit()
+
+        scripts_dir = tmp_path / "configs" / host.name / str(inst.id) / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "ok.so").write_bytes(b"\x7fELF" + b"\x00" * 64)
+        monkeypatch.setattr(mod, "CONFIGS_BASE", str(tmp_path / "configs"))
+        monkeypatch.setattr(mod, "ensure_instance_cpu_affinity", lambda inst: None)
+        yield inst
+
+
+def _success_result():
+    return SimpleNamespace(rc=0, status="successful")
+
+
+def test_success_restarts_and_sets_running(app, instance_with_so, monkeypatch):
+    monkeypatch.setattr(
+        mod,
+        "_run_ansible_playbook",
+        lambda inst, pb, extravars=None: (_success_result(), None),
+    )
+    with app.app_context():
+        assert mod.apply_instance_hooks_logic(instance_with_so.id) is True
+        fresh = db.session.get(QLInstance, instance_with_so.id)
+        assert fresh.status == InstanceStatus.RUNNING
+
+
+def test_success_when_stopped_skips_restart_and_sets_stopped(app, instance_with_so, monkeypatch):
+    captured = {}
+
+    def fake_run(inst, pb, extravars=None):
+        captured["extravars"] = extravars
+        return _success_result(), None
+
+    monkeypatch.setattr(mod, "_run_ansible_playbook", fake_run)
+    with app.app_context():
+        assert mod.apply_instance_hooks_logic(instance_with_so.id, restart_service=False) is True
+        fresh = db.session.get(QLInstance, instance_with_so.id)
+        assert fresh.status == InstanceStatus.STOPPED
+        assert captured["extravars"]["restart_service"] is False
+
+
+def test_preserves_cpu_affinity_extravars(app, instance_with_so, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(mod, "ensure_instance_cpu_affinity", lambda inst: 2)
+
+    def fake_run(inst, pb, extravars=None):
+        captured["extravars"] = extravars
+        return _success_result(), None
+
+    monkeypatch.setattr(mod, "_run_ansible_playbook", fake_run)
+    with app.app_context():
+        assert mod.apply_instance_hooks_logic(instance_with_so.id) is True
+        assert captured["extravars"]["cpu_affinity"] == 2
+
+
+def test_preflight_fail_when_file_missing(app, instance_with_so, monkeypatch, tmp_path):
+    os.remove(tmp_path / "configs" / "h" / str(instance_with_so.id) / "scripts" / "ok.so")
+    called = {"ran": False}
+
+    def fake_run(*args, **kwargs):
+        called["ran"] = True
+        return _success_result(), None
+
+    monkeypatch.setattr(mod, "_run_ansible_playbook", fake_run)
+    with app.app_context():
+        assert mod.apply_instance_hooks_logic(instance_with_so.id) is False
+        fresh = db.session.get(QLInstance, instance_with_so.id)
+        assert fresh.status == InstanceStatus.ERROR
+        assert called["ran"] is False
+
+
+def test_preflight_fail_when_non_elf(app, instance_with_so, monkeypatch, tmp_path):
+    bad = tmp_path / "configs" / "h" / str(instance_with_so.id) / "scripts" / "ok.so"
+    bad.write_bytes(b"NOT_ELF")
+    monkeypatch.setattr(
+        mod,
+        "_run_ansible_playbook",
+        lambda *args, **kwargs: (_success_result(), None),
+    )
+    with app.app_context():
+        assert mod.apply_instance_hooks_logic(instance_with_so.id) is False
+        fresh = db.session.get(QLInstance, instance_with_so.id)
+        assert fresh.status == InstanceStatus.ERROR
+
+
+def test_ansible_failure_sets_error(app, instance_with_so, monkeypatch):
+    monkeypatch.setattr(
+        mod,
+        "_run_ansible_playbook",
+        lambda *args, **kwargs: (None, "boom"),
+    )
+    with app.app_context():
+        assert mod.apply_instance_hooks_logic(instance_with_so.id) is False
+        fresh = db.session.get(QLInstance, instance_with_so.id)
+        assert fresh.status == InstanceStatus.ERROR

--- a/tests/test_extravars_include_ld_preload.py
+++ b/tests/test_extravars_include_ld_preload.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+import pytest
+
+from ui import db
+from ui.models import Host, QLInstance
+from ui.task_logic import ansible_instance_mgmt as mod
+
+
+@pytest.fixture
+def instance_in_db(app):
+    with app.app_context():
+        host = Host(name="test-host", provider="vultr", ip_address="10.0.0.1")
+        db.session.add(host)
+        db.session.flush()
+        inst = QLInstance(
+            name="ti",
+            port=27960,
+            hostname="hn",
+            host_id=host.id,
+            qlx_plugins="",
+            ld_preload_hooks="hook_a.so,hook_b.so",
+            zmq_rcon_port=28888,
+            zmq_rcon_password="x",
+            zmq_stats_port=29999,
+            zmq_stats_password="y",
+        )
+        db.session.add(inst)
+        db.session.commit()
+        yield inst
+
+
+@pytest.mark.parametrize("logic_fn", [
+    "deploy_instance_logic",
+    "restart_instance_logic",
+    "apply_instance_config_logic",
+    "reconfigure_instance_lan_rate_logic",
+])
+def test_each_logic_passes_ld_preload_paths(app, instance_in_db, logic_fn, monkeypatch):
+    captured = {}
+
+    def fake_run(instance, playbook, extravars=None):
+        captured["extravars"] = extravars
+        return SimpleNamespace(rc=0, status="successful", stdout=lambda: ""), None
+
+    monkeypatch.setattr(mod, "_run_ansible_playbook", fake_run)
+    monkeypatch.setattr(mod, "_prepare_instance_zmq", lambda inst: None)
+    monkeypatch.setattr(mod, "ensure_instance_cpu_affinity", lambda inst: None)
+    monkeypatch.setattr(mod, "with_self_host_network_extravars", lambda inst, e: e)
+    monkeypatch.setattr(mod, "get_current_job", lambda: SimpleNamespace(id="test-job"))
+
+    with app.app_context():
+        getattr(mod, logic_fn)(instance_in_db.id)
+
+    expected = (
+        "/home/ql/qlds-27960/minqlx-plugins/hook_a.so:"
+        "/home/ql/qlds-27960/minqlx-plugins/hook_b.so"
+    )
+    assert captured["extravars"]["ld_preload_paths"] == expected

--- a/tests/test_hook_cascade.py
+++ b/tests/test_hook_cascade.py
@@ -1,0 +1,74 @@
+import io
+import os
+
+import pytest
+
+from tests.helpers import auth_headers
+from ui import db
+from ui.models import Host, QLInstance
+
+
+@pytest.fixture
+def instance_with_so(app, tmp_path, monkeypatch):
+    monkeypatch.setattr("ui.routes.draft_routes.CONFIGS_BASE", str(tmp_path / "configs"))
+    with app.app_context():
+        host = Host(name="h1", provider="vultr", ip_address="1.1.1.1")
+        db.session.add(host)
+        db.session.flush()
+        inst = QLInstance(
+            name="i1",
+            port=27960,
+            hostname="hn",
+            host_id=host.id,
+            qlx_plugins="",
+            ld_preload_hooks="a.so,b.so",
+            zmq_rcon_port=28888,
+            zmq_rcon_password="x",
+            zmq_stats_port=29999,
+            zmq_stats_password="y",
+        )
+        db.session.add(inst)
+        db.session.commit()
+        scripts = tmp_path / "configs" / host.name / str(inst.id) / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "a.so").write_bytes(b"\x7fELF" + b"\x00" * 32)
+        (scripts / "b.so").write_bytes(b"\x7fELF" + b"\x00" * 32)
+        yield inst
+
+
+def test_commit_removes_orphan_hooks_from_instance(client, app, instance_with_so):
+    headers = auth_headers(app, "testuser")
+    response = client.post(
+        "/api/drafts/",
+        json={
+            "source": "instance",
+            "host": instance_with_so.host.name,
+            "instance_id": instance_with_so.id,
+        },
+        headers=headers,
+    )
+    assert response.status_code == 201
+    draft_id = response.get_json()["data"]["draft_id"]
+    os.remove(os.path.join(app.config["DRAFTS_BASE"], draft_id, "scripts", "a.so"))
+    upload = client.post(
+        f"/api/drafts/{draft_id}/upload",
+        data={"file": (io.BytesIO(b"\x7fELF" + b"\x00" * 32), "b.so")},
+        headers=headers,
+        content_type="multipart/form-data",
+    )
+    assert upload.status_code == 200
+
+    response = client.post(
+        f"/api/drafts/{draft_id}/commit",
+        json={
+            "target": "instance",
+            "host": instance_with_so.host.name,
+            "instance_id": instance_with_so.id,
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200
+
+    with app.app_context():
+        fresh = db.session.get(QLInstance, instance_with_so.id)
+        assert fresh.ld_preload_hooks == "b.so"

--- a/tests/test_instance_hooks_routes.py
+++ b/tests/test_instance_hooks_routes.py
@@ -1,0 +1,207 @@
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tests.helpers import auth_headers
+from ui import db
+from ui.models import BinaryMetadata, Host, InstanceStatus, QLInstance
+
+
+@pytest.fixture
+def headers(app):
+    return auth_headers(app, "testuser")
+
+
+@pytest.fixture
+def instance_with_scripts(app, tmp_path, monkeypatch):
+    with app.app_context():
+        host = Host(name="h1", provider="vultr", ip_address="1.1.1.1")
+        db.session.add(host)
+        db.session.flush()
+        inst = QLInstance(
+            name="i1",
+            port=27960,
+            hostname="hn",
+            host_id=host.id,
+            qlx_plugins="",
+            ld_preload_hooks="a.so,b.so",
+            status=InstanceStatus.RUNNING,
+            zmq_rcon_port=28888,
+            zmq_rcon_password="x",
+            zmq_stats_port=29999,
+            zmq_stats_password="y",
+        )
+        db.session.add(inst)
+        db.session.commit()
+
+        scripts = tmp_path / "configs" / host.name / str(inst.id) / "scripts"
+        scripts.mkdir(parents=True)
+        for filename in ("a.so", "b.so", "c.so"):
+            (scripts / filename).write_bytes(b"\x7fELF" + b"\x00" * 32)
+        monkeypatch.setattr(
+            "ui.routes.instance_hooks_routes.CONFIGS_BASE",
+            str(tmp_path / "configs"),
+        )
+        yield inst
+
+
+def _put(client, headers, instance_id, body):
+    return client.put(
+        f"/api/instances/{instance_id}/hooks",
+        data=json.dumps(body),
+        headers={**headers, "Content-Type": "application/json"},
+    )
+
+
+def test_get_lists_available_with_enabled_and_order(client, headers, instance_with_scripts):
+    response = client.get(f"/api/instances/{instance_with_scripts.id}/hooks", headers=headers)
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    by_name = {hook["filename"]: hook for hook in data["available"]}
+    assert by_name["a.so"]["enabled"] is True
+    assert by_name["a.so"]["order"] == 1
+    assert by_name["b.so"]["enabled"] is True
+    assert by_name["b.so"]["order"] == 2
+    assert by_name["c.so"]["enabled"] is False
+    assert by_name["c.so"]["order"] is None
+    assert data["system_hooks_active"] == []
+
+
+def test_get_includes_binary_metadata_description(app, client, headers, instance_with_scripts):
+    with app.app_context():
+        db.session.add(BinaryMetadata(
+            context_type="instance",
+            context_key=str(instance_with_scripts.id),
+            file_path="a.so",
+            description="Speed hook",
+        ))
+        db.session.commit()
+
+    response = client.get(f"/api/instances/{instance_with_scripts.id}/hooks", headers=headers)
+    by_name = {hook["filename"]: hook for hook in response.get_json()["data"]["available"]}
+    assert by_name["a.so"]["description"] == "Speed hook"
+    assert by_name["b.so"]["description"] == ""
+
+
+def test_get_excludes_orphaned_enabled_entries(client, headers, instance_with_scripts, tmp_path):
+    os.remove(tmp_path / "configs" / "h1" / str(instance_with_scripts.id) / "scripts" / "a.so")
+    response = client.get(f"/api/instances/{instance_with_scripts.id}/hooks", headers=headers)
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert all(hook["filename"] != "a.so" for hook in data["available"])
+
+
+def test_get_404_when_instance_missing(client, headers):
+    response = client.get("/api/instances/99999/hooks", headers=headers)
+    assert response.status_code == 404
+
+
+def test_get_requires_auth(client, instance_with_scripts):
+    response = client.get(f"/api/instances/{instance_with_scripts.id}/hooks")
+    assert response.status_code == 401
+
+
+def test_put_rejects_missing_body(client, headers, instance_with_scripts):
+    response = client.put(
+        f"/api/instances/{instance_with_scripts.id}/hooks",
+        data="not json",
+        headers={**headers, "Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+def test_put_rejects_non_list(client, headers, instance_with_scripts):
+    response = _put(client, headers, instance_with_scripts.id, {"enabled": "a.so"})
+    assert response.status_code == 400
+
+
+def test_put_rejects_path_traversal(client, headers, instance_with_scripts):
+    response = _put(client, headers, instance_with_scripts.id, {"enabled": ["../etc/passwd.so"]})
+    assert response.status_code == 400
+
+
+def test_put_rejects_non_so_extension(client, headers, instance_with_scripts):
+    response = _put(client, headers, instance_with_scripts.id, {"enabled": ["evil.txt"]})
+    assert response.status_code == 400
+
+
+def test_put_rejects_reserved_filename(client, headers, instance_with_scripts):
+    response = _put(client, headers, instance_with_scripts.id, {"enabled": ["force_rate.so"]})
+    assert response.status_code == 400
+    assert "reserved" in response.get_json()["error"]["message"].lower()
+
+
+def test_put_rejects_nonexistent_file(client, headers, instance_with_scripts):
+    response = _put(client, headers, instance_with_scripts.id, {"enabled": ["nope.so"]})
+    assert response.status_code == 400
+
+
+def test_put_rejects_non_elf(client, headers, instance_with_scripts, tmp_path):
+    bad = tmp_path / "configs" / "h1" / str(instance_with_scripts.id) / "scripts" / "bad.so"
+    bad.write_bytes(b"NOT_ELF")
+    response = _put(client, headers, instance_with_scripts.id, {"enabled": ["bad.so"]})
+    assert response.status_code == 400
+
+
+def test_put_rejects_duplicates(client, headers, instance_with_scripts):
+    response = _put(client, headers, instance_with_scripts.id, {"enabled": ["a.so", "a.so"]})
+    assert response.status_code == 400
+
+
+def test_put_returns_409_when_instance_lock_held(client, headers, instance_with_scripts):
+    with patch("ui.routes.instance_hooks_routes.acquire_lock", return_value=False):
+        response = _put(client, headers, instance_with_scripts.id, {"enabled": ["a.so"]})
+    assert response.status_code == 409
+
+
+def test_put_enqueue_failure_reverts_hooks_and_marks_error(
+    app,
+    client,
+    headers,
+    instance_with_scripts,
+):
+    original = instance_with_scripts.ld_preload_hooks
+    with patch("ui.routes.instance_hooks_routes.acquire_lock", return_value=True), \
+            patch("ui.routes.instance_hooks_routes.release_lock") as release, \
+            patch("ui.routes.instance_hooks_routes.enqueue_apply_hooks", return_value=None):
+        response = _put(client, headers, instance_with_scripts.id, {"enabled": ["b.so"]})
+
+    assert response.status_code == 500
+    with app.app_context():
+        fresh = db.session.get(QLInstance, instance_with_scripts.id)
+        assert fresh.ld_preload_hooks == original
+        assert fresh.status == InstanceStatus.ERROR
+    release.assert_called_once()
+
+
+def test_put_stopped_instance_enqueues_without_restart(app, client, headers, instance_with_scripts):
+    with app.app_context():
+        instance_with_scripts.status = InstanceStatus.STOPPED
+        db.session.commit()
+
+    with patch("ui.routes.instance_hooks_routes.acquire_lock", return_value=True), \
+            patch("ui.routes.instance_hooks_routes.release_lock"), \
+            patch("ui.routes.instance_hooks_routes.enqueue_apply_hooks") as enq:
+        enq.return_value = SimpleNamespace(id="job-id-stopped")
+        response = _put(client, headers, instance_with_scripts.id, {"enabled": ["a.so"]})
+
+    assert response.status_code == 202
+    assert enq.call_args.kwargs["restart_service"] is False
+
+
+def test_put_happy_path_persists_and_enqueues(app, client, headers, instance_with_scripts):
+    with patch("ui.routes.instance_hooks_routes.acquire_lock", return_value=True), \
+            patch("ui.routes.instance_hooks_routes.release_lock"), \
+            patch("ui.routes.instance_hooks_routes.enqueue_apply_hooks") as enq:
+        enq.return_value = SimpleNamespace(id="job-id-123")
+        response = _put(client, headers, instance_with_scripts.id, {"enabled": ["b.so", "a.so"]})
+
+    assert response.status_code == 202
+    assert response.get_json()["data"]["task_id"] == "job-id-123"
+    with app.app_context():
+        fresh = db.session.get(QLInstance, instance_with_scripts.id)
+        assert fresh.ld_preload_hooks == "b.so,a.so"
+        assert fresh.status == InstanceStatus.CONFIGURING

--- a/tests/test_ld_preload_paths.py
+++ b/tests/test_ld_preload_paths.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+from ui.task_logic.ansible_instance_mgmt import (
+    RESERVED_HOOK_FILENAMES,
+    _build_ld_preload_paths,
+)
+
+
+def _inst(port=27960, ld_preload_hooks=None, lan_rate_enabled=False):
+    return SimpleNamespace(
+        port=port,
+        ld_preload_hooks=ld_preload_hooks,
+        lan_rate_enabled=lan_rate_enabled,
+    )
+
+
+def test_empty_when_no_hooks():
+    assert _build_ld_preload_paths(_inst()) == ""
+
+
+def test_single_user_hook():
+    inst = _inst(ld_preload_hooks="highfps_hook.so")
+    assert _build_ld_preload_paths(inst) == (
+        "/home/ql/qlds-27960/minqlx-plugins/highfps_hook.so"
+    )
+
+
+def test_multiple_user_hooks_colon_joined_in_order():
+    inst = _inst(port=27961, ld_preload_hooks="a.so,b.so,c.so")
+    assert _build_ld_preload_paths(inst) == ":".join([
+        "/home/ql/qlds-27961/minqlx-plugins/a.so",
+        "/home/ql/qlds-27961/minqlx-plugins/b.so",
+        "/home/ql/qlds-27961/minqlx-plugins/c.so",
+    ])
+
+
+def test_whitespace_stripped_and_empty_entries_skipped():
+    inst = _inst(ld_preload_hooks="  a.so , ,b.so  ,,")
+    assert _build_ld_preload_paths(inst) == (
+        "/home/ql/qlds-27960/minqlx-plugins/a.so:"
+        "/home/ql/qlds-27960/minqlx-plugins/b.so"
+    )
+
+
+def test_no_system_hooks_by_default():
+    from ui.task_logic import ansible_instance_mgmt
+
+    assert ansible_instance_mgmt._SYSTEM_HOOKS == []
+
+
+def test_system_hook_prepended_when_predicate_true(monkeypatch):
+    from ui.task_logic import ansible_instance_mgmt
+
+    monkeypatch.setattr(
+        ansible_instance_mgmt,
+        "_SYSTEM_HOOKS",
+        [("force_rate.so", lambda i: i.lan_rate_enabled, "baseq3")],
+    )
+    inst = _inst(ld_preload_hooks="user.so", lan_rate_enabled=True)
+    assert _build_ld_preload_paths(inst) == (
+        "/home/ql/qlds-27960/baseq3/force_rate.so:"
+        "/home/ql/qlds-27960/minqlx-plugins/user.so"
+    )
+
+
+def test_system_hook_not_prepended_when_predicate_false(monkeypatch):
+    from ui.task_logic import ansible_instance_mgmt
+
+    monkeypatch.setattr(
+        ansible_instance_mgmt,
+        "_SYSTEM_HOOKS",
+        [("force_rate.so", lambda i: i.lan_rate_enabled, "baseq3")],
+    )
+    inst = _inst(ld_preload_hooks="user.so")
+    assert _build_ld_preload_paths(inst) == (
+        "/home/ql/qlds-27960/minqlx-plugins/user.so"
+    )
+
+
+def test_reserved_hook_filenames_contains_force_rate():
+    assert "force_rate.so" in RESERVED_HOOK_FILENAMES

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,12 @@
+from ui.models import QLInstance
+
+
+def test_qlinstance_has_ld_preload_hooks_column(app):
+    columns = {column.name for column in QLInstance.__table__.columns}
+    assert "ld_preload_hooks" in columns
+
+
+def test_qlinstance_ld_preload_hooks_is_nullable_text(app):
+    col = QLInstance.__table__.columns["ld_preload_hooks"]
+    assert col.nullable is True
+    assert str(col.type).upper().startswith("TEXT")

--- a/tests/test_reserved_hook_filename.py
+++ b/tests/test_reserved_hook_filename.py
@@ -1,0 +1,63 @@
+import io
+
+import pytest
+
+from tests.helpers import auth_headers
+from ui import db
+from ui.models import Host, QLInstance
+
+
+@pytest.fixture
+def instance_in_db(app):
+    with app.app_context():
+        host = Host(name="h1", provider="vultr", ip_address="1.1.1.1")
+        db.session.add(host)
+        db.session.flush()
+        inst = QLInstance(
+            name="i1",
+            port=27960,
+            hostname="hn",
+            host_id=host.id,
+            qlx_plugins="",
+            zmq_rcon_port=28888,
+            zmq_rcon_password="x",
+            zmq_stats_port=29999,
+            zmq_stats_password="y",
+        )
+        db.session.add(inst)
+        db.session.commit()
+        yield inst
+
+
+def test_commit_rejects_reserved_filename(client, app, instance_in_db):
+    headers = auth_headers(app, "testuser")
+    response = client.post(
+        "/api/drafts/",
+        json={
+            "source": "instance",
+            "host": instance_in_db.host.name,
+            "instance_id": instance_in_db.id,
+        },
+        headers=headers,
+    )
+    assert response.status_code == 201
+    draft_id = response.get_json()["data"]["draft_id"]
+    upload = client.post(
+        f"/api/drafts/{draft_id}/upload",
+        data={"file": (io.BytesIO(b"\x7fELF" + b"\x00" * 32), "force_rate.so")},
+        headers=headers,
+        content_type="multipart/form-data",
+    )
+    assert upload.status_code == 200
+
+    response = client.post(
+        f"/api/drafts/{draft_id}/commit",
+        json={
+            "target": "instance",
+            "host": instance_in_db.host.name,
+            "instance_id": instance_in_db.id,
+        },
+        headers=headers,
+    )
+    assert response.status_code == 400
+    assert "reserved" in response.get_json()["error"]["message"].lower()

--- a/tests/test_systemd_template_render.py
+++ b/tests/test_systemd_template_render.py
@@ -1,0 +1,26 @@
+import os
+
+from jinja2 import Environment, FileSystemLoader
+
+
+TEMPLATES = os.path.join(os.path.dirname(__file__), "..", "ansible", "templates")
+
+
+def _render(vars_dict):
+    env = Environment(loader=FileSystemLoader(TEMPLATES), keep_trailing_newline=True)
+    return env.get_template("qlds@.service.j2").render(**vars_dict)
+
+
+def test_no_env_line_when_ld_preload_empty():
+    out = _render({"qlds_args": "+set foo bar", "ld_preload_paths": ""})
+    assert "Environment=LD_PRELOAD" not in out
+
+
+def test_no_env_line_when_ld_preload_missing():
+    out = _render({"qlds_args": "+set foo bar"})
+    assert "Environment=LD_PRELOAD" not in out
+
+
+def test_env_line_present_when_ld_preload_set():
+    out = _render({"qlds_args": "+set foo bar", "ld_preload_paths": "/a.so:/b.so"})
+    assert "Environment=LD_PRELOAD=/a.so:/b.so" in out

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -215,6 +215,8 @@ def create_app(test_config=None):
     # Register resource-specific API blueprints
     api_bp.register_blueprint(host_api_bp, url_prefix='/hosts')
     api_bp.register_blueprint(instance_api_bp, url_prefix='/instances')
+    from ui.routes.instance_hooks_routes import instance_hooks_bp
+    api_bp.register_blueprint(instance_hooks_bp, url_prefix='/instances')
     api_bp.register_blueprint(auth_api_bp, url_prefix='/auth')
     api_bp.register_blueprint(preset_api_bp, url_prefix='/presets')
     api_bp.register_blueprint(user_api_bp, url_prefix='/users')

--- a/ui/models.py
+++ b/ui/models.py
@@ -114,6 +114,7 @@ class QLInstance(db.Model):
     lan_rate_enabled = db.Column(db.Boolean, default=False, nullable=False) # 99k LAN rate mode
     config = db.Column(db.Text, nullable=True)  # JSON stored as text
     qlx_plugins = db.Column(db.String(1000), nullable=True) # Selected plugins as comma-separated string
+    ld_preload_hooks = db.Column(db.Text, nullable=True) # Comma-separated .so filenames in preload order
     cpu_affinity = db.Column(db.Integer, nullable=True) # Optional Linux CPU index assigned to this service
     status = db.Column(db.Enum(InstanceStatus), default=InstanceStatus.IDLE, nullable=False) # Status of the QL instance itself
     logs = db.Column(db.Text, nullable=True) # Stores logs from background tasks (e.g., Ansible)
@@ -149,6 +150,7 @@ class QLInstance(db.Model):
             'lan_rate_enabled': self.lan_rate_enabled, # 99k LAN rate mode
             'config': self.config,
             'qlx_plugins': self.qlx_plugins,
+            'ld_preload_hooks': self.ld_preload_hooks,
             'cpu_affinity': self.cpu_affinity,
             'status': self.status.value if self.status else None,
             'logs': self.logs, # Include logs

--- a/ui/routes/draft_routes.py
+++ b/ui/routes/draft_routes.py
@@ -643,6 +643,15 @@ def commit_draft(draft_id):
         return jsonify({"error": {"message": "Invalid target. Provide host + instance_id or preset name."}}), 400
 
     draft_scripts_path = _get_draft_scripts_path(draft_id)
+    from ui.task_logic.ansible_instance_mgmt import RESERVED_HOOK_FILENAMES
+    if os.path.isdir(draft_scripts_path):
+        for name in os.listdir(draft_scripts_path):
+            if name in RESERVED_HOOK_FILENAMES:
+                return jsonify({
+                    "error": {
+                        "message": f"Filename '{name}' is reserved for a system hook",
+                    },
+                }), 400
 
     try:
         if os.path.exists(target_path):
@@ -651,6 +660,29 @@ def commit_draft(draft_id):
     except OSError as e:
         current_app.logger.error(f"Failed to commit draft {draft_id}: {e}")
         return jsonify({"error": {"message": "Failed to commit draft"}}), 500
+
+    if data.get("target") == "instance":
+        from ui.models import QLInstance
+        from ui.task_logic.common import append_log
+
+        instance = db.session.get(QLInstance, int(data["instance_id"]))
+        if instance and instance.ld_preload_hooks:
+            on_disk = (
+                {name for name in os.listdir(target_path) if name.endswith(".so")}
+                if os.path.isdir(target_path)
+                else set()
+            )
+            current_hooks = [
+                item.strip()
+                for item in instance.ld_preload_hooks.split(",")
+                if item.strip()
+            ]
+            kept_hooks = [name for name in current_hooks if name in on_disk]
+            if kept_hooks != current_hooks:
+                removed = sorted(set(current_hooks) - set(kept_hooks))
+                instance.ld_preload_hooks = ",".join(kept_hooks) if kept_hooks else None
+                append_log(instance, f"Removed deleted hooks from LD_PRELOAD: {removed}")
+                db.session.commit()
 
     shutil.rmtree(_get_draft_base_path(draft_id), ignore_errors=True)
     current_app.logger.info(f"Committed draft {draft_id} to {target_path}")

--- a/ui/routes/draft_routes.py
+++ b/ui/routes/draft_routes.py
@@ -605,6 +605,8 @@ def _get_commit_target_path(data):
             return None
         if not _is_safe_name(host) or not _is_safe_name(str(instance_id)):
             return None
+        if not str(instance_id).isdigit():
+            return None
         if host == PRESETS_DIR:
             return None
         allowed_root = os.path.join(base, host)
@@ -643,8 +645,9 @@ def commit_draft(draft_id):
         return jsonify({"error": {"message": "Invalid target. Provide host + instance_id or preset name."}}), 400
 
     draft_scripts_path = _get_draft_scripts_path(draft_id)
-    from ui.task_logic.ansible_instance_mgmt import RESERVED_HOOK_FILENAMES
-    if os.path.isdir(draft_scripts_path):
+
+    if data.get("target") == "instance" and os.path.isdir(draft_scripts_path):
+        from ui.task_logic.ansible_instance_mgmt import RESERVED_HOOK_FILENAMES
         for name in os.listdir(draft_scripts_path):
             if name in RESERVED_HOOK_FILENAMES:
                 return jsonify({

--- a/ui/routes/instance_hooks_routes.py
+++ b/ui/routes/instance_hooks_routes.py
@@ -7,7 +7,7 @@ from flask_jwt_extended import jwt_required
 from ui import db
 from ui.models import BinaryMetadata, InstanceStatus, QLInstance
 from ui.task_lock import acquire_lock, release_lock
-from ui.task_logic.ansible_instance_mgmt import RESERVED_HOOK_FILENAMES
+from ui.task_logic.ansible_instance_mgmt import RESERVED_HOOK_FILENAMES, _SYSTEM_HOOKS
 
 
 CONFIGS_BASE = "configs"
@@ -63,6 +63,8 @@ def _validate_filename(name):
         return "filename must end in .so"
     if "/" in name or "\\" in name or ".." in name:
         return "filename contains forbidden characters"
+    if any(c in name for c in ('\n', '\r', '\x00')):
+        return "filename contains forbidden control characters"
     if name in RESERVED_HOOK_FILENAMES:
         return "filename is reserved for a system hook"
     return None
@@ -113,10 +115,14 @@ def get_instance_hooks(instance_id):
             "description": descriptions.get(filename, ""),
         })
 
+    system_hooks_active = [
+        filename for filename, predicate, _subdir in _SYSTEM_HOOKS if predicate(instance)
+    ]
+
     return jsonify({
         "data": {
             "available": available,
-            "system_hooks_active": [],
+            "system_hooks_active": system_hooks_active,
         },
     }), 200
 

--- a/ui/routes/instance_hooks_routes.py
+++ b/ui/routes/instance_hooks_routes.py
@@ -1,0 +1,190 @@
+import os
+import uuid
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
+
+from ui import db
+from ui.models import BinaryMetadata, InstanceStatus, QLInstance
+from ui.task_lock import acquire_lock, release_lock
+from ui.task_logic.ansible_instance_mgmt import RESERVED_HOOK_FILENAMES
+
+
+CONFIGS_BASE = "configs"
+ELF_MAGIC = b"\x7fELF"
+
+instance_hooks_bp = Blueprint("instance_hooks_api", __name__)
+
+
+def _scripts_dir(instance):
+    return os.path.join(CONFIGS_BASE, instance.host.name, str(instance.id), "scripts")
+
+
+def _enabled_list(instance):
+    if not instance.ld_preload_hooks:
+        return []
+    return [h.strip() for h in instance.ld_preload_hooks.split(",") if h.strip()]
+
+
+def _list_so_files(scripts_dir):
+    files = []
+    if not os.path.isdir(scripts_dir):
+        return files
+    for name in sorted(os.listdir(scripts_dir)):
+        if not name.endswith(".so"):
+            continue
+        full_path = os.path.join(scripts_dir, name)
+        try:
+            stat = os.stat(full_path)
+        except OSError:
+            continue
+        files.append({
+            "filename": name,
+            "size": stat.st_size,
+            "modified": int(stat.st_mtime),
+        })
+    return files
+
+
+def _description_map(instance):
+    rows = BinaryMetadata.query.filter_by(
+        context_type="instance",
+        context_key=str(instance.id),
+    ).all()
+    return {row.file_path: row.description or "" for row in rows}
+
+
+def _validate_filename(name):
+    if not isinstance(name, str) or not name.strip():
+        return "empty filename"
+    if name != name.strip():
+        return "filename must not contain leading or trailing whitespace"
+    if not name.endswith(".so"):
+        return "filename must end in .so"
+    if "/" in name or "\\" in name or ".." in name:
+        return "filename contains forbidden characters"
+    if name in RESERVED_HOOK_FILENAMES:
+        return "filename is reserved for a system hook"
+    return None
+
+
+def _is_elf_file(path):
+    try:
+        with open(path, "rb") as handle:
+            return handle.read(4) == ELF_MAGIC
+    except OSError:
+        return False
+
+
+def enqueue_apply_hooks(instance_id, *, restart_service, lock_token):
+    from ui.task_logic.job_failure_handlers import instance_job_failure_handler
+    from ui.tasks import apply_instance_hooks, enqueue_task
+
+    return enqueue_task(
+        apply_instance_hooks,
+        instance_id,
+        restart_service=restart_service,
+        lock_token=lock_token,
+        on_failure=instance_job_failure_handler,
+    )
+
+
+@instance_hooks_bp.route("/<int:instance_id>/hooks", methods=["GET"])
+@jwt_required()
+def get_instance_hooks(instance_id):
+    instance = db.session.get(QLInstance, instance_id)
+    if not instance:
+        return jsonify({"error": {"message": "Instance not found"}}), 404
+
+    on_disk = _list_so_files(_scripts_dir(instance))
+    on_disk_names = {item["filename"] for item in on_disk}
+    enabled = [name for name in _enabled_list(instance) if name in on_disk_names]
+    order_map = {name: idx + 1 for idx, name in enumerate(enabled)}
+    descriptions = _description_map(instance)
+
+    available = []
+    for item in on_disk:
+        filename = item["filename"]
+        is_enabled = filename in order_map
+        available.append({
+            **item,
+            "enabled": is_enabled,
+            "order": order_map[filename] if is_enabled else None,
+            "description": descriptions.get(filename, ""),
+        })
+
+    return jsonify({
+        "data": {
+            "available": available,
+            "system_hooks_active": [],
+        },
+    }), 200
+
+
+@instance_hooks_bp.route("/<int:instance_id>/hooks", methods=["PUT"])
+@jwt_required()
+def put_instance_hooks(instance_id):
+    instance = db.session.get(QLInstance, instance_id)
+    if not instance:
+        return jsonify({"error": {"message": "Instance not found"}}), 404
+
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict) or "enabled" not in payload:
+        return jsonify({"error": {"message": 'Body must be JSON {"enabled": [...]}'}}), 400
+
+    enabled = payload["enabled"]
+    if not isinstance(enabled, list) or not all(isinstance(item, str) for item in enabled):
+        return jsonify({"error": {"message": "enabled must be a list of strings"}}), 400
+    if len(enabled) != len(set(enabled)):
+        return jsonify({"error": {"message": "duplicate filenames in enabled list"}}), 400
+
+    for name in enabled:
+        error = _validate_filename(name)
+        if error:
+            return jsonify({"error": {"message": f"{name}: {error}"}}), 400
+
+    scripts_dir = _scripts_dir(instance)
+    for name in enabled:
+        full_path = os.path.join(scripts_dir, name)
+        if not os.path.isfile(full_path):
+            return jsonify({"error": {"message": f"{name}: file not found in scripts/"}}), 400
+        if not _is_elf_file(full_path):
+            return jsonify({"error": {"message": f"{name}: not a valid ELF binary"}}), 400
+
+    lock_token = str(uuid.uuid4())
+    if not acquire_lock("instance", instance.id, lock_token, ttl=360):
+        msg = f'Another operation is running on instance "{instance.name}". Please wait for it to complete.'
+        return jsonify({"error": {"message": msg}}), 409
+
+    original_hooks = instance.ld_preload_hooks
+    restart_service = instance.status != InstanceStatus.STOPPED
+    lock_transferred = False
+    instance.ld_preload_hooks = ",".join(enabled) if enabled else None
+    instance.status = InstanceStatus.CONFIGURING
+    db.session.commit()
+
+    try:
+        job = enqueue_apply_hooks(
+            instance.id,
+            restart_service=restart_service,
+            lock_token=lock_token,
+        )
+        if job:
+            lock_transferred = True
+            return jsonify({"data": {"task_id": job.id}}), 202
+
+        instance.ld_preload_hooks = original_hooks
+        instance.status = InstanceStatus.ERROR
+        db.session.commit()
+        return jsonify({"error": {"message": "Error queuing hook apply task."}}), 500
+    except Exception:
+        db.session.rollback()
+        current = db.session.get(QLInstance, instance_id)
+        if current:
+            current.ld_preload_hooks = original_hooks
+            current.status = InstanceStatus.ERROR
+            db.session.commit()
+        return jsonify({"error": {"message": "Error queuing hook apply task."}}), 500
+    finally:
+        if not lock_transferred:
+            release_lock("instance", instance_id, lock_token)

--- a/ui/routes/instance_hooks_routes.py
+++ b/ui/routes/instance_hooks_routes.py
@@ -107,10 +107,17 @@ def get_instance_hooks(instance_id):
         return jsonify({"error": {"message": "Instance not found"}}), 404
 
     draft_id = request.args.get('draft_id', '').strip()
-    if draft_id and _DRAFT_ID_RE.match(draft_id):
+    use_draft = bool(draft_id and _DRAFT_ID_RE.match(draft_id))
+    if use_draft:
         scripts_dir = _draft_scripts_dir(draft_id)
+        committed_scripts = _scripts_dir(instance)
+        committed_names = (
+            {n for n in os.listdir(committed_scripts) if n.endswith(".so")}
+            if os.path.isdir(committed_scripts) else set()
+        )
     else:
         scripts_dir = _scripts_dir(instance)
+        committed_names = None
 
     on_disk = _list_so_files(scripts_dir)
     on_disk_names = {item["filename"] for item in on_disk}
@@ -122,11 +129,13 @@ def get_instance_hooks(instance_id):
     for item in on_disk:
         filename = item["filename"]
         is_enabled = filename in order_map
+        committed = (filename in committed_names) if use_draft else True
         available.append({
             **item,
             "enabled": is_enabled,
             "order": order_map[filename] if is_enabled else None,
             "description": descriptions.get(filename, ""),
+            "committed": committed,
         })
 
     system_hooks_active = [

--- a/ui/routes/instance_hooks_routes.py
+++ b/ui/routes/instance_hooks_routes.py
@@ -1,4 +1,6 @@
 import os
+import re
+import tempfile
 import uuid
 
 from flask import Blueprint, jsonify, request
@@ -12,12 +14,18 @@ from ui.task_logic.ansible_instance_mgmt import RESERVED_HOOK_FILENAMES, _SYSTEM
 
 CONFIGS_BASE = "configs"
 ELF_MAGIC = b"\x7fELF"
+_DRAFT_ID_RE = re.compile(r'^[0-9a-f-]{36}$')
 
 instance_hooks_bp = Blueprint("instance_hooks_api", __name__)
 
 
 def _scripts_dir(instance):
     return os.path.join(CONFIGS_BASE, instance.host.name, str(instance.id), "scripts")
+
+
+def _draft_scripts_dir(draft_id):
+    base = os.environ.get('QLDS_DRAFTS_DIR') or os.path.join(tempfile.gettempdir(), 'qlds-drafts')
+    return os.path.join(base, draft_id, 'scripts')
 
 
 def _enabled_list(instance):
@@ -98,7 +106,13 @@ def get_instance_hooks(instance_id):
     if not instance:
         return jsonify({"error": {"message": "Instance not found"}}), 404
 
-    on_disk = _list_so_files(_scripts_dir(instance))
+    draft_id = request.args.get('draft_id', '').strip()
+    if draft_id and _DRAFT_ID_RE.match(draft_id):
+        scripts_dir = _draft_scripts_dir(draft_id)
+    else:
+        scripts_dir = _scripts_dir(instance)
+
+    on_disk = _list_so_files(scripts_dir)
     on_disk_names = {item["filename"] for item in on_disk}
     enabled = [name for name in _enabled_list(instance) if name in on_disk_names]
     order_map = {name: idx + 1 for idx, name in enumerate(enabled)}

--- a/ui/routes/instance_hooks_routes.py
+++ b/ui/routes/instance_hooks_routes.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import tempfile
 import uuid
 
@@ -107,17 +108,10 @@ def get_instance_hooks(instance_id):
         return jsonify({"error": {"message": "Instance not found"}}), 404
 
     draft_id = request.args.get('draft_id', '').strip()
-    use_draft = bool(draft_id and _DRAFT_ID_RE.match(draft_id))
-    if use_draft:
+    if draft_id and _DRAFT_ID_RE.match(draft_id):
         scripts_dir = _draft_scripts_dir(draft_id)
-        committed_scripts = _scripts_dir(instance)
-        committed_names = (
-            {n for n in os.listdir(committed_scripts) if n.endswith(".so")}
-            if os.path.isdir(committed_scripts) else set()
-        )
     else:
         scripts_dir = _scripts_dir(instance)
-        committed_names = None
 
     on_disk = _list_so_files(scripts_dir)
     on_disk_names = {item["filename"] for item in on_disk}
@@ -129,13 +123,11 @@ def get_instance_hooks(instance_id):
     for item in on_disk:
         filename = item["filename"]
         is_enabled = filename in order_map
-        committed = (filename in committed_names) if use_draft else True
         available.append({
             **item,
             "enabled": is_enabled,
             "order": order_map[filename] if is_enabled else None,
             "description": descriptions.get(filename, ""),
-            "committed": committed,
         })
 
     system_hooks_active = [
@@ -173,10 +165,22 @@ def put_instance_hooks(instance_id):
             return jsonify({"error": {"message": f"{name}: {error}"}}), 400
 
     scripts_dir = _scripts_dir(instance)
+    draft_id = payload.get('draft_id', '') or ''
+    use_draft = bool(draft_id and _DRAFT_ID_RE.match(draft_id))
+    draft_dir = _draft_scripts_dir(draft_id) if use_draft else None
+
     for name in enabled:
         full_path = os.path.join(scripts_dir, name)
         if not os.path.isfile(full_path):
-            return jsonify({"error": {"message": f"{name}: file not found in scripts/"}}), 400
+            if draft_dir:
+                draft_path = os.path.join(draft_dir, name)
+                if os.path.isfile(draft_path):
+                    os.makedirs(scripts_dir, exist_ok=True)
+                    shutil.copy2(draft_path, full_path)
+                else:
+                    return jsonify({"error": {"message": f"{name}: file not found in scripts/"}}), 400
+            else:
+                return jsonify({"error": {"message": f"{name}: file not found in scripts/"}}), 400
         if not _is_elf_file(full_path):
             return jsonify({"error": {"message": f"{name}: not a valid ELF binary"}}), 400
 

--- a/ui/task_logic/ansible_instance_hooks.py
+++ b/ui/task_logic/ansible_instance_hooks.py
@@ -1,0 +1,87 @@
+import os
+
+from ui import db
+from ui.models import QLInstance, InstanceStatus
+from ui.task_logic.ansible_instance_mgmt import (
+    _build_ld_preload_paths,
+    _build_qlds_args_string,
+    _run_ansible_playbook,
+    ensure_instance_cpu_affinity,
+)
+from ui.task_logic.common import append_log
+
+
+CONFIGS_BASE = "configs"
+ELF_MAGIC = b"\x7fELF"
+
+
+def _instance_scripts_dir(instance):
+    return os.path.join(CONFIGS_BASE, instance.host.name, str(instance.id), "scripts")
+
+
+def _enabled_hooks(instance):
+    if not instance.ld_preload_hooks:
+        return []
+    return [h.strip() for h in instance.ld_preload_hooks.split(",") if h.strip()]
+
+
+def _preflight(instance):
+    for filename in _enabled_hooks(instance):
+        full_path = os.path.join(_instance_scripts_dir(instance), filename)
+        if not os.path.isfile(full_path):
+            return f"{filename} missing"
+        try:
+            with open(full_path, "rb") as handle:
+                if handle.read(4) != ELF_MAGIC:
+                    return f"{filename} is not an ELF shared object"
+        except OSError as exc:
+            return f"{filename} could not be read: {exc}"
+    return None
+
+
+def apply_instance_hooks_logic(instance_id, restart_service=True):
+    instance = db.session.get(QLInstance, instance_id)
+    if not instance:
+        return False
+    if not instance.host:
+        instance.status = InstanceStatus.ERROR
+        append_log(instance, "apply_instance_hooks failed: associated host not found")
+        db.session.commit()
+        return False
+
+    append_log(instance, "Task started: apply_instance_hooks")
+    instance.status = InstanceStatus.CONFIGURING
+    db.session.commit()
+
+    preflight_error = _preflight(instance)
+    if preflight_error:
+        instance.status = InstanceStatus.ERROR
+        append_log(instance, f"LD_PRELOAD pre-flight failed: {preflight_error}")
+        db.session.commit()
+        return False
+
+    cpu_affinity = ensure_instance_cpu_affinity(instance)
+    extravars = {
+        "port": instance.port,
+        "host_name": instance.host.name,
+        "qlds_args": _build_qlds_args_string(instance),
+        "ld_preload_paths": _build_ld_preload_paths(instance),
+        "cpu_affinity": cpu_affinity,
+        "restart_service": restart_service,
+    }
+    runner_result, error_msg = _run_ansible_playbook(
+        instance,
+        "update_instance_hooks.yml",
+        extravars=extravars,
+    )
+
+    if error_msg or runner_result is None or getattr(runner_result, "rc", 1) != 0:
+        instance.status = InstanceStatus.ERROR
+        append_log(instance, f"apply_instance_hooks failed: {error_msg or 'ansible error'}")
+        db.session.commit()
+        return False
+
+    instance.status = InstanceStatus.RUNNING if restart_service else InstanceStatus.STOPPED
+    append_log(instance, "apply_instance_hooks completed")
+    db.session.commit()
+    return True

--- a/ui/task_logic/ansible_instance_hooks.py
+++ b/ui/task_logic/ansible_instance_hooks.py
@@ -64,6 +64,7 @@ def apply_instance_hooks_logic(instance_id, restart_service=True):
     extravars = {
         "port": instance.port,
         "host_name": instance.host.name,
+        "instance_id": instance.id,
         "qlds_args": _build_qlds_args_string(instance),
         "ld_preload_paths": _build_ld_preload_paths(instance),
         "cpu_affinity": cpu_affinity,

--- a/ui/task_logic/ansible_instance_mgmt.py
+++ b/ui/task_logic/ansible_instance_mgmt.py
@@ -21,6 +21,13 @@ from .zmq_utils import ensure_zmq_rcon_setup
 
 SYSTEM_PLUGINS = ['serverchecker']
 
+# Built-in LD_PRELOAD hooks. Always prepended ahead of user hooks.
+# Each tuple is (filename, predicate(instance) -> bool, subdir under /home/ql/qlds-<port>/).
+_SYSTEM_HOOKS = []
+
+# Reserved so users cannot upload files that shadow future built-in hooks.
+RESERVED_HOOK_FILENAMES = {"force_rate.so"}
+
 
 # Validates and sanitizes input to prevent injection or malformed args
 def _validate_instance_fields(instance):
@@ -126,6 +133,18 @@ def _build_qlds_args_string(instance):
     return ' '.join(parts)
 
 
+def _build_ld_preload_paths(instance):
+    """Return a colon-joined LD_PRELOAD value, or an empty string."""
+    paths = []
+    for filename, predicate, subdir in _SYSTEM_HOOKS:
+        if predicate(instance):
+            paths.append(f"/home/ql/qlds-{instance.port}/{subdir}/{filename}")
+    if instance.ld_preload_hooks:
+        hooks = (h.strip() for h in instance.ld_preload_hooks.split(',') if h.strip())
+        paths.extend(f"/home/ql/qlds-{instance.port}/minqlx-plugins/{fn}" for fn in hooks)
+    return ":".join(paths)
+
+
 log = logging.getLogger(__name__)
 
 
@@ -174,11 +193,13 @@ def deploy_instance_logic(instance_id):
         
         # Prepare extravars specific to deployment (now safe to access instance.host.name)
         qlds_args_string = _build_qlds_args_string(instance)
+        ld_preload_paths = _build_ld_preload_paths(instance)
 
         deploy_extravars = {
             'port': instance.port,
             'host_name': instance.host.name, # Pass the host name (used for config path)
             'qlds_args': qlds_args_string, # Pass the constructed args for the service
+            'ld_preload_paths': ld_preload_paths,
             'cpu_affinity': cpu_affinity,
             'lan_rate_enabled': instance.lan_rate_enabled # Pass for conditional iptables/sysctl
         }
@@ -280,6 +301,7 @@ def restart_instance_logic(instance_id):
         
         # Construct qlds_args
         qlds_args_string = _build_qlds_args_string(instance)
+        ld_preload_paths = _build_ld_preload_paths(instance)
 
         # Prepare extravars for sync_instance_configs_and_restart.yml
         # We use this playbook because it re-templates the service file with new args AND restarts
@@ -288,6 +310,7 @@ def restart_instance_logic(instance_id):
             'port': instance.port,
             'id': instance.id,
             'qlds_args': qlds_args_string,
+            'ld_preload_paths': ld_preload_paths,
             'cpu_affinity': cpu_affinity
         }
         restart_extravars = with_self_host_network_extravars(instance, restart_extravars)
@@ -497,6 +520,7 @@ def apply_instance_config_logic(instance_id, restart=True, reconcile_lan_rate_ne
         cpu_affinity = ensure_instance_cpu_affinity(instance)
         
         qlds_args_string = _build_qlds_args_string(instance)
+        ld_preload_paths = _build_ld_preload_paths(instance)
 
         # Prepare extravars
         apply_config_extravars = {
@@ -504,6 +528,7 @@ def apply_instance_config_logic(instance_id, restart=True, reconcile_lan_rate_ne
             'port': instance.port,         # Add port to target correct service name for restart
             'id': instance.id,             # Keep id
             'qlds_args': qlds_args_string, # Pass constructed args for service re-templating
+            'ld_preload_paths': ld_preload_paths,
             'cpu_affinity': cpu_affinity,
             'lan_rate_enabled': instance.lan_rate_enabled,
             'reconcile_lan_rate_network': reconcile_lan_rate_network,
@@ -734,11 +759,13 @@ def reconfigure_instance_lan_rate_logic(instance_id):
         cpu_affinity = ensure_instance_cpu_affinity(instance)
         
         qlds_args_string = _build_qlds_args_string(instance)
+        ld_preload_paths = _build_ld_preload_paths(instance)
 
         reconfigure_extravars = {
             'port': instance.port,
             'host_name': instance.host.name,
             'qlds_args': qlds_args_string,
+            'ld_preload_paths': ld_preload_paths,
             'cpu_affinity': cpu_affinity,
             'lan_rate_enabled': instance.lan_rate_enabled
         }

--- a/ui/tasks.py
+++ b/ui/tasks.py
@@ -218,7 +218,6 @@ def reconfigure_instance_lan_rate(instance_id, lock_token=None):
 @rq.job(timeout=300)
 @with_app_context
 def apply_instance_hooks(instance_id, restart_service=True, lock_token=None):
-    """RQ task entry point for applying LD_PRELOAD hook changes."""
     try:
         return apply_instance_hooks_logic(instance_id, restart_service=restart_service)
     finally:

--- a/ui/tasks.py
+++ b/ui/tasks.py
@@ -14,6 +14,7 @@ from ui.task_logic.ansible_instance_mgmt import (
     delete_instance_logic,
     reconfigure_instance_lan_rate_logic
 )
+from ui.task_logic.ansible_instance_hooks import apply_instance_hooks_logic
 from ui.task_logic.ansible_host_setup import setup_host_ansible_logic
 from ui.task_logic.ansible_host_restart import restart_host_ansible_logic
 from ui.task_logic.ansible_host_rename import rename_host_logic
@@ -209,6 +210,17 @@ def reconfigure_instance_lan_rate(instance_id, lock_token=None):
     """RQ task entry point for reconfiguring LAN rate settings for a QL instance."""
     try:
         return reconfigure_instance_lan_rate_logic(instance_id)
+    finally:
+        if lock_token:
+            from ui.task_lock import release_lock
+            release_lock('instance', instance_id, lock_token)
+
+@rq.job(timeout=300)
+@with_app_context
+def apply_instance_hooks(instance_id, restart_service=True, lock_token=None):
+    """RQ task entry point for applying LD_PRELOAD hook changes."""
+    try:
+        return apply_instance_hooks_logic(instance_id, restart_service=restart_service)
     finally:
         if lock_token:
             from ui.task_lock import release_lock


### PR DESCRIPTION
## Summary
- Add per-instance `ld_preload_hooks` storage, migration, API routes, validation, and RQ/Ansible apply flow.
- Add LD_PRELOAD path building and preserve it through deploy/restart/config/LAN-rate unit re-renders.
- Add Hooks UI tab, hook badge entry point, frontend API helpers, docs, and test coverage.
- Clean up existing frontend lint errors so `pnpm lint` exits successfully.

## Validation
- `.venv/bin/pytest tests/ -q` -> 840 passed
- `pnpm test --run` -> 161 passed
- `pnpm lint` -> exits 0 with existing warnings
- `python3 -m py_compile ui/routes/instance_hooks_routes.py ui/task_logic/ansible_instance_hooks.py ui/tasks.py ui/models.py ui/routes/draft_routes.py`
- `python3 -c "import yaml; yaml.safe_load(open('ansible/playbooks/update_instance_hooks.yml'))"`
- `.venv/bin/flask db upgrade`; `.venv/bin/flask db downgrade -- -1`; `.venv/bin/flask db upgrade`
- `.venv/bin/flask db heads` -> `d4ddc1b30d85 (head)`

## Notes
- Did not run the optional real-instance smoke test or start the dev server, per repository instruction not to manage local dev services unless explicitly requested.
- Fresh subagent code review was not run because this environment requires explicit user authorization before spawning subagents.