### PR TITLE
fix: remove incorrect hook filename reservation and expose Cancel button on Hooks tab

### DIFF
--- a/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
+++ b/frontend-react/src/components/instances/EditInstanceConfigModal.jsx
@@ -896,21 +896,24 @@ function EditInstanceConfigModal({
                           )}
                         </div>
 
-                        {activeMainTab !== 'hooks' && (
                         <div className="mt-4 flex justify-between items-center flex-shrink-0">
-                          {/* Left side - Preset management buttons */}
+                          {/* Left side - Preset management buttons (non-hooks tabs only) */}
                           <div className="flex gap-2">
-                            <button type="button" onClick={() => setIsLoadPresetModalOpen(true)} className="btn btn-secondary">
-                              <FolderOpen className="w-4 h-4 mr-2" />
-                              Load Preset
-                            </button>
-                            <button type="button" onClick={() => setIsSavePresetModalOpen(true)} className="btn btn-secondary">
-                              <Save className="w-4 h-4 mr-2" />
-                              Save Preset
-                            </button>
+                            {activeMainTab !== 'hooks' && (
+                              <>
+                                <button type="button" onClick={() => setIsLoadPresetModalOpen(true)} className="btn btn-secondary">
+                                  <FolderOpen className="w-4 h-4 mr-2" />
+                                  Load Preset
+                                </button>
+                                <button type="button" onClick={() => setIsSavePresetModalOpen(true)} className="btn btn-secondary">
+                                  <Save className="w-4 h-4 mr-2" />
+                                  Save Preset
+                                </button>
+                              </>
+                            )}
                           </div>
 
-                          {/* Right side - Esc hint + Cancel/Save */}
+                          {/* Right side - Esc hint + Cancel + Save (Save hidden on hooks tab) */}
                           <div className="flex items-center gap-3">
                             <span className="font-mono text-xs text-[var(--text-muted)] tracking-wide hidden sm:inline-flex items-center gap-1.5">
                               <kbd className="px-1.5 py-0.5 rounded bg-[var(--surface-elevated)] border border-[var(--surface-border)] text-[10px] font-bold">Esc</kbd>
@@ -919,21 +922,22 @@ function EditInstanceConfigModal({
                             <button type="button" onClick={handleAttemptClose} className="btn btn-secondary">
                               Cancel
                             </button>
-                            <button
-                              type="submit"
-                              disabled={saving || loading}
-                              className="btn btn-primary"
-                            >
-                              {saving ? (
-                                <span className="flex items-center">
-                                  <LoaderCircle size={16} className="animate-spin mr-2" />
-                                  Saving...
-                                </span>
-                              ) : 'Save Configuration'}
-                            </button>
+                            {activeMainTab !== 'hooks' && (
+                              <button
+                                type="submit"
+                                disabled={saving || loading}
+                                className="btn btn-primary"
+                              >
+                                {saving ? (
+                                  <span className="flex items-center">
+                                    <LoaderCircle size={16} className="animate-spin mr-2" />
+                                    Saving...
+                                  </span>
+                                ) : 'Save Configuration'}
+                              </button>
+                            )}
                           </div>
                         </div>
-                        )}
                       </form>
                     )}
                   </div>

--- a/ui/task_logic/ansible_instance_mgmt.py
+++ b/ui/task_logic/ansible_instance_mgmt.py
@@ -25,8 +25,7 @@ SYSTEM_PLUGINS = ['serverchecker']
 # Each tuple is (filename, predicate(instance) -> bool, subdir under /home/ql/qlds-<port>/).
 _SYSTEM_HOOKS = []
 
-# Reserved so users cannot upload files that shadow future built-in hooks.
-RESERVED_HOOK_FILENAMES = {"force_rate.so"}
+RESERVED_HOOK_FILENAMES = {filename for filename, _, _ in _SYSTEM_HOOKS}
 
 
 # Validates and sanitizes input to prevent injection or malformed args


### PR DESCRIPTION
## Summary

- **Backend:** `RESERVED_HOOK_FILENAMES` was hardcoded to `{"force_rate.so"}` while `_SYSTEM_HOOKS = []`, meaning there was no actual system hook by that name — the reservation was incorrectly blocking users from uploading/enabling a plugin with that filename. It is now derived from `_SYSTEM_HOOKS` so the two can't drift out of sync.
- **Frontend:** The entire modal footer (including the modal-level Cancel button) was wrapped in `{activeMainTab !== 'hooks' && ...}`, making it invisible when on the Hooks tab. After a failed hook save, the user had no way to dismiss the modal except the X icon. Cancel and Save Configuration are now conditionally rendered inside an always-visible footer row.

## Test plan

- [ ] Upload a `.so` file named `force_rate.so` via the Plugins tab — it should upload and be listable on the Hooks tab without a "reserved" error
- [ ] Enable `force_rate.so` on the Hooks tab and click Apply & Restart — should succeed (or fail for a real reason, not the reservation)
- [ ] With any tab active, click Cancel in the modal footer — should always be visible and callable
- [ ] On the Hooks tab after a failed Apply & Restart, confirm the modal-level Cancel button is present and dismisses the modal
- [ ] On non-hooks tabs, confirm Load Preset / Save Preset / Save Configuration buttons still appear normally