### PR TITLE
fix: enable Re-run Host Setup from ERROR state

### DIFF
--- a/frontend-react/src/components/HostActionsMenu.jsx
+++ b/frontend-react/src/components/HostActionsMenu.jsx
@@ -181,7 +181,7 @@ function HostActionsMenu({
                       <button
                         type="button"
                         onClick={() => { closeMenu(); setIsRerunSetupModalOpen(true); }}
-                        disabled={!isHostActive || isQlFilterBusy || isHostBusy}
+                        disabled={!isHostReady || isQlFilterBusy || isHostBusy}
                         className={`group flex rounded-md items-center w-full px-3 py-2 text-sm transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${active ? 'bg-black/[0.04] dark:bg-white/[0.06] text-theme-primary' : 'text-theme-secondary'}`}
                       >
                         <RotateCcw size={15} className="mr-3 flex-shrink-0 text-theme-muted" />


### PR DESCRIPTION
## Summary
- `Re-run Host Setup` was disabled when host status is `ERROR` (checked `isHostActive`) while `Restart Host` was already allowed from `ERROR` (checks `isHostReady = ACTIVE || ERROR`)
- Changed the disabled guard on `Re-run Host Setup` from `!isHostActive` to `!isHostReady` so it's available when the host is in ERROR state — the most common scenario where you'd need it

## Test plan
- [ ] Set a host to ERROR state and confirm Re-run Host Setup is now enabled in the actions menu
- [ ] Confirm Re-run Host Setup is still disabled during REBOOTING / CONFIGURING / DELETING (isHostBusy check still applies)
- [ ] Confirm Restart Host behaviour unchanged