### PR TITLE
fix(ansible): ensure ssh.service is enabled on boot

### DIFF
--- a/ansible/playbooks/setup_host.yml
+++ b/ansible/playbooks/setup_host.yml
@@ -618,6 +618,8 @@
     - name: restart networking
       service: { name: networking, state: restarted }
       when: not is_standalone
+    - name: enable ssh service on boot
+      service: { name: ssh, enabled: true }
     - name: restart ssh
       service: { name: ssh, state: restarted }
       when: not is_standalone


### PR DESCRIPTION
## Summary

- Add `enabled: true` to the `restart ssh` handler in `setup_host.yml` so that `ssh.service` is persistently enabled across reboots
- On Ubuntu 24.04, the default SSH setup uses socket activation (`ssh.socket`) rather than a persistent `ssh.service`; when `unattended-upgrades` upgrades systemd packages and triggers `systemctl daemon-reexec`, the socket listener can drop — leaving the host unreachable until a full reboot
- Enabling `ssh.service` makes sshd run as a persistent daemon that owns its own TCP socket, so it survives `daemon-reexec` cycling socket activation

## Root cause (incident Jun 9 2026)

1. `host-auto-restart.timer` rebooted the OVH host at 21:54 EDT on Jun 8
2. SSH came back via `ssh.socket` and worked normally for ~9 hours
3. At 07:00:05 EDT (11:00 UTC) on Jun 9, `apt-daily-upgrade.service` upgraded systemd packages and called `daemon-reexec`
4. `ssh.socket` lost its port 22 listener — host became unreachable until manual KVM reboot ~4h later

## Prevention layers applied

1. **This PR:** `ssh.service` enabled in Ansible so future host setups are immune to `daemon-reexec`
2. **On host:** systemd/udev/libsystemd blacklisted from unattended-upgrades (applied directly to existing hosts)

## Test plan

- [ ] Run `setup_host.yml` against a test host and verify `ssh.service` is `enabled` and `active` after playbook completes
- [ ] Confirm `systemctl is-enabled ssh` returns `enabled` (not `disabled` or `indirect`)
- [ ] Verify SSH connectivity survives `sudo systemctl daemon-reexec`

---
Generated with [Claude Code](https://claude.com/claude-code)