### PR TITLE
fix(hooks): toggle animation, drag constraints, and delete modal

### DIFF
--- a/frontend-react/src/components/instances/HookRow.jsx
+++ b/frontend-react/src/components/instances/HookRow.jsx
@@ -259,7 +259,7 @@ function HookRowContent({ hook, onToggle, dragHandleProps = null, style = undefi
     }
   };
 
-  const vtName = `hook-${hook.filename.replace(/[^a-zA-Z0-9]/g, '-')}`;
+  const vtName = `hook-${hook.filename.replace(/[^a-zA-Z0-9]/g, (c) => `x${c.charCodeAt(0).toString(16)}x`)}`;
   return (
     <div
       style={{ ...style, viewTransitionName: vtName }}

--- a/frontend-react/src/components/instances/HookRow.jsx
+++ b/frontend-react/src/components/instances/HookRow.jsx
@@ -1,4 +1,4 @@
-import { Fragment, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { Menu, Transition } from '@headlessui/react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -195,6 +195,15 @@ function HookActionsMenu({ hook, instanceId, onChanged, onDelete, onRename }) {
 }
 
 function HookRowContent({ hook, onToggle, dragHandleProps = null, style = undefined, readOnly = false, instanceId, onChanged, onDelete }) {
+  const [localEnabled, setLocalEnabled] = useState(hook.enabled);
+  useEffect(() => { setLocalEnabled(hook.enabled); }, [hook.enabled]);
+
+  const handleToggle = () => {
+    if (readOnly) return;
+    setLocalEnabled((v) => !v);
+    setTimeout(() => onToggle(hook.filename), 300);
+  };
+
   const [renaming, setRenaming] = useState(false);
   const [renameSaving, setRenameSaving] = useState(false);
   const [renameValue, setRenameValue] = useState(hook.filename);
@@ -272,14 +281,14 @@ function HookRowContent({ hook, onToggle, dragHandleProps = null, style = undefi
       {readOnly && <span className="h-7 w-7 flex-shrink-0" />}
       <button
         type="button"
-        onClick={readOnly ? undefined : () => onToggle(hook.filename)}
+        onClick={readOnly ? undefined : handleToggle}
         disabled={readOnly}
         className="neu-toggle neu-toggle--sm flex-shrink-0"
         aria-label={`Enable ${hook.filename}`}
-        aria-pressed={hook.enabled}
+        aria-pressed={localEnabled}
       >
-        <span className={`neu-toggle__track ${hook.enabled ? 'neu-toggle__track--on' : 'neu-toggle__track--off'}`}>
-          <span className={`neu-toggle__knob ${hook.enabled ? 'neu-toggle__knob--on' : 'neu-toggle__knob--off'}`} />
+        <span className={`neu-toggle__track ${localEnabled ? 'neu-toggle__track--on' : 'neu-toggle__track--off'}`}>
+          <span className={`neu-toggle__knob ${localEnabled ? 'neu-toggle__knob--on' : 'neu-toggle__knob--off'}`} />
         </span>
       </button>
       {renaming ? (

--- a/frontend-react/src/components/instances/HookRow.jsx
+++ b/frontend-react/src/components/instances/HookRow.jsx
@@ -259,9 +259,10 @@ function HookRowContent({ hook, onToggle, dragHandleProps = null, style = undefi
     }
   };
 
+  const vtName = `hook-${hook.filename.replace(/[^a-zA-Z0-9]/g, '-')}`;
   return (
     <div
-      style={style}
+      style={{ ...style, viewTransitionName: vtName }}
       className={`flex min-h-12 items-center gap-3 rounded-lg border border-[var(--surface-border)] bg-[var(--surface-raised)] px-3 py-2.5${readOnly ? '' : ' hover:bg-[var(--surface-elevated)]'}`}
       data-testid={`hook-row-${hook.filename}`}
     >

--- a/frontend-react/src/components/instances/HooksTab.jsx
+++ b/frontend-react/src/components/instances/HooksTab.jsx
@@ -4,6 +4,7 @@ import { closestCenter, DndContext } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { deleteInstanceHook, fetchInstanceHooks, saveInstanceHooks, uploadInstanceHook } from '../../services/api';
 import HookRow, { MissingHookRow, ReadOnlyHookRow, SortableHookRow } from './HookRow';
+import ConfirmationModal from '../ConfirmationModal';
 
 function errorMessage(error, fallback) {
   return error?.error?.message || error?.message || fallback;
@@ -24,7 +25,6 @@ export default function HooksTab({ instanceId, draftId, onApplied }) {
   const [missingHooks, setMissingHooks] = useState([]);
   const [initialMissing, setInitialMissing] = useState([]);
   const [pendingDelete, setPendingDelete] = useState(null);
-  const [deleteError, setDeleteError] = useState(null);
 
   const reload = () => setReloadKey((k) => k + 1);
 
@@ -95,13 +95,11 @@ export default function HooksTab({ instanceId, draftId, onApplied }) {
   };
 
   const confirmDelete = async () => {
-    setDeleteError(null);
     try {
       await deleteInstanceHook(instanceId, pendingDelete.filename);
-      setPendingDelete(null);
       reload();
     } catch (err) {
-      setDeleteError(errorMessage(err, 'Delete failed.'));
+      setError(errorMessage(err, 'Delete failed.'));
     }
   };
 
@@ -261,33 +259,16 @@ export default function HooksTab({ instanceId, draftId, onApplied }) {
           {applying ? 'Applying...' : 'Apply & Restart'}
         </button>
       </div>
-      {pendingDelete && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div role="dialog" aria-modal="true" className="w-80 rounded-lg border border-[var(--surface-border)] bg-[var(--surface-elevated)] p-6 shadow-xl">
-            <h3 className="mb-2 font-semibold text-[var(--text-primary)]">Delete hook?</h3>
-            <p className="mb-4 text-sm text-[var(--text-muted)]">
-              <span className="font-mono text-[var(--text-primary)]">{pendingDelete.filename}</span> will be permanently deleted.
-            </p>
-            {deleteError && <p className="mb-3 text-sm text-theme-danger">{deleteError}</p>}
-            <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => { setPendingDelete(null); setDeleteError(null); }}
-                className="btn btn-secondary"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={confirmDelete}
-                className="rounded px-3 py-1.5 text-sm font-medium bg-red-600 text-white hover:bg-red-700"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <ConfirmationModal
+        isOpen={!!pendingDelete}
+        onClose={() => setPendingDelete(null)}
+        onConfirm={confirmDelete}
+        title="Delete hook?"
+        message={<>Delete <span className="font-mono text-theme-primary">{pendingDelete?.filename}</span>? This cannot be undone.</>}
+        confirmButtonText="Delete"
+        confirmButtonVariant="danger"
+        zIndexClass="z-[60]"
+      />
     </div>
   );
 }

--- a/frontend-react/src/components/instances/HooksTab.jsx
+++ b/frontend-react/src/components/instances/HooksTab.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 import { closestCenter, DndContext } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { deleteInstanceHook, fetchInstanceHooks, saveInstanceHooks, uploadInstanceHook } from '../../services/api';
@@ -111,11 +112,16 @@ export default function HooksTab({ instanceId, draftId, onApplied }) {
   );
 
   const toggleHook = (filename) => {
-    setEnabledOrder((current) => (
+    const doUpdate = () => setEnabledOrder((current) => (
       current.includes(filename)
         ? current.filter((item) => item !== filename)
         : [...current, filename]
     ));
+    if (document.startViewTransition) {
+      document.startViewTransition(() => flushSync(doUpdate));
+    } else {
+      doUpdate();
+    }
   };
 
   const handleDragEnd = ({ active, over }) => {

--- a/frontend-react/src/components/instances/HooksTab.jsx
+++ b/frontend-react/src/components/instances/HooksTab.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { closestCenter, DndContext } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -11,6 +11,7 @@ function errorMessage(error, fallback) {
 
 export default function HooksTab({ instanceId, draftId, onApplied }) {
   const uploadRef = useRef(null);
+  const scrollRef = useRef(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -111,6 +112,14 @@ export default function HooksTab({ instanceId, draftId, onApplied }) {
     [enabledOrder, initialEnabled, missingHooks, initialMissing],
   );
 
+  const restrictToTab = useCallback(({ transform, draggingNodeRect }) => {
+    if (!scrollRef.current || !draggingNodeRect) return { ...transform, x: 0 };
+    const bounds = scrollRef.current.getBoundingClientRect();
+    const minY = bounds.top - draggingNodeRect.top;
+    const maxY = bounds.bottom - draggingNodeRect.bottom;
+    return { ...transform, x: 0, y: Math.min(Math.max(transform.y, minY), maxY) };
+  }, []);
+
   const toggleHook = (filename) => {
     const doUpdate = () => setEnabledOrder((current) => (
       current.includes(filename)
@@ -178,7 +187,7 @@ export default function HooksTab({ instanceId, draftId, onApplied }) {
           </div>
         </div>
       )}
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
         <div className="flex items-center justify-between px-4 pt-2 pb-3">
           <span className="text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">User hooks</span>
           {!draftId && instanceId && (
@@ -196,7 +205,7 @@ export default function HooksTab({ instanceId, draftId, onApplied }) {
           )}
         </div>
         <div className="flex flex-col gap-2 px-3 pb-17">
-          <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd} modifiers={[restrictToTab]}>
             <SortableContext items={enabledOrder} strategy={verticalListSortingStrategy}>
               {enabledRows.map((hook) => (
                 <SortableHookRow

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -2804,6 +2804,13 @@ body {
   left: 18px;
 }
 
+/* Suppress root page cross-fade when hook rows animate between sections */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
 /* Responsive adjustments */
 @media (max-width: 1023px) {
   .navbar-content {

--- a/ql-assets/data/minqlx-plugins/spec_switch_guard.py
+++ b/ql-assets/data/minqlx-plugins/spec_switch_guard.py
@@ -40,10 +40,14 @@ class spec_switch_guard(minqlx.Plugin):
         self._spec_since = {}  # steam_id -> float: wall-clock time player entered spec from an active team
 
     def handle_team_switch(self, player, old_team, new_team):
+        # Record only. Do NOT pop the entry here on spec->active: an in-frame
+        # free->spec->free cycle (the queue-skip exploit) fires two
+        # team_switch events back-to-back, and the second would wipe the
+        # timer before team_switch_attempt can block the rejoiner. Entries
+        # decay naturally on the next free->spec (overwrite) and are
+        # cleaned on player_disconnect.
         if new_team == "spectator" and old_team in ("red", "blue", "free"):
             self._spec_since[player.steam_id] = time.time()
-        elif new_team != "spectator":
-            self._spec_since.pop(player.steam_id, None)
 
     def handle_team_switch_attempt(self, player, old_team, new_team):
         if not self._enabled:


### PR DESCRIPTION
## Summary
- **Toggle knob animation**: Hooks tab toggle was instant instead of smooth — the knob CSS transition was killed because toggling moves the row between two different React subtrees (unmount/remount). Fix: optimistic local `localEnabled` state flips immediately on click so the CSS transition plays on the live DOM node, then `onToggle` fires 300ms later after the animation completes.
- **Row movement animation**: After the knob animates, the card now flies from its old DOM position to its new section using the View Transitions API (`startViewTransition` + `flushSync`). The root cross-fade is suppressed to avoid a full-page flicker.
- **Drag constraint**: Drag-and-drop was unrestricted — cards could escape the modal entirely. Added a custom dnd-kit modifier that locks horizontal movement to zero and clamps vertical movement to the hooks tab's scrollable container bounds.
- **Delete confirmation modal**: Replaced the hand-rolled inline `fixed` div with the platform's shared `ConfirmationModal` (danger icon, backdrop transition, correct button styles). Delete errors now surface in the tab's top error banner.

## Test plan
- [ ] Toggle a disabled hook ON — knob slides right, track turns blue, then card flies to the enabled section
- [ ] Toggle an enabled hook OFF — knob slides left, track turns grey, then card flies to the disabled section
- [ ] Drag an enabled hook row — card stays within the hooks tab panel and only moves vertically
- [ ] Delete a hook — confirmation uses the platform modal design (danger icon, animated backdrop, red Delete button)
- [ ] Delete fails (e.g. disconnect network) — error appears in the top banner, not a broken modal