### PR TITLE
fix(specqueue): move AFK spec logic inside elif to prevent mass-spec

### DIFF
--- a/ql-assets/data/minqlx-plugins/specqueue.py
+++ b/ql-assets/data/minqlx-plugins/specqueue.py
@@ -1975,16 +1975,16 @@ class specqueue(minqlx.Plugin):
                 elif now - self._afk_last_moved.get(sid, 0) >= afk_time:
                     self._afk_last_pos.pop(sid, None)
                     self._afk_last_moved.pop(sid, None)
-                name = getattr(player, "clean_name", None) or player.name
+                    name = getattr(player, "clean_name", None) or player.name
 
-                @minqlx.next_frame
-                def move(p=player, n=name):
-                    try:
-                        p.put("spectator")
-                        self.msg("^1{} was moved to spectator for being AFK.".format(n))
-                    except Exception:
-                        pass
-                move()
+                    @minqlx.next_frame
+                    def move(p=player, n=name):
+                        try:
+                            p.put("spectator")
+                            self.msg("^1{} was moved to spectator for being AFK.".format(n))
+                        except Exception:
+                            pass
+                    move()
 
     # Search for a player name match using the supplied string
     def find_player(self, name):


### PR DESCRIPTION
## Summary

- **Bug:** In `_check_afk_positions()`, the `move()` call that forces a player to spectator was indented at the `with self._afk_pos_lock:` level instead of inside the `elif` AFK-timeout block. This caused `p.put("spectator")` to be called for **every FFA player on every poll tick (every 1 second)** whenever `self._queue.count >= 1`.
- **Trigger:** As soon as any player tried to join a full/in-progress FFA server and landed in the queue, the very next poll tick (≤1s) forced all active players to spectator simultaneously.
- **Evidence from logs on 95.179.222.60:27960:**
  ```
  [00:11:11] specqueue add to queue: uwww
  [00:11:12] specqueue process team switch: 0 to spectator
  [00:11:12] specqueue process team switch: Joc to spectator
  [00:11:12] specqueue process team switch: jartanistan to spectator
  [00:11:12] specqueue process team switch: twitch.tv/Zuni to spectator
  [00:11:12] specqueue process team switch: die to spectator
  [00:11:12] specqueue process team switch: dickhead to spectator
  [00:11:12] specqueue process team switch: recuerdame to spectator
  ```
  All 7 active players specced within 1 second of someone joining the queue.
- **Fix:** Indent `name`, `@minqlx.next_frame`, `def move()`, and `move()` four more spaces so they sit inside the `elif` block and only execute when a player has genuinely been AFK for `qlx_queueAfkMoveTime` seconds.

## Test plan

- Start an FFA server with `qlx_queueAfkMoveTime > 0`
- Fill the server to capacity so the next joiner lands in the queue
- Confirm active players are **not** kicked to spec
- Leave a player stationary for the configured AFK timeout — confirm only that player gets specced