### PR TITLE
feat(reset_acc): auto-reset acc/stats on kill or death

### DIFF
--- a/ql-assets/data/minqlx-plugins/reset_acc.py
+++ b/ql-assets/data/minqlx-plugins/reset_acc.py
@@ -182,15 +182,10 @@ class reset_acc(minqlx.Plugin):
         if reset_fn is None:
             return
 
-        if delay == 0:
-            player.tell("^3Auto-resetting now...")
-        else:
-            player.tell(f"^3Auto-reset in ^7{delay}s^3 — check ^7Tab^3 or ^7+acc^3 now.")
-
         def _fire(p=player, fn=reset_fn):
             @minqlx.next_frame
             def _execute():
-                fn(p, p)
+                fn(p, p, silent=True)
             _execute()
 
         for old_t in self._pending_timers.pop(sid, []):
@@ -216,7 +211,7 @@ class reset_acc(minqlx.Plugin):
     # Reset helpers
     # -------------------------------------------------------------------------
 
-    def _reset_all(self, requester, target):
+    def _reset_all(self, requester, target, silent=False):
         if not hasattr(minqlx, "reset_player_stats"):
             requester.tell("^1reset_player_stats not available — minqlx patch required.")
             return
@@ -229,13 +224,14 @@ class reset_acc(minqlx.Plugin):
 
         minqlx.set_score(target.id, 0)
 
-        if requester.id == target.id:
-            requester.tell("^2Stats reset. ^7Accuracy, K/D, and score are now 0.")
-        else:
-            requester.tell(f"^2Reset stats for ^7{target.clean_name}^2.")
-            target.tell(f"^2Your stats were reset by ^7{requester.clean_name}^2.")
+        if not silent:
+            if requester.id == target.id:
+                requester.tell("^2Stats reset. ^7Accuracy, K/D, and score are now 0.")
+            else:
+                requester.tell(f"^2Reset stats for ^7{target.clean_name}^2.")
+                target.tell(f"^2Your stats were reset by ^7{requester.clean_name}^2.")
 
-    def _reset_accuracy(self, requester, target):
+    def _reset_accuracy(self, requester, target, silent=False):
         if not hasattr(minqlx, "reset_player_accuracy"):
             requester.tell("^1reset_player_accuracy not available — minqlx patch required.")
             return
@@ -246,11 +242,12 @@ class reset_acc(minqlx.Plugin):
             requester.tell("^1Could not reset accuracy (player not fully connected?).")
             return
 
-        if requester.id == target.id:
-            requester.tell("^2Accuracy reset. ^7WEAP and +acc are now 0.")
-        else:
-            requester.tell(f"^2Reset accuracy for ^7{target.clean_name}^2.")
-            target.tell(f"^2Your accuracy was reset by ^7{requester.clean_name}^2.")
+        if not silent:
+            if requester.id == target.id:
+                requester.tell("^2Accuracy reset. ^7WEAP and +acc are now 0.")
+            else:
+                requester.tell(f"^2Reset accuracy for ^7{target.clean_name}^2.")
+                target.tell(f"^2Your accuracy was reset by ^7{requester.clean_name}^2.")
 
     def _find_player(self, name_fragment):
         for p in self.players():

--- a/ql-assets/data/minqlx-plugins/reset_acc.py
+++ b/ql-assets/data/minqlx-plugins/reset_acc.py
@@ -182,14 +182,16 @@ class reset_acc(minqlx.Plugin):
         if reset_fn is None:
             return
 
+        if self._pending_timers.get(sid):
+            return
+
         def _fire(p=player, fn=reset_fn):
+            self._pending_timers.pop(p.steam_id, None)
+
             @minqlx.next_frame
             def _execute():
                 fn(p, p, silent=True)
             _execute()
-
-        for old_t in self._pending_timers.pop(sid, []):
-            old_t.cancel()
 
         t = threading.Timer(delay, _fire)
         t.daemon = True

--- a/ql-assets/data/minqlx-plugins/reset_acc.py
+++ b/ql-assets/data/minqlx-plugins/reset_acc.py
@@ -13,17 +13,46 @@ Commands:
   !resetstats <name>   - Admin: reset another player's stats
   !resetacc            - Reset accuracy only (K/D unchanged)
   !resetacc <name>     - Admin: reset another player's accuracy only
+  !autoresetacc [kill|death|both|off] [delay]
+                       - Auto-reset accuracy after kill/death
+  !autoresetstats [kill|death|both|off] [delay]
+                       - Auto-reset full stats after kill/death
+
+CVars:
+  qlx_autoResetDelay   - Default delay in seconds before auto-reset fires
+                         (default: 2, range: 0-5)
 """
 
+import threading
 import minqlx
 
 ADMIN_LEVEL = 2
+AUTO_RESET_DELAY_DEFAULT = 2
+AUTO_RESET_DELAY_MAX = 5
+VALID_MODES = ("kill", "death", "both", "off")
 
 
 class reset_acc(minqlx.Plugin):
     def __init__(self):
         self.add_command("resetstats", self.cmd_resetstats, 0)
         self.add_command("resetacc", self.cmd_resetacc, 0)
+        self.add_command("autoresetacc", self.cmd_autoresetacc, 0)
+        self.add_command("autoresetstats", self.cmd_autoresetstats, 0)
+
+        self.add_hook("kill", self.handle_kill)
+        self.add_hook("player_disconnect", self.handle_disconnect)
+
+        # {steam_id: {"mode": "kill"|"death"|"both", "delay": int}}
+        self._auto_acc = {}
+        self._auto_stats = {}
+        # {steam_id: [threading.Timer, ...]}
+        self._pending_timers = {}
+
+        self.set_cvar_once("qlx_autoResetDelay", str(AUTO_RESET_DELAY_DEFAULT))
+
+    # -------------------------------------------------------------------------
+    # Manual reset commands
+    # -------------------------------------------------------------------------
 
     def cmd_resetstats(self, player, msg, channel):
         if len(msg) == 1:
@@ -58,6 +87,135 @@ class reset_acc(minqlx.Plugin):
 
         self._reset_accuracy(player, target)
         return minqlx.RET_STOP_ALL
+
+    # -------------------------------------------------------------------------
+    # Auto-reset toggle commands
+    # -------------------------------------------------------------------------
+
+    def cmd_autoresetacc(self, player, msg, channel):
+        self._handle_auto_cmd(player, msg, self._auto_acc, "accuracy", "autoresetacc")
+        return minqlx.RET_STOP_ALL
+
+    def cmd_autoresetstats(self, player, msg, channel):
+        self._handle_auto_cmd(player, msg, self._auto_stats, "stats", "autoresetstats")
+        return minqlx.RET_STOP_ALL
+
+    def _handle_auto_cmd(self, player, msg, store, label, cmd):
+        sid = player.steam_id
+
+        if len(msg) == 1:
+            pref = store.get(sid)
+            if pref is None:
+                player.tell(f"^7Auto-reset {label}: ^1off^7. Usage: ^3!{cmd} [kill|death|both|off] [0-5]")
+            else:
+                player.tell(f"^7Auto-reset {label}: ^2{pref['mode']}^7, delay ^2{pref['delay']}s^7.")
+            return
+
+        mode = msg[1].lower()
+        if mode not in VALID_MODES:
+            player.tell(f"^1Invalid mode. Use: kill | death | both | off")
+            return
+
+        if mode == "off":
+            store.pop(sid, None)
+            player.tell(f"^7Auto-reset {label}: ^1disabled^7.")
+            return
+
+        delay = self._parse_delay(player, msg[2] if len(msg) > 2 else None)
+        if delay is None:
+            return
+
+        store[sid] = {"mode": mode, "delay": delay}
+        player.tell(f"^7Auto-reset {label}: ^2{mode}^7, delay ^2{delay}s^7.")
+
+    def _parse_delay(self, player, raw):
+        """Parse and validate a delay argument. Returns int or None on error."""
+        if raw is None:
+            return self._server_delay()
+
+        if not raw.isdigit():
+            player.tell("^1Delay must be a whole number of seconds (0–5).")
+            return None
+
+        val = int(raw)
+        if val > AUTO_RESET_DELAY_MAX:
+            player.tell(f"^1Max delay is {AUTO_RESET_DELAY_MAX}s.")
+            return None
+
+        return max(0, val)
+
+    def _server_delay(self):
+        raw = self.get_cvar("qlx_autoResetDelay", int)
+        if raw is None:
+            return AUTO_RESET_DELAY_DEFAULT
+        return max(0, min(AUTO_RESET_DELAY_MAX, raw))
+
+    # -------------------------------------------------------------------------
+    # Kill hook
+    # -------------------------------------------------------------------------
+
+    def handle_kill(self, victim, killer, data):
+        if data.get("TEAMKILL"):
+            return
+
+        self_kill = killer.steam_id == victim.steam_id
+
+        if not self_kill:
+            self._schedule_auto_reset(killer, "kill")
+        self._schedule_auto_reset(victim, "death")
+
+    def _schedule_auto_reset(self, player, trigger):
+        sid = player.steam_id
+
+        # Determine which reset applies (stats takes priority over acc)
+        stats_pref = self._auto_stats.get(sid)
+        acc_pref = self._auto_acc.get(sid)
+
+        reset_fn = None
+        delay = self._server_delay()
+
+        if stats_pref and stats_pref["mode"] in (trigger, "both"):
+            reset_fn = self._reset_all
+            delay = stats_pref["delay"]
+        elif acc_pref and acc_pref["mode"] in (trigger, "both"):
+            reset_fn = self._reset_accuracy
+            delay = acc_pref["delay"]
+
+        if reset_fn is None:
+            return
+
+        if delay == 0:
+            player.tell("^3Auto-resetting now...")
+        else:
+            player.tell(f"^3Auto-reset in ^7{delay}s^3 — check ^7Tab^3 or ^7+acc^3 now.")
+
+        def _fire(p=player, fn=reset_fn):
+            @minqlx.next_frame
+            def _execute():
+                fn(p, p)
+            _execute()
+
+        t = threading.Timer(delay, _fire)
+        t.daemon = True
+        t.start()
+
+        timers = self._pending_timers.setdefault(sid, [])
+        timers.append(t)
+
+    # -------------------------------------------------------------------------
+    # Disconnect cleanup
+    # -------------------------------------------------------------------------
+
+    def handle_disconnect(self, player, reason):
+        sid = player.steam_id
+        for t in self._pending_timers.pop(sid, []):
+            t.cancel()
+        self._auto_acc.pop(sid, None)
+        self._auto_stats.pop(sid, None)
+
+    # -------------------------------------------------------------------------
+    # Reset helpers
+    # -------------------------------------------------------------------------
 
     def _reset_all(self, requester, target):
         if not hasattr(minqlx, "reset_player_stats"):

--- a/ql-assets/data/minqlx-plugins/reset_acc.py
+++ b/ql-assets/data/minqlx-plugins/reset_acc.py
@@ -31,6 +31,8 @@ AUTO_RESET_DELAY_DEFAULT = 2.0
 AUTO_RESET_DELAY_MAX = 5.0
 VALID_MODES = ("kill", "death", "both", "off")
 
+DB_KEY = "minqlx:players:{}:reset_acc:{}"
+
 
 class reset_acc(minqlx.Plugin):
     def __init__(self):
@@ -40,6 +42,7 @@ class reset_acc(minqlx.Plugin):
         self.add_command("autoresetstats", self.cmd_autoresetstats, 0)
 
         self.add_hook("kill", self.handle_kill)
+        self.add_hook("player_loaded", self.handle_loaded)
         self.add_hook("player_disconnect", self.handle_disconnect)
 
         # {steam_id: {"mode": "kill"|"death"|"both", "delay": float}}
@@ -49,6 +52,35 @@ class reset_acc(minqlx.Plugin):
         self._pending_timers = {}
 
         self.set_cvar_once("qlx_autoResetDelay", str(AUTO_RESET_DELAY_DEFAULT))
+
+    # -------------------------------------------------------------------------
+    # Redis persistence
+    # -------------------------------------------------------------------------
+
+    def _db_load(self, player, store, key):
+        sid = player.steam_id
+        mode = self.db.get(DB_KEY.format(sid, f"{key}:mode"))
+        if mode not in ("kill", "death", "both"):
+            return
+        try:
+            delay = float(self.db.get(DB_KEY.format(sid, f"{key}:delay")) or AUTO_RESET_DELAY_DEFAULT)
+        except (TypeError, ValueError):
+            delay = AUTO_RESET_DELAY_DEFAULT
+        delay = max(0.0, min(AUTO_RESET_DELAY_MAX, delay))
+        store[sid] = {"mode": mode, "delay": delay}
+
+    def _db_save(self, player, key, pref):
+        sid = player.steam_id
+        if pref is None:
+            self.db.delete(DB_KEY.format(sid, f"{key}:mode"))
+            self.db.delete(DB_KEY.format(sid, f"{key}:delay"))
+        else:
+            self.db[DB_KEY.format(sid, f"{key}:mode")] = pref["mode"]
+            self.db[DB_KEY.format(sid, f"{key}:delay")] = str(pref["delay"])
+
+    def handle_loaded(self, player):
+        self._db_load(player, self._auto_acc, "acc")
+        self._db_load(player, self._auto_stats, "stats")
 
     # -------------------------------------------------------------------------
     # Manual reset commands
@@ -93,14 +125,14 @@ class reset_acc(minqlx.Plugin):
     # -------------------------------------------------------------------------
 
     def cmd_autoresetacc(self, player, msg, channel):
-        self._handle_auto_cmd(player, msg, self._auto_acc, "accuracy", "autoresetacc")
+        self._handle_auto_cmd(player, msg, self._auto_acc, "accuracy", "autoresetacc", "acc")
         return minqlx.RET_STOP_ALL
 
     def cmd_autoresetstats(self, player, msg, channel):
-        self._handle_auto_cmd(player, msg, self._auto_stats, "stats", "autoresetstats")
+        self._handle_auto_cmd(player, msg, self._auto_stats, "stats", "autoresetstats", "stats")
         return minqlx.RET_STOP_ALL
 
-    def _handle_auto_cmd(self, player, msg, store, label, cmd):
+    def _handle_auto_cmd(self, player, msg, store, label, cmd, db_key):
         sid = player.steam_id
 
         if len(msg) == 1:
@@ -113,11 +145,12 @@ class reset_acc(minqlx.Plugin):
 
         mode = msg[1].lower()
         if mode not in VALID_MODES:
-            player.tell(f"^1Invalid mode. Use: kill | death | both | off")
+            player.tell("^1Invalid mode. Use: kill | death | both | off")
             return
 
         if mode == "off":
             store.pop(sid, None)
+            self._db_save(player, db_key, None)
             player.tell(f"^7Auto-reset {label}: ^1disabled^7.")
             return
 
@@ -125,7 +158,9 @@ class reset_acc(minqlx.Plugin):
         if delay is None:
             return
 
-        store[sid] = {"mode": mode, "delay": delay}
+        pref = {"mode": mode, "delay": delay}
+        store[sid] = pref
+        self._db_save(player, db_key, pref)
         player.tell(f"^7Auto-reset {label}: ^2{mode}^7, delay ^2{delay}s^7.")
 
     def _parse_delay(self, player, raw):

--- a/ql-assets/data/minqlx-plugins/reset_acc.py
+++ b/ql-assets/data/minqlx-plugins/reset_acc.py
@@ -155,12 +155,10 @@ class reset_acc(minqlx.Plugin):
     # -------------------------------------------------------------------------
 
     def handle_kill(self, victim, killer, data):
-        if data.get("TEAMKILL"):
-            return
-
         self_kill = killer.steam_id == victim.steam_id
+        is_teamkill = bool(data.get("TEAMKILL"))
 
-        if not self_kill:
+        if not self_kill and not is_teamkill:
             self._schedule_auto_reset(killer, "kill")
         self._schedule_auto_reset(victim, "death")
 
@@ -195,12 +193,13 @@ class reset_acc(minqlx.Plugin):
                 fn(p, p)
             _execute()
 
+        for old_t in self._pending_timers.pop(sid, []):
+            old_t.cancel()
+
         t = threading.Timer(delay, _fire)
         t.daemon = True
         t.start()
-
-        timers = self._pending_timers.setdefault(sid, [])
-        timers.append(t)
+        self._pending_timers[sid] = [t]
 
     # -------------------------------------------------------------------------
     # Disconnect cleanup

--- a/ql-assets/data/minqlx-plugins/reset_acc.py
+++ b/ql-assets/data/minqlx-plugins/reset_acc.py
@@ -20,15 +20,15 @@ Commands:
 
 CVars:
   qlx_autoResetDelay   - Default delay in seconds before auto-reset fires
-                         (default: 2, range: 0-5)
+                         (default: 2.0, range: 0-5, decimals ok e.g. 0.5)
 """
 
 import threading
 import minqlx
 
 ADMIN_LEVEL = 2
-AUTO_RESET_DELAY_DEFAULT = 2
-AUTO_RESET_DELAY_MAX = 5
+AUTO_RESET_DELAY_DEFAULT = 2.0
+AUTO_RESET_DELAY_MAX = 5.0
 VALID_MODES = ("kill", "death", "both", "off")
 
 
@@ -42,7 +42,7 @@ class reset_acc(minqlx.Plugin):
         self.add_hook("kill", self.handle_kill)
         self.add_hook("player_disconnect", self.handle_disconnect)
 
-        # {steam_id: {"mode": "kill"|"death"|"both", "delay": int}}
+        # {steam_id: {"mode": "kill"|"death"|"both", "delay": float}}
         self._auto_acc = {}
         self._auto_stats = {}
         # {steam_id: [threading.Timer, ...]}
@@ -106,7 +106,7 @@ class reset_acc(minqlx.Plugin):
         if len(msg) == 1:
             pref = store.get(sid)
             if pref is None:
-                player.tell(f"^7Auto-reset {label}: ^1off^7. Usage: ^3!{cmd} [kill|death|both|off] [0-5]")
+                player.tell(f"^7Auto-reset {label}: ^1off^7. Usage: ^3!{cmd} [kill|death|both|off] [0-5, decimals ok]")
             else:
                 player.tell(f"^7Auto-reset {label}: ^2{pref['mode']}^7, delay ^2{pref['delay']}s^7.")
             return
@@ -129,26 +129,26 @@ class reset_acc(minqlx.Plugin):
         player.tell(f"^7Auto-reset {label}: ^2{mode}^7, delay ^2{delay}s^7.")
 
     def _parse_delay(self, player, raw):
-        """Parse and validate a delay argument. Returns int or None on error."""
         if raw is None:
             return self._server_delay()
 
-        if not raw.isdigit():
-            player.tell("^1Delay must be a whole number of seconds (0–5).")
+        try:
+            val = float(raw)
+        except ValueError:
+            player.tell(f"^1Delay must be a number between 0 and {AUTO_RESET_DELAY_MAX}.")
             return None
 
-        val = int(raw)
         if val > AUTO_RESET_DELAY_MAX:
             player.tell(f"^1Max delay is {AUTO_RESET_DELAY_MAX}s.")
             return None
 
-        return max(0, val)
+        return max(0.0, val)
 
     def _server_delay(self):
-        raw = self.get_cvar("qlx_autoResetDelay", int)
+        raw = self.get_cvar("qlx_autoResetDelay", float)
         if raw is None:
             return AUTO_RESET_DELAY_DEFAULT
-        return max(0, min(AUTO_RESET_DELAY_MAX, raw))
+        return max(0.0, min(AUTO_RESET_DELAY_MAX, raw))
 
     # -------------------------------------------------------------------------
     # Kill hook


### PR DESCRIPTION
## Summary

- Adds `!autoresetacc [kill|death|both|off] [delay]` — players opt in to automatic accuracy reset after each kill, death, or both
- Adds `!autoresetstats [kill|death|both|off] [delay]` — same but resets full stats (K/D, score, accuracy)
- Adds `qlx_autoResetDelay` cvar (default: `2`, range: `0–5`) for server-wide delay before the reset fires
- Players can override the delay per-command (e.g. `!autoresetacc kill 4`), capped at 5s
- Immediate tell on kill/death warns the player to check Tab or `+acc` before stats zero out

## Frame Safety

`threading.Timer` fires in a background OS thread. All game mutations (`reset_player_stats`, `set_score`, `player.tell`) inside the timer callback are wrapped in `@minqlx.next_frame` to avoid game loop corruption.

## Edge Cases

- Teamkills: skipped — no auto-reset fires
- Self-kills (rocket jump etc.): only death-mode fires, kill-mode skipped to avoid double reset
- Stats mode takes priority over acc mode for the same trigger
- Pending timers cancelled on disconnect

## Test Plan

- `!autoresetacc kill` → get a frag → after delay, Tab shows zeroed acc, K/D unchanged
- `!autoresetstats death` → get killed → after delay, acc + K/D + score all zero
- `!autoresetacc` (no args) → shows current mode and delay
- `!autoresetacc off` → disable, confirm no reset fires
- `!autoresetacc kill 10` → should reject with "Max delay is 5s."
- Teamkill → neither player's auto-reset fires
- Disconnect mid-timer → no crash, timer cancelled cleanly