### PR TITLE
fix: resolve three pre-existing test suite regressions

### DIFF
--- a/ql-assets/data/minqlx-plugins/kickban.py
+++ b/ql-assets/data/minqlx-plugins/kickban.py
@@ -17,9 +17,18 @@ import time
 import uuid
 
 import minqlx
+from redis.exceptions import RedisError as _RedisError
 
 PLAYER_KEY = "minqlx:players:{}"
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def zadd_compat(db, key, member, score):
+    """Support both redis-py 2.x (raises RedisError) and 3.x+ (dict mapping) zadd signatures."""
+    try:
+        return db.zadd(key, {member: score})
+    except (TypeError, _RedisError):
+        return db.zadd(key, score, member)
 
 
 class kickban(minqlx.Plugin):
@@ -105,7 +114,7 @@ class kickban(minqlx.Plugin):
         ts = time.time()
         # Use a UUID as the member so two kicks within the same float-timestamp
         # resolution are stored as distinct sorted set entries.
-        self.db.zadd(self._kicks_key(steam_id), ts, str(uuid.uuid4()))
+        zadd_compat(self.db, self._kicks_key(steam_id), str(uuid.uuid4()), ts)
         count += 1
 
         if count >= self._threshold():
@@ -163,7 +172,7 @@ class kickban(minqlx.Plugin):
         ban_id = self.db.zcard(base_key)
 
         pipe = self.db.pipeline()
-        pipe.zadd(base_key, time.time() + duration * 60, ban_id)
+        zadd_compat(pipe, base_key, ban_id, time.time() + duration * 60)
         pipe.hset(
             base_key + ":{}".format(ban_id),
             mapping={

--- a/tests/test_host_api_routes.py
+++ b/tests/test_host_api_routes.py
@@ -883,7 +883,6 @@ def test_test_connection_password_accepts_supported_ubuntu24(mock_test, mock_det
     assert response.status_code == 200
     assert response.get_json()['data']['success'] is True
     assert 'Detected OS: Ubuntu 24.04.2 LTS' in response.get_json()['data']['message']
-    assert '99k LAN rate is not compatible with Ubuntu' in response.get_json()['data']['message']
     mock_test.assert_called_once_with('203.0.113.25', 22, 'root', 'secret')
     mock_detect_os.assert_called_once()
 

--- a/tests/test_serverchecker_workshop_resolution.py
+++ b/tests/test_serverchecker_workshop_resolution.py
@@ -8,7 +8,7 @@ import pytest
 
 
 def _load_serverchecker_module(monkeypatch):
-    fake_minqlx = types.SimpleNamespace(Plugin=type('Plugin', (), {}))
+    fake_minqlx = types.SimpleNamespace(Plugin=type('Plugin', (), {}), thread=lambda fn: fn)
     monkeypatch.setitem(sys.modules, 'minqlx', fake_minqlx)
 
     module_path = (


### PR DESCRIPTION
## Summary
- `kickban.py`: use the `zadd_compat` shim already established in `ban.py` instead of calling `db.zadd`/`pipe.zadd` directly with the old redis-py 2.x positional signature — the bundled redis-py version is unpinned and its `zadd` signature isn't guaranteed.
- `tests/test_serverchecker_workshop_resolution.py`: the minimal `minqlx` test stub was missing a `thread` attribute, broken since `serverchecker.py` added a `@minqlx.thread` decorator in `25996e8` (offload Redis writes off the game frame).
- `tests/test_host_api_routes.py`: drop a stale assertion expecting the Ubuntu 99k LAN rate incompatibility warning — that warning was intentionally removed from the app in `81f3e13` (Ubuntu has supported 99k LAN rate via the LD_PRELOAD hook since v1.10.0) but the test assertion was left behind.

No app-facing behavior changes; version bump / releases.md intentionally skipped per request.

## Test plan
- [x] `pytest tests/` — 971 passed, 0 failed (previously 965 passed / 6 failed)