### PR TITLE
fix: eliminate test-order pollution and stale HooksTab delete tests

### DIFF
--- a/frontend-react/src/components/instances/__tests__/HooksTab.test.jsx
+++ b/frontend-react/src/components/instances/__tests__/HooksTab.test.jsx
@@ -185,7 +185,8 @@ describe('HooksTab', () => {
 
     const row = screen.getByTestId('hook-row-a.so');
     fireEvent.click(within(row).getByRole('button', { name: /actions for a.so/i }));
-    fireEvent.click(within(row).getByRole('menuitem', { name: /delete/i, hidden: true }));
+    // The actions menu portals its items to document.body, so it's not a descendant of `row`.
+    fireEvent.click(screen.getByRole('menuitem', { name: /delete/i, hidden: true }));
 
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText(/delete hook\?/i)).toBeInTheDocument();
@@ -197,7 +198,8 @@ describe('HooksTab', () => {
 
     const row = screen.getByTestId('hook-row-a.so');
     fireEvent.click(within(row).getByRole('button', { name: /actions for a.so/i }));
-    fireEvent.click(within(row).getByRole('menuitem', { name: /delete/i, hidden: true }));
+    // The actions menu portals its items to document.body, so it's not a descendant of `row`.
+    fireEvent.click(screen.getByRole('menuitem', { name: /delete/i, hidden: true }));
 
     const dialog = await screen.findByRole('dialog');
     fireEvent.click(within(dialog).getByRole('button', { name: /delete/i }));
@@ -211,7 +213,8 @@ describe('HooksTab', () => {
 
     const row = screen.getByTestId('hook-row-a.so');
     fireEvent.click(within(row).getByRole('button', { name: /actions for a.so/i }));
-    fireEvent.click(within(row).getByRole('menuitem', { name: /delete/i, hidden: true }));
+    // The actions menu portals its items to document.body, so it's not a descendant of `row`.
+    fireEvent.click(screen.getByRole('menuitem', { name: /delete/i, hidden: true }));
 
     const dialog = await screen.findByRole('dialog');
     fireEvent.click(within(dialog).getByRole('button', { name: /cancel/i }));

--- a/tests/test_job_failure_handlers.py
+++ b/tests/test_job_failure_handlers.py
@@ -16,6 +16,7 @@ def test_host_failure_handler_updates_provisioning_to_error():
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()
@@ -43,6 +44,7 @@ def test_host_failure_handler_updates_rebooting_to_error():
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()
@@ -70,6 +72,7 @@ def test_host_failure_handler_updates_setup_pending_to_error():
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()
@@ -98,6 +101,7 @@ def test_instance_failure_handler_releases_lock(mock_release):
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()
@@ -126,6 +130,7 @@ def test_host_failure_handler_releases_lock(mock_release):
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()
@@ -157,6 +162,7 @@ def test_host_failure_handler_releases_instance_locks_before_host_lock(
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()

--- a/tests/test_reconfigure_lan_rate_branching.py
+++ b/tests/test_reconfigure_lan_rate_branching.py
@@ -11,7 +11,7 @@ from ui.task_logic import ansible_instance_mgmt
 
 @pytest.fixture(scope='module')
 def app():
-    _app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+    _app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:', 'RCON_ENABLED': False})
     with _app.app_context():
         db.create_all()
         yield _app

--- a/tests/test_redis_args.py
+++ b/tests/test_redis_args.py
@@ -7,7 +7,7 @@ from ui.task_logic.ansible_instance_mgmt import REDIS_UNIX_SOCKET_PATH
 
 @pytest.fixture(scope='module')
 def test_app():
-    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:', 'RCON_ENABLED': False})
     with app.app_context():
         yield app
 

--- a/tests/test_server_status_routes.py
+++ b/tests/test_server_status_routes.py
@@ -13,6 +13,7 @@ def status_app():
         'JWT_SECRET_KEY': 'test-secret',
         'JWT_TOKEN_LOCATION': ['headers'],
         'JWT_COOKIE_CSRF_PROTECT': False,
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()

--- a/tests/test_task_ansible_host_rename.py
+++ b/tests/test_task_ansible_host_rename.py
@@ -14,7 +14,8 @@ def test_app():
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
-        'SERVER_NAME': 'localhost.test'
+        'SERVER_NAME': 'localhost.test',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()

--- a/tests/test_task_apply_config.py
+++ b/tests/test_task_apply_config.py
@@ -10,7 +10,7 @@ TASK_LOGIC_MODULE = 'ui.task_logic.ansible_instance_mgmt'
 
 @pytest.fixture(scope='module')
 def test_app():
-    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:', 'RCON_ENABLED': False})
     with app.app_context():
         yield app
 

--- a/tests/test_task_deploy_instance.py
+++ b/tests/test_task_deploy_instance.py
@@ -11,7 +11,7 @@ TASK_LOGIC_MODULE = 'ui.task_logic.ansible_instance_mgmt'
 
 @pytest.fixture(scope='module')
 def test_app():
-    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:', 'RCON_ENABLED': False})
     with app.app_context():
         yield app
 

--- a/tests/test_task_destroy_host.py
+++ b/tests/test_task_destroy_host.py
@@ -13,7 +13,8 @@ def test_app():
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
-        'SERVER_NAME': 'localhost.test'
+        'SERVER_NAME': 'localhost.test',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()

--- a/tests/test_task_provision_host.py
+++ b/tests/test_task_provision_host.py
@@ -15,7 +15,8 @@ def test_app():
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:',
-        'SERVER_NAME': 'localhost.test'
+        'SERVER_NAME': 'localhost.test',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()

--- a/tests/test_task_resize_host.py
+++ b/tests/test_task_resize_host.py
@@ -15,6 +15,7 @@ def test_app():
         "TESTING": True,
         "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
         "SERVER_NAME": "localhost.test",
+        "RCON_ENABLED": False,
     })
     with app.app_context():
         db.create_all()

--- a/tests/test_task_restart_instance.py
+++ b/tests/test_task_restart_instance.py
@@ -10,7 +10,7 @@ TASK_LOGIC_MODULE = 'ui.task_logic.ansible_instance_mgmt'
 
 @pytest.fixture(scope='module')
 def test_app():
-    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:', 'RCON_ENABLED': False})
     with app.app_context():
         yield app
 

--- a/tests/test_task_self_host_instance_network.py
+++ b/tests/test_task_self_host_instance_network.py
@@ -17,7 +17,7 @@ TASK_LOGIC_MODULE = 'ui.task_logic.ansible_instance_mgmt'
 
 @pytest.fixture(scope='module')
 def test_app():
-    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:'})
+    app = create_app({'TESTING': True, 'SQLALCHEMY_DATABASE_URI': 'sqlite:///:memory:', 'RCON_ENABLED': False})
     with app.app_context():
         yield app
 

--- a/tests/test_task_stop_instance.py
+++ b/tests/test_task_stop_instance.py
@@ -28,7 +28,7 @@ def _mock_instance():
 @patch(f"{MOD}.db.session")
 @patch(f"{MOD}.get_current_job", return_value=None)
 def test_stop_instance_logic_without_rq_job(mock_job, mock_session, mock_log, mock_run):
-    app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"})
+    app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:", "RCON_ENABLED": False})
     with app.app_context():
         inst = _mock_instance()
         mock_session.get.return_value = inst

--- a/tests/test_wal_mode.py
+++ b/tests/test_wal_mode.py
@@ -8,6 +8,7 @@ def test_sqlite_wal_mode_enabled(tmp_path):
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': f'sqlite:///{db_path}',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()
@@ -20,6 +21,7 @@ def test_sqlite_busy_timeout_set(tmp_path):
     app = create_app({
         'TESTING': True,
         'SQLALCHEMY_DATABASE_URI': f'sqlite:///{db_path}',
+        'RCON_ENABLED': False,
     })
     with app.app_context():
         db.create_all()


### PR DESCRIPTION
## Summary
- Backend: 13 test files called `create_app()` without `'RCON_ENABLED': False` (unlike the shared `conftest.py` app fixture). Each leaked a real background `RedisListener` thread against a redis URL requiring auth, which retried forever and polluted shared `socketio` state for tests later in the run. This caused 2 failures + 50 errors in `test_rcon_fleet_events.py` and `test_socketio_rcon_integration.py` — none of which reproduced when those files ran in isolation. Added the same guard already used by the shared fixture.
- Frontend: 3 tests in `HooksTab.test.jsx` scoped their `menuitem` query to `within(row)`, but `HookActionsMenu` portals its dropdown to `document.body`, so the menu items are never descendants of the row. Switched to `screen.getByRole`.

## Test plan
- `pytest tests/` — 1392 passed, 0 failed, 0 errors (previously 2 failed + 50 errors on a full-suite run)
- `pnpm test` (frontend-react) — 537 passed, 0 failed (previously 3 failed)