### PR TITLE
Fix redis-py 2.x/3.x compat bugs in kickban/player_info/silence/voteban

### DIFF
--- a/configs/presets/_builtin/default/scripts/player_info.py
+++ b/configs/presets/_builtin/default/scripts/player_info.py
@@ -32,6 +32,7 @@ import random
 import time
 import os
 import re
+from redis.exceptions import RedisError as _RedisError
 
 # This code makes sure the required superclass is loaded automatically
 try:
@@ -62,6 +63,14 @@ MAX_ATTEMPTS = 3
 CACHE_EXPIRE = 60*30 # 30 minutes TTL.
 DEFAULT_RATING = 1500
 SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm")
+
+
+def zadd_compat(db, key, member, score):
+    """Support both redis-py 2.x (raises RedisError) and 3.x+ (dict mapping) zadd signatures."""
+    try:
+        return db.zadd(key, {member: score})
+    except (TypeError, _RedisError):
+        return db.zadd(key, score, member)
 
 
 class player_info(iouonegirlPlugin):
@@ -318,7 +327,7 @@ class player_info(iouonegirlPlugin):
             base_key = PLAYER_KEY.format(player.steam_id) + ":bans"
             ban_id = self.db.zcard(base_key)
             db = self.db.pipeline()
-            db.zadd(base_key, time.time() + td.total_seconds(), ban_id)
+            zadd_compat(db, base_key, ban_id, time.time() + td.total_seconds())
             ban = {"expires": expires, "reason": "deactivated account", "issued": now, "issued_by": "player_info"}
             db.hmset(base_key + ":{}".format(ban_id), ban)
             db.execute()

--- a/configs/presets/_builtin/default/scripts/silence.py
+++ b/configs/presets/_builtin/default/scripts/silence.py
@@ -20,10 +20,20 @@ import minqlx
 import datetime
 import time
 import re
+from redis.exceptions import RedisError as _RedisError
 
 LENGTH_REGEX = re.compile(r"(?P<number>[0-9]+) (?P<scale>seconds?|minutes?|hours?|days?|weeks?|months?|years?)")
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 PLAYER_KEY = "minqlx:players:{}"
+
+
+def zadd_compat(db, key, member, score):
+    """Support both redis-py 2.x (raises RedisError) and 3.x+ (dict mapping) zadd signatures."""
+    try:
+        return db.zadd(key, {member: score})
+    except (TypeError, _RedisError):
+        return db.zadd(key, score, member)
+
 
 class silence(minqlx.Plugin):
     def __init__(self):
@@ -149,7 +159,7 @@ class silence(minqlx.Plugin):
             silence_id = self.db.zcard(base_key)
             score = time.time() + td.total_seconds()
             db = self.db.pipeline()
-            db.zadd(base_key, score, silence_id)
+            zadd_compat(db, base_key, silence_id, score)
             silence = {"expires": expires, "reason": reason, "issued": now, "issued_by": player.steam_id}
             db.hmset(base_key + ":{}".format(silence_id), silence)
             db.execute()
@@ -194,7 +204,7 @@ class silence(minqlx.Plugin):
         else:
             db = self.db.pipeline()
             for silence_id, score in silences:
-                db.zincrby(base_key, silence_id, -score)
+                db.zincrby(base_key, amount=-score, value=silence_id)
             db.execute()
             if ident in self.silenced:
                 del self.silenced[ident]

--- a/configs/presets/_builtin/default/scripts/voteban.py
+++ b/configs/presets/_builtin/default/scripts/voteban.py
@@ -20,6 +20,7 @@ import requests
 import datetime
 import time
 import os
+from redis.exceptions import RedisError as _RedisError
 
 LENGTH_REGEX = re.compile(r"(?P<number>[0-9]+) (?P<scale>seconds?|minutes?|hours?|days?|weeks?|months?|years?)")
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -28,6 +29,15 @@ PLAYER_KEY = "minqlx:players:{}"
 VERSION = "v1.11"
 
 VOTEBAN_FILE = "voteban.txt"
+
+
+def zadd_compat(db, key, member, score):
+    """Support both redis-py 2.x (raises RedisError) and 3.x+ (dict mapping) zadd signatures."""
+    try:
+        return db.zadd(key, {member: score})
+    except (TypeError, _RedisError):
+        return db.zadd(key, score, member)
+
 
 class voteban(minqlx.Plugin):
     def __init__(self):
@@ -212,7 +222,7 @@ class voteban(minqlx.Plugin):
             base_key = PLAYER_KEY.format(id) + ":votebans"
             ban_id = self.db.zcard(base_key)
             db = self.db.pipeline()
-            db.zadd(base_key, time.time() + td.total_seconds(), ban_id)
+            zadd_compat(db, base_key, ban_id, time.time() + td.total_seconds())
             ban = {"expires": expires, "reason": reason, "issued": now, "issued_by": player.steam_id}
             db.hmset(base_key + ":{}".format(ban_id), ban)
             db.execute()
@@ -323,7 +333,7 @@ class voteban(minqlx.Plugin):
             else:
                 db = self.db.pipeline()
                 for p, score in votebans:
-                    db.zincrby(base_key, p, -score)
+                    db.zincrby(base_key, amount=-score, value=p)
                 db.execute()
                 player.tell("^2{}^3 has been deleted from the Vote Ban list.".format(messageName))
             

--- a/ql-assets/data/minqlx-plugins/kickban.py
+++ b/ql-assets/data/minqlx-plugins/kickban.py
@@ -31,6 +31,14 @@ def zadd_compat(db, key, member, score):
         return db.zadd(key, score, member)
 
 
+def hset_compat(db, key, mapping):
+    """Support both redis-py < 3.5.0 (no mapping= kwarg on hset) and >= 3.5.0 hset signatures."""
+    try:
+        return db.hset(key, mapping=mapping)
+    except TypeError:
+        return db.hmset(key, mapping)
+
+
 class kickban(minqlx.Plugin):
     def __init__(self):
         super().__init__()
@@ -173,9 +181,10 @@ class kickban(minqlx.Plugin):
 
         pipe = self.db.pipeline()
         zadd_compat(pipe, base_key, ban_id, time.time() + duration * 60)
-        pipe.hset(
+        hset_compat(
+            pipe,
             base_key + ":{}".format(ban_id),
-            mapping={
+            {
                 "expires": expires_str,
                 "reason": "Auto-banned: kicked {} times within {} minutes".format(count, window),
                 "issued": now_str,

--- a/ql-assets/data/minqlx-plugins/player_info.py
+++ b/ql-assets/data/minqlx-plugins/player_info.py
@@ -32,6 +32,7 @@ import random
 import time
 import os
 import re
+from redis.exceptions import RedisError as _RedisError
 
 # This code makes sure the required superclass is loaded automatically
 try:
@@ -62,6 +63,14 @@ MAX_ATTEMPTS = 3
 CACHE_EXPIRE = 60*30 # 30 minutes TTL.
 DEFAULT_RATING = 1500
 SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm")
+
+
+def zadd_compat(db, key, member, score):
+    """Support both redis-py 2.x (raises RedisError) and 3.x+ (dict mapping) zadd signatures."""
+    try:
+        return db.zadd(key, {member: score})
+    except (TypeError, _RedisError):
+        return db.zadd(key, score, member)
 
 
 class player_info(iouonegirlPlugin):
@@ -318,7 +327,7 @@ class player_info(iouonegirlPlugin):
             base_key = PLAYER_KEY.format(player.steam_id) + ":bans"
             ban_id = self.db.zcard(base_key)
             db = self.db.pipeline()
-            db.zadd(base_key, time.time() + td.total_seconds(), ban_id)
+            zadd_compat(db, base_key, ban_id, time.time() + td.total_seconds())
             ban = {"expires": expires, "reason": "deactivated account", "issued": now, "issued_by": "player_info"}
             db.hmset(base_key + ":{}".format(ban_id), ban)
             db.execute()

--- a/ql-assets/data/minqlx-plugins/silence.py
+++ b/ql-assets/data/minqlx-plugins/silence.py
@@ -20,10 +20,20 @@ import minqlx
 import datetime
 import time
 import re
+from redis.exceptions import RedisError as _RedisError
 
 LENGTH_REGEX = re.compile(r"(?P<number>[0-9]+) (?P<scale>seconds?|minutes?|hours?|days?|weeks?|months?|years?)")
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 PLAYER_KEY = "minqlx:players:{}"
+
+
+def zadd_compat(db, key, member, score):
+    """Support both redis-py 2.x (raises RedisError) and 3.x+ (dict mapping) zadd signatures."""
+    try:
+        return db.zadd(key, {member: score})
+    except (TypeError, _RedisError):
+        return db.zadd(key, score, member)
+
 
 class silence(minqlx.Plugin):
     def __init__(self):
@@ -149,7 +159,7 @@ class silence(minqlx.Plugin):
             silence_id = self.db.zcard(base_key)
             score = time.time() + td.total_seconds()
             db = self.db.pipeline()
-            db.zadd(base_key, score, silence_id)
+            zadd_compat(db, base_key, silence_id, score)
             silence = {"expires": expires, "reason": reason, "issued": now, "issued_by": player.steam_id}
             db.hmset(base_key + ":{}".format(silence_id), silence)
             db.execute()
@@ -194,7 +204,7 @@ class silence(minqlx.Plugin):
         else:
             db = self.db.pipeline()
             for silence_id, score in silences:
-                db.zincrby(base_key, silence_id, -score)
+                db.zincrby(base_key, amount=-score, value=silence_id)
             db.execute()
             if ident in self.silenced:
                 del self.silenced[ident]

--- a/ql-assets/data/minqlx-plugins/voteban.py
+++ b/ql-assets/data/minqlx-plugins/voteban.py
@@ -20,6 +20,7 @@ import requests
 import datetime
 import time
 import os
+from redis.exceptions import RedisError as _RedisError
 
 LENGTH_REGEX = re.compile(r"(?P<number>[0-9]+) (?P<scale>seconds?|minutes?|hours?|days?|weeks?|months?|years?)")
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -28,6 +29,15 @@ PLAYER_KEY = "minqlx:players:{}"
 VERSION = "v1.11"
 
 VOTEBAN_FILE = "voteban.txt"
+
+
+def zadd_compat(db, key, member, score):
+    """Support both redis-py 2.x (raises RedisError) and 3.x+ (dict mapping) zadd signatures."""
+    try:
+        return db.zadd(key, {member: score})
+    except (TypeError, _RedisError):
+        return db.zadd(key, score, member)
+
 
 class voteban(minqlx.Plugin):
     def __init__(self):
@@ -212,7 +222,7 @@ class voteban(minqlx.Plugin):
             base_key = PLAYER_KEY.format(id) + ":votebans"
             ban_id = self.db.zcard(base_key)
             db = self.db.pipeline()
-            db.zadd(base_key, time.time() + td.total_seconds(), ban_id)
+            zadd_compat(db, base_key, ban_id, time.time() + td.total_seconds())
             ban = {"expires": expires, "reason": reason, "issued": now, "issued_by": player.steam_id}
             db.hmset(base_key + ":{}".format(ban_id), ban)
             db.execute()
@@ -323,7 +333,7 @@ class voteban(minqlx.Plugin):
             else:
                 db = self.db.pipeline()
                 for p, score in votebans:
-                    db.zincrby(base_key, p, -score)
+                    db.zincrby(base_key, amount=-score, value=p)
                 db.execute()
                 player.tell("^2{}^3 has been deleted from the Vote Ban list.".format(messageName))
             


### PR DESCRIPTION
## Summary

Same class of bug as `41829b5` (ban.py's `zincrby` fix): the bundled `redis-py` version on a QLDS host isn't pinned and can be 2.x or 3.x, and several redis-py commands changed argument order/signature between those major versions. An audit of every `self.db`/redis-touching plugin in `ql-assets/data/minqlx-plugins` (36 files) turned up four more sibling plugins hitting this same class of bug:

- **kickban.py** — `pipe.hset(key, mapping={...})`. The `mapping=` kwarg on `hset` only exists on redis-py ≥3.5.0 (verified against actual redis-py source: 3.0.0's signature is `hset(name, key, value)`, no `mapping` param at all). On any older host this raises `TypeError` mid-pipeline, silently dropping the already-queued ban-score write too. Fix: new `hset_compat` helper, mirroring the existing `zadd_compat`.
- **player_info.py** — raw positional `zadd(name, score, value)` in `ban_deactivated()`. Same broken pattern `zadd_compat` already fixes in ban.py, but this file never had the helper. Worse: the whole block is wrapped in a bare `except:`, so on redis-py 3.x the `TypeError` is silently swallowed — the player gets **kicked but never actually banned**, while the code reports "could not be banned."
- **silence.py** — same raw positional `zadd` bug in `cmd_silence`, plus a `zincrby(name, value, amount)` argument-order swap in `cmd_unsilence` (identical to the already-fixed ban.py bug). On redis-py 3.x, `!unsilence` increments the wrong sorted-set member, so the silence silently never actually clears.
- **voteban.py** — same raw positional `zadd` bug in `cmd_voteBan`, plus the same `zincrby` argument-order swap in `cmd_voteUnBan`. Vote-ban removal silently fails on redis-py 3.x hosts for the same reason.

All four fixes reuse the same two established patterns from ban.py:
- `zadd_compat(db, key, member, score)` — try the modern mapping-dict call, fall back to the legacy positional one.
- `hset_compat(db, key, mapping)` (new, kickban.py only) — try `hset(mapping=...)`, fall back to `hmset`.
- `zincrby(..., amount=, value=)` — keyword args resolve correctly on both redis-py major versions.

Also syncs the fix to the git-tracked `configs/presets/_builtin/default/scripts/` copies of `player_info.py`/`silence.py`/`voteban.py` (`kickban.py` has no `_builtin` copy). Other on-disk preset directories under `configs/presets/` are gitignored/untracked local files, not part of this PR.

## Test plan

- [x] `python3 -m py_compile` on all 4 changed canonical files + all synced preset copies — all pass.
- [x] Manually traced minqlx's actual `database.py` source to confirm `self.db` always wraps `redis.StrictRedis` (never the legacy `redis.Redis` class), and cross-checked the redis-py source at 2.10.6, 3.0.0, and 3.5.3 for the exact signatures being patched.
- [ ] No automated test harness exists for minqlx plugins in this repo (they run inside the bundled minqlx interpreter on the game host) — verification is by code review + the compile check above.
