### PR TITLE
P3: port the 6 remaining QLSM plugins to minqlxtended

### DIFF
--- a/configs/presets/_builtin/default-minqlxtended/scripts/commands.py
+++ b/configs/presets/_builtin/default-minqlxtended/scripts/commands.py
@@ -1,0 +1,86 @@
+# This is an extension plugin for minqlxtended.
+# Copyright (C) 2018 BarelyMiSSeD (github)
+
+# You can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+
+# You should have received a copy of the GNU General Public License
+# along with minqlxtended. If not, see <http://www.gnu.org/licenses/>.
+
+# This is a plugin and command listing script for the minqlxtended admin bot.
+# This plugin will list all the in game commands loaded on the server.
+"""
+//Server Config cvars
+//Set the permission level needed to list the commands
+set qlx_commandsAdmin "3"
+//Enable to show only the commands the calling player can use, disable to show all commands (0=disable, 1=enable)
+set qlx_commandsOnlyEligible "1"
+"""
+
+import minqlxtended
+
+VERSION = "1.0"
+
+# Hard cap on output lines per invocation to avoid flooding the client
+# command buffer. Use !lc <plugin_name> to narrow results past the cap.
+MAX_TELL_LINES = 20
+
+# Number of plugin names listed per line in !plugins output.
+PLUGINS_PER_LINE = 7
+
+
+class commands(minqlxtended.Plugin):
+    def __init__(self):
+        # queue cvars
+        self.set_cvar_once("qlx_commandsAdmin", "3")
+        self.set_cvar_once("qlx_commandsOnlyEligible", "1")
+
+        # Minqlx bot commands
+        self.add_command("plugins", self.list_plugins, self.get_cvar("qlx_commandsAdmin", int))
+        self.add_command(("lc", "listcmds", "listcommands"), self.cmd_list, self.get_cvar("qlx_commandsAdmin", int),
+                         usage="<plugin_name>")
+
+    def list_plugins(self, player, msg, channel):
+        names = sorted(self.plugins)
+        count = len(names)
+        if not count:
+            return
+        lines = []
+        for i in range(0, count, PLUGINS_PER_LINE):
+            lines.append("^7, ^6".join(names[i:i + PLUGINS_PER_LINE]))
+        player.tell("^1{} ^3Plugins found:".format(count))
+        player.tell("^6{}".format("^7\n^6".join(lines)))
+
+    def cmd_list(self, player, msg, channel):
+        plugins = sorted(self.plugins)
+        only_eligible = self.get_cvar("qlx_commandsOnlyEligible", bool)
+        caller_perm = self.db.get_permission(player)
+        search = msg[1].lower() if len(msg) > 1 else None
+        lines = ["^1Plugin^7: ^2Number of Commands"]
+        count = 0
+        for name in plugins:
+            if search and search not in name.lower():
+                continue
+            try:
+                cmds = self.plugins[name].commands
+            except Exception:
+                minqlxtended.log_exception()
+                continue
+            entries = []
+            for cmd in cmds:
+                if only_eligible and caller_perm < cmd.permission:
+                    continue
+                entries.append("^7(^2{}^7) ^6{}".format(cmd.permission, "^7|^6".join(cmd.name)))
+            if entries:
+                m = len(entries)
+                lines.append("^1{}^7: {} ^3Command{}".format(name, m, "s" if m > 1 else ""))
+                lines.append("^7, ".join(entries))
+                count += 1
+        if not count:
+            player.tell("^3No Plugin matches ^4{}".format(search))
+            return
+        for line in lines[:MAX_TELL_LINES]:
+            player.tell(line)
+        if len(lines) > MAX_TELL_LINES:
+            player.tell("^3Output truncated. Use ^7!lc <plugin_name> ^3to narrow results.")

--- a/configs/presets/_builtin/default-minqlxtended/scripts/myFun.py
+++ b/configs/presets/_builtin/default-minqlxtended/scripts/myFun.py
@@ -1,0 +1,2561 @@
+# This is an extension plugin  for minqlxtended.
+# Copyright (C) 2018 BarelyMiSSeD (github)
+
+# You can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+
+# You should have received a copy of the GNU General Public License
+# along with minqlxtended. If not, see <http://www.gnu.org/licenses/>.
+
+# This plugin is a replacement for minqlx's fun.py
+# https://github.com/MinoMino/minqlx
+
+# Created by BarelyMiSSeD
+# https://github.com/BarelyMiSSeD
+
+# You are free to modify this plugin.
+# This plugin comes with no warranty or guarantee.
+
+"""
+*** This is my replacement for the minqlxtended fun.py so if you use this file make sure not to load fun.py ***
+
+This plugin plays sounds for players on the Quake Live server
+It plays the sounds included in fun.py and some from other workshop item sound packs.
+
+This can limit sound spamming to the server.
+It only allows one sound to be played at a time and each user is limited in the frequency they can play sounds.
+If you desire no restriction then set both of the 2 following cvars to "0".
+The default qlx_funSoundDelay setting will require 5 seconds from the start of any sound
+before another sound can be played by anyone.
+The default qlx_funPlayerSoundRepeat setting will require 30 seconds from the start of a player called sound before
+that player can call another sound.
+
+To set the time required between any sound add this line to your server.cfg and edit the "5":
+set qlx_funSoundDelay "5"
+
+To set the time a player has to wait after playing a sound add this like to your server.cfg and edit the "30":
+set qlx_funPlayerSoundRepeat "30"
+
+ The amount of seconds an admin has to wait before using the !playsound command again (0 will effectively disable)
+ This is to keep admins from being able to totally bypass the sound call restrictions by using !playsound
+set qlx_funAdminSoundCall "5"
+
+#Play Join Sound when players connect (set to "path/file" like below example to play sound)
+#  *** Disable the MOTD sound to use this with set qlx_motdSound "0" ****
+set qlx_funJoinSound "sound/feedback/welcome_02.wav"
+
+#Play Join Sound even if players have sounds disabled
+set qlx_funJoinSoundForEveryone "0"
+
+#Play Join Sound on every map change (set to "1" to play join sound every map change)
+set qlx_funJoinSoundEveryMap "0"
+
+#Join sound path/file
+set qlx_funJoinSound "sound/feedback/welcome_02.wav"
+
+# Play Sound when last 2 players alive (should set to "3" to play sounds always)
+# 0 = don't play sound for anyone when the last 2 (or  1 on either team of a team based game) remains
+# 1 = play sound for all except those alive when the last 2 (or  1 on either team of a team based game) remains
+# 2 = only play sounds for people who are dead/spectating when game is active
+# 3 = play sound for everyone with sounds enabled
+set qlx_funLast2Sound "3"
+
+# Enable to use a dictionary to store sounds, faster responses to trigger text (0=disable, 1=enable)
+#  Enabling will cause the server to use more memory, only enable if memory is available.
+#  Must be enabled on server startup or it will not work.
+set qlx_funFastSoundLookup "1"
+
+These extra workshop items need to be loaded on the server for it to work correctly if all sound packs are enabled:
+(put the workshop item numbers in your workshop.txt file)
+#Prestige Worldwide Soundhonks
+585892371
+#Funny Sounds Pack for Minqlx
+620087103
+#Duke Nukem Voice Sound Pack for minqlx
+572453229
+#Warp Sounds for Quake Live
+1250689005
+#West Coast Crew Sound
+1733859113
+
+The minqlxtended 'workshop' plugin needs to be loaded and the required workshop
+items added to the set qlx_workshopReferences line
+(This example shows only these required workshop items):
+set qlx_workshopReferences "585892371, 620087103, 572453229, 1250689005, 1733859113"
+(Only include the sound pack workshop item numbers that you decide to enable on the server)
+(The Default sounds use sounds already available as part of the Quake Live install)
+
+Soundpacks:
+1) The Default soundpack uses sounds that are already included in the Quake Live install.
+2) The Prestige Worldwide Soundhonks soundpack can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=585892371
+3) The Funny Sounds Pack for Minqlx can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=620087103
+4) The Duke Nukem Voice Sound Pack for minqlx soundpack can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=572453229
+5) The Warp Sounds for Quake Live soundpack can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=1250689005
+6) The West Coast Crew Sound soundpack can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=1733859113
+
+The soundpacks are all enabled by default. Which soundpacks are enabled can be set.
+set qlx_funEnableSoundPacks "63" : Enables all sound packs.
+****** How to set which sound packs are enabled ******
+Add the values for each sound pack listed below and set that value to the
+ qlx_funEnableSoundPacks in the same location as the rest of your minqlxtended cvar's.
+
+ ****Sound Pack Values****
+                               Default:  1
+         Prestige Worldwide Soundhonks:  2
+          Funny Sounds Pack for Minqlx:  4
+Duke Nukem Voice Sound Pack for minqlx:  8
+            Warp Sounds for Quake Live:  16
+                 West Coast Crew Sound:  32
+
+   Duke Nukem Soundpack Disabled Example: set qlx_funEnableSoundPacks "55"
+
+When a player issues the !listsounds command it wil list all of the sounds available on the server with
+ the sounds displayed in a tabbed format to help enable the redability of the sounds without requiring
+  the use of pages or exessie scrolling. Only the soundpacks that are enabled will be shown. Any disabled
+   soundpacks will not be displayed and will not be searchable.
+
+If !listsounds is issued with a search term it will search for sounds that contain that term and display
+ each enabled soundpack and the sounds found in them.
+
+Example: !listsounds yeah would list all the sound phrases containing 'yeah'
+and would print this to the player's console (assuming all sound packs are enabled):
+
+SOUNDS: Type these words/phrases in normal chat to play a sound on the server.
+Default
+haha yeah haha hahaha yeah yeah hahaha yeahhh
+Prestige Worldwide Soundhonks
+No Matches
+Funny Sounds Pack for Minqlx
+No Matches
+Duke Nukem Voice Sound Pack for minqlx
+No Matches
+Warp Sounds for Quake Live
+No Matches
+West Coast Crew Sound
+No Matches
+4 SOUNDS: Type these words/phrases in normal chat to play a sound on the server.
+
+If !listsounds is issued with a sound pack limiting value it will only search that soundpack for sounds.
+!listsounds #Default would only list the sounds in the Default soundpack, if it is enabled.
+
+Example: '!listsounds #Default yeah' would list all the sounds containing 'yeah' but limit that search to
+just the Default sounds and produce the following output:
+
+SOUNDS: Type these words/phrases in normal chat to play a sound on the server.
+Default
+haha yeah haha hahaha yeah yeah hahaha yeahhh
+4 SOUNDS: Type these words/phrases in normal chat to play a sound on the server.
+
+// Copy after this line into your server config
+// Let players with at least perm level 'qlx_funAdminlevel' play sounds unrestricted (change applies at load time)
+// 0-Restricted like all players; 1-Unrestricted for player time limits only; 2-Unrestricted from any time limit
+set qlx_funUnrestrictAdmin "0"
+// Set the permission level for a myFun admin (change applies at load time)
+set qlx_funAdminlevel "5"
+// Delay between sounds being played
+set qlx_funSoundDelay "5"
+// **** Used for limiting players spamming sounds. ****
+//  Amount of seconds player has to wait before allowed to play another sound
+set qlx_funPlayerSoundRepeat "30"
+// Amount of seconds an admin has to wait before using the !playsound command again (0 will effectively disable)
+set qlx_funAdminSoundCall "5"
+// Keep muted players from playing sounds
+set qlx_funDisableMutedPlayers "1"
+// Enable/Disable sound pack files
+set qlx_funEnableSoundPacks "63"
+// Join sound path/file ("0" disables sound)
+set qlx_funJoinSound "0"
+// Play Join Sound even if players have sounds disabled
+set qlx_funJoinSoundForEveryone "0"
+// Play Join Sound on every map change
+set qlx_funJoinSoundEveryMap "0"
+// Play Sound when last 2 players alive (should set to "3" to play sounds always)
+// 0 = don't play sound for anyone when the last 2 (or  1 on either team of a team based game) remains
+// 1 = play sound for all except those alive when the last 2 (or  1 on either team of a team based game) remains
+// 2 = only play sounds for people who are dead/spectating when game is active
+// 3 = play sound for everyone with sounds enabled
+set qlx_funLast2Sound "1"
+// Enable fast sound lookup
+set qlx_funFastSoundLookup "1"
+
+#############
+# NOTE
+#############
+Any sound triggers that want to be called using characters outside of A thru Z (case insensitive) need to be added as
+a custom trigger. I.E.: getting 'smiley face' to play when a user types :) would be done with
+!addtrigger smiley face = :)
+
+################################################################################################################
+#    Adding Additional Sound Packs
+################################################################################################################
+*** If making changes to the ADDITIONAL_SOUNDPACKS perform !erasedb first, then reload/restart  *****
+***** To add new sound packs without editing this file "much" *****
+Sound Pack File Requirements:
+The sound file names will use a sound trigger based on the file name. The sound file name will replace
+ underscores (_) with spaces or insert spaces after words starting with a capital letter.
+ The path inside the sound_pack.pk3 is not used to generate the sound trigger, only the sound file name.
+ I.E. The sound 'sound/warp/bend_me_over.ogg' will create the sound trigger 'bend me over'.
+      The sound 'sound/warp/BendMeOver.ogg' will also create the sound trigger 'bend me over'.
+ *** Note: These are the only 2 formats that will be correctly interpreted. I.E. 'sound/warp/bendMeOver.ogg' will not
+     generate the full sound trigger correctly.
+ *** NOTE: The name of the sound pack file stored in the baseq3 directory of the server does not have to match the
+     name of the sound pack file in the steam workshop. As long as the contents of the file are exactly the same.
+     You can rename the file stored in the baseq3 to whatever you want the sound pack called, ending it with
+     the .pk3 file extension. Use underscores for spaces in the sound pack name. (i.e. My_Enjoyable_Sounds.pk3 will be
+     shown as the sound pack 'My Enjoyable Sounds'.
+
+1) put the <sound_pack.pk3> file into the baseq3 directory of the server.
+    The baseq3 sub-directory stored in the cvar fs_basepath.
+2) add the <sound_pack.pk3> file name to the ADDITIONAL_SOUNDPACKS below with the format
+    ADDITIONAL_SOUNDPACKS = ['sound_pack.pk3', 'sound_pack_2.pk3', 'sound_pack_3.pk3']
+3) add the steam workshop item number to the qlx_workshopReferences cvar in the server.cfg
+    set qlx_workshopReferences "585892371, 620087103, 572453229, 1250689005, 1733859113, <new workshop item number>"
+
+The sound pack will be added starting at the end of the list, as sound pack 6 if nothing else was edited in the file.
+Any sound pack added here will automatically be enabled.
+"""
+
+import minqlxtended
+import random
+import time
+import re
+from os import path
+from zipfile import ZipFile
+import traceback
+import threading
+
+VERSION = "8.0"
+SOUND_TRIGGERS = "minqlx:myFun:triggers:{}:{}"
+TRIGGERS_LOCATION = "minqlx:myFun:addedTriggers:{}"
+DISABLED_SOUNDS = "minqlx:myFun:disabled:{}"
+PLAYERS_SOUNDS = "minqlx:players:{}:flags:myFun:{}"
+TEAM_BASED_GAMETYPES = ("ca", "ctf", "ft", "ictf", "tdm")
+CATEGORIES = ["#Default", "#Prestige", "#Funny", "#Duke", "#Warp", "#West"]
+SOUND_PACKS = ["Default Quake Live Sounds", "Prestige Worldwide Soundhonks", "Funny Sounds Pack for Minqlx",
+               "Duke Nukem Voice Sound Pack for minqlx", "Warp Sounds for Quake Live", "West Coast Crew Sound"]
+""" NOTE: If this is changed, you may want to perform a !erasedb before unloading/reloading myFun """
+ADDITIONAL_SOUNDPACKS = ['doompack.pk3', 'doompack2.pk3']
+
+
+class myFun(minqlxtended.Plugin):
+    Enabled_SoundPacks = []
+    soundPacks = []
+    categories = []
+    soundLists = []
+    _enable_dictionary = False
+    _sound_dictionary = {}
+    _custom_triggers = {}
+    sound_list_count = 0
+    help_msg = []
+
+    def __init__(self):
+        # Let players with perm level qlx_funAdminlevel play sounds
+        self.set_cvar_once("qlx_funUnrestrictAdmin", "0")
+        # sets the admin level for playing unrestricted sounds (level 5 recommended)
+        self.set_cvar_once("qlx_funAdminlevel", "5")
+        # Delay between sounds being played
+        self.set_cvar_once("qlx_funSoundDelay", "5")
+        # **** Used for limiting players spamming sounds. ****
+        #  Amount of seconds player has to wait before allowed to play another sound
+        self.set_cvar_once("qlx_funPlayerSoundRepeat", "30")
+        # Amount of seconds an admin has to wait before using the !playsound command again (0 will effectively disable)
+        self.set_cvar_once("qlx_funAdminSoundCall", "5")
+        # Keep muted players from playing sounds
+        self.set_cvar_once("qlx_funDisableMutedPlayers", "1")
+        # Enable/Disable sound pack files
+        self.set_cvar_once("qlx_funEnableSoundPacks", "63")
+        # Join sound path/file ("0" disables sound)
+        self.set_cvar_once("qlx_funJoinSound", "0")
+        # Play Join Sound even if players have sounds disabled
+        self.set_cvar_once("qlx_funJoinSoundForEveryone", "0")
+        # Play Join Sound on every map change
+        self.set_cvar_once("qlx_funJoinSoundEveryMap", "0")
+        # Play Sound when last 2 players alive (should set to "3" to play sounds always)
+        # 0 = don't play sound for anyone when the last 2 (or  1 on either team of a team based game) remains
+        # 1 = play sound for all except those alive when the last 2 (or  1 on either team of a team based game) remains
+        # 2 = only play sounds for people who are dead/spectating when game is active
+        # 3 = play sound for everyone with sounds enabled
+        self.set_cvar_once("qlx_funLast2Sound", "3")
+        # Enable to use a dictionary to store sounds, faster responses to trigger text (0=disable, 1=enable)
+        #  Enabling will cause the server to use more memory, only enable if memory is available.
+        #  Must be enabled on server startup, or it will not work.
+        self.set_cvar_once("qlx_funFastSoundLookup", "1")
+
+        self.add_hook("chat", self.handle_chat)
+        self.add_hook("console_print", self.handle_console_print)
+        self.add_hook("server_command", self.handle_server_command)
+        self.add_hook("player_disconnect", self.handle_player_disconnect)
+        self.add_hook("player_loaded", self.handle_player_loaded, priority=minqlxtended.Priority.LOWEST)
+        self.add_command("cookies", self.cmd_cookies)
+        self.add_command(("ls", "listsounds"), self.list_sounds)
+        self.add_command(("myfun", "fun"), self.cmd_help)
+        self.add_command(("off", "soundoff"), self.sound_off, client_cmd_perm=0)
+        self.add_command(("on", "soundon"), self.sound_on, client_cmd_perm=0)
+        self.add_command(("ol", "offlist", "soundofflist"), self.cmd_sound_off_list, client_cmd_perm=0)
+        self.add_command(("ps", "playsound", "sound"), self.cmd_sound, 3)
+        self.add_command(("pt", "playtrigger"), self.cmd_play_trigger, 3)
+        self.add_command(("ds", "disablesound"), self.cmd_disable_sound, client_cmd_perm=5, usage="<sound trigger>")
+        self.add_command(("es", "enablesound"), self.cmd_enable_sound, client_cmd_perm=5, usage="<sound trigger>")
+        self.add_command(("ld", "listdisabled"), self.cmd_list_disabled, client_cmd_perm=5)
+        self.add_command(("at", "addtrigger"), self.add_trigger, 5)
+        self.add_command(("dt", "deltrigger"), self.del_trigger, 5)
+        self.add_command(("lt", "listtriggers"), self.request_triggers, 3)
+        self.add_command(("ed", "erasedisabled"), self.erase_disabled, 5)
+        self.add_command("sounds", self.cmd_enable_sounds, usage="<0/1>")
+        self.add_command(("erase_sounds", "erasedb"), self.start_erase_db, 5)
+        self.add_command(("fill_sounds", "filldb"), self.start_fill_db, 5)
+        self.add_command("restrictadmin", self.get_set_restrict_admin, 5)
+        self.add_command("adminlevel", self.get_set_admin_level, 5)
+
+        # lambda function to insert spaces in a string (replaces _ or inserts between CamelCase). Returns lowercase.
+        self.convert = lambda x: x.replace('_', ' ') if x.islower() else ' '.join(re.findall('[A-Z][^A-Z]*', x)).lower()
+        # Class Variables
+        self.populating = False
+        # variable to show when a sound has been played
+        self.played = False
+        # variable to store the sound to be called
+        self.soundFile = None
+        # variable to store the sound trigger
+        self.trigger = ""
+        # lock serialising concurrent scan_chat threads accessing soundFile/trigger/played
+        self._sound_lock = threading.Lock()
+        # stores time of last sound play
+        self.last_sound = None
+        # variables used when checking for the presence of a sound file
+        self.checking_file = False
+        self.file_status = False
+        # sounds count
+        self._total_sounds = 0
+        # Dictionary used to store player sound call times.
+        self.sound_limiting = {}
+        # Dictionary used to store admin play sound times.
+        self.admin_limiting = {}
+        # List to store steam ids of muted players
+        self.muted_players = []
+        # populate the database and sound lists with the sound packs
+        self.start_fill_db()
+        # Welcome sound played list
+        self.playedWelcome = []
+        # command prefix
+        self._command_prefix = self.get_cvar("qlx_commandPrefix")
+        # admin settings
+        self.admin_allowed = self.get_cvar("qlx_funUnrestrictAdmin", int)
+        self.admin_level = self.get_cvar("qlx_funAdminlevel", int)
+        # Execute function to remove loaded !sound commands in other scripts
+        self.remove_conflicting_sound_commands()
+
+    def get_set_admin_level(self, player, msg, channel):
+        if len(msg) > 1:
+            try:
+                level = int(msg[1])
+                if level < 0 or level > 5:
+                    raise ValueError
+                self.admin_level = level
+                player.tell("^2myFun admin level set to ^3{}".format(self.admin_level))
+            except Exception as e:
+                player.tell("Level must be an integer. Valid levels are 0-5. Exception: {}".format(type(e).__name__))
+        else:
+            player.tell("^2myFun admin level is ^3{}\n^2{}adminlevel <perms_level> ^3to set admin level."
+                        .format(self.admin_level, self._command_prefix))
+
+    def get_set_restrict_admin(self, player, msg, channel):
+        if len(msg) > 1:
+            try:
+                level = int(msg[1])
+                if level < 0 or level > 5:
+                    raise ValueError
+                elif level == 0:
+                    self.admin_allowed = 0
+                    player.tell("^1myFun admin sound play is restricted.")
+                elif level == 1:
+                    self.admin_allowed = 1
+                    player.tell("^2myFun admin sound play is unrestricted to player time limits.")
+                else:
+                    self.admin_allowed = 2
+                    player.tell("^2myFun admin sound play is fully un-restricted.")
+            except Exception as e:
+                player.tell("Admin restriction valid values are 0/1/2. Exception: {}".format(type(e).__name__))
+        else:
+            r = ['', 'partially un-', 'fully un-']
+            player.tell("^2myFun admin is ^3{}restricted\n"
+                        "^2{}restrictadmin <0/1/2> ^3to restrict/partially un-restrict/fully un-restrict."
+                        .format(r[self.admin_allowed], self._command_prefix))
+
+    @minqlxtended.delay(3)
+    def remove_conflicting_sound_commands(self):
+        loaded_scripts = self.plugins
+        loaded_scripts.pop(self.__class__.__name__)
+        for script, handler in loaded_scripts.items():
+            try:
+                for cmd in handler.commands:
+                    if {"sound"}.intersection(cmd.name):
+                        handler.remove_command(cmd.name, cmd.handler)
+                        minqlxtended.console_print("^1myFun: Removing command ^7{} ^1used in ^7{} ^1plugin"
+                                             .format(cmd.name, script))
+            except:
+                continue
+
+    def start_erase_db(self, player, msg=None, channel=None):
+        self.erase_db(player)
+
+    @minqlxtended.thread
+    def erase_db(self, player, msg=None, channel=None):
+        length = len(self.Enabled_SoundPacks)
+        done = self.erase_triggers(player, length)
+        self.soundPacks = []
+        self.categories = []
+        self.soundLists = []
+        self.help_msg = []
+        self._total_sounds = 0
+        player.tell("^1Completed Database Sound Trigger Erase.")
+
+    def erase_triggers(self, player, index, all_triggers=True):
+        def del_db(num):
+            y = self.db.keys(SOUND_TRIGGERS.format(num, "*"))
+            for key in y:
+                del self.db[key]
+            try:
+                player.tell("^1Database Table {} delete commands issued".format(self.categories[num]))
+            except:
+                pass
+
+        if all_triggers:
+            for x in range(index):
+                del_db(x)
+        else:
+            del_db(index)
+        return True
+
+    def start_fill_db(self, player=None, msg=None, channel=None):
+        self.fill_db(player)
+
+    @minqlxtended.thread
+    def fill_db(self, player, msg=None, channel=None):
+        try:
+            if player:
+                player.tell("^1Filling myFun Sounds Database")
+            # List to store the enable/disabled status of the sound packs (they should all be 0 here)
+            self.Enabled_SoundPacks = [0] * len(CATEGORIES)
+            # set the desired sound packs to enabled
+            self.enable_packs()
+            self.soundPacks = SOUND_PACKS
+            self.categories = CATEGORIES
+            self.soundLists = []
+            # Using sound dictionary or database list return
+            self._enable_dictionary = self.get_cvar("qlx_funFastSoundLookup", bool)
+            if self._enable_dictionary:
+                # Sound dictionary, used if enabled
+                self._sound_dictionary = {}
+                self._custom_triggers = {}
+                for num in range(len(self.Enabled_SoundPacks)):
+                    self._sound_dictionary[num] = {}
+            self.populate_database(player)
+        except Exception as e:
+            minqlxtended.console_print("^3myFun fill_db Exception: {}\n{}".format(type(e).__name__, traceback.format_exc()))
+
+    def enable_packs(self):
+        packs = self.get_cvar("qlx_funEnableSoundPacks", int)
+        maximum = 2 ** len(CATEGORIES)
+        if packs > maximum:
+            packs = maximum
+        binary = bin(packs)[2:]
+        length = len(binary)
+        count = 0
+        # Set all values to disabled, initially
+        for x in range(len(self.Enabled_SoundPacks)):
+            self.Enabled_SoundPacks[x] = 0
+
+        # save the packs value's binary representation to the slots in self.Enabled_SoundPacks
+        # to identify the enabled sound packs
+        while length > 0:
+            self.Enabled_SoundPacks[count] = int(binary[length - 1])
+            count += 1
+            length -= 1
+
+    @minqlxtended.delay(2)
+    def handle_player_loaded(self, player):
+        if self.get_cvar("qlx_motdSound") != "0" or self.get_cvar("qlx_funJoinSound") == "0":
+            return
+        # plays the join sound for a connecting player if qlx_funJoinSound is set and qlx_motdSound is not set
+        # join sound can be played for everyone even if sounds are disabled if qlx_funJoinSoundForEveryone is enabled
+        # join sound will play every map load for already connected players if qlx_funJoinSoundEveryMap is enabled
+        welcome_sound = self.get_cvar("qlx_funJoinSound")
+        if welcome_sound and player.steam_id not in self.playedWelcome and\
+                (self.get_cvar("qlx_funJoinSoundForEveryone", bool) or
+                 self.db.get_flag(player, "essentials:sounds_enabled", default=True)):
+            super().play_sound(welcome_sound, player)
+            if not self.get_cvar("qlx_funJoinSoundEveryMap", bool):
+                self.playedWelcome.append(player.steam_id)
+
+    # Remove stored information for disconnecting players
+    def handle_player_disconnect(self, player, reason):
+        self.process_player_disconnect(player)
+        return
+
+    def process_player_disconnect(self, player):
+        try:
+            del self.sound_limiting[player.steam_id]
+        except:
+            pass
+        try:
+            self.muted_players.remove(player.steam_id)
+        except:
+            pass
+        try:
+            self.playedWelcome.remove(player.steam_id)
+        except:
+            pass
+
+    # stores the mute status of a player when muted or un-muted
+    def handle_server_command(self, player, cmd):
+        self.process_server_command(cmd)
+        return
+
+    def process_server_command(self, cmd):
+        if "has been muted" in cmd:
+            cmd_string = cmd.split()
+            cmd_len = len(cmd_string)
+            name_length = cmd_len - 4
+            name = " ".join(cmd_string[1:name_length]).strip('"')
+            muted = self.find_player(name)
+            steam_id = muted[0].steam_id
+            if steam_id not in self.muted_players:
+                self.muted_players.append(steam_id)
+        elif "has been unmuted" in cmd:
+            cmd_string = cmd.split()
+            cmd_len = len(cmd_string)
+            name_length = cmd_len - 4
+            name = " ".join(cmd_string[1:name_length]).strip('"')
+            muted = self.find_player(name)
+            steam_id = muted[0].steam_id
+            try:
+                self.muted_players.remove(steam_id)
+            except:
+                pass
+
+    # Monitors the chat messages of players to process the sound triggers
+    def handle_chat(self, player, msg, channel):
+        self.scan_chat(player, msg, channel)
+        return
+
+    @minqlxtended.thread
+    def scan_chat(self, player, msg, channel):
+        # don't process the chat if it was in the wrong channel or the player is muted or has sounds turned off
+        if msg.startswith("{}".format(self._command_prefix)) or channel != "chat" or\
+                player.steam_id in self.muted_players or\
+                not self.db.get_flag(player, "essentials:sounds_enabled", default=True):
+            return
+
+        # find the sound trigger for this sound (sets self.trigger, self.soundFile)
+        # lock ensures concurrent chat messages from two players don't race on shared fields
+        with self._sound_lock:
+            if self.find_sound_trigger(self.clean_text(msg)):
+                # stop sound processing if the player has this sound trigger turned off
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, self.soundFile)):
+                    return minqlxtended.Return.NONE
+                # check sound delay time
+                delay_time = self.check_time(player)
+                # see if admin is trying to play sound
+                admin_sound = self.db.get_permission(player.steam_id) >= self.admin_level
+                if delay_time:
+                    # if admins have no delay time restriction then PASS
+                    if self.admin_allowed and admin_sound:
+                        pass
+                    # otherwise, impose the delay time wait and stop sound trigger processing
+                    else:
+                        player.tell("^3You played a sound recently. {} seconds timeout remaining."
+                                    .format(delay_time))
+                        return minqlxtended.Return.NONE
+                # check to see if a sound has been played
+                if not self.last_sound or self.admin_allowed > 1 and admin_sound:
+                    pass
+                # Make sure the last sound played was not within the sound delay limit
+                elif time.time() - self.last_sound < self.get_cvar("qlx_funSoundDelay", int):
+                    player.tell("^3A sound has been played in last {} seconds. Try again after the timeout."
+                                .format(self.get_cvar("qlx_funSoundDelay")))
+                    return minqlxtended.Return.NONE
+                # call the play sound function
+                self.play_sound(self.soundFile)
+
+            # If the sound played record the time with the player's steam id (for delay_time processing)
+            if self.played:
+                self.sound_limiting[player.steam_id] = time.time()
+            # unset self.played so it can be checked again the next time a sound trigger is typed
+            self.played = False
+        return minqlxtended.Return.NONE
+
+    def handle_console_print(self, text):
+        self.process_console_print(text)
+        return
+
+    def process_console_print(self, text):
+        try:
+            if self.checking_file and 'files listed' in text:
+                self.file_status = True if text.split(" ")[0] == "1" else False
+        except:
+            minqlxtended.log_exception()
+    
+    @staticmethod
+    def match_string(pattern, string, flags=0):
+        return re.fullmatch(pattern, string, flags)
+
+    # Compares the msg with the sound triggers to determine if there is a match
+    # --This function is only called from other functions running as their own threads.--
+    def find_sound_trigger(self, msg):
+        self.trigger = None
+        self.soundFile = None
+        msg_lower = msg.lower()
+        match_msg = msg_lower.replace(':()?', '')
+        sound_dict = 0
+        while sound_dict < len(self.Enabled_SoundPacks):
+            if self.Enabled_SoundPacks[sound_dict]:
+                if self._enable_dictionary:
+                    if msg_lower[0] in self._sound_dictionary[sound_dict]:
+                        for sound, item in self._sound_dictionary[sound_dict][msg_lower[0]].items():
+                            match = item.split(";")
+                            try:
+                                # if sound trigger matches set self.trigger to the trigger,
+                                #  self.soundFile to the location of the sound
+                                if self.match_string(match[0], match_msg):
+                                    if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                        return False
+                                    self.trigger = sound
+                                    if match[1]:
+                                        self.soundFile = match[1]
+                                    return True
+                            except Exception as e:
+                                minqlxtended.console_print("^3myFun find sound trigger dictionary Exception: {}\n{}"
+                                                     .format(type(e).__name__, traceback.format_exc()))
+                else:
+                    keys = self.db.keys(SOUND_TRIGGERS.format(sound_dict, "*"))
+                    for key in keys:
+                        match = self.db.get(key).split(";")
+                        # if sound trigger matches set self.trigger to the trigger,
+                        #  self.soundFile to the location of the sound
+                        try:
+                            if self.match_string(match[0], match_msg):
+                                if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                    return False
+                                self.trigger = key.split(":")[4]
+                                if match[1]:
+                                    self.soundFile = match[1]
+                                return True
+                            # if custom sound triggers have been added for the sound being examined
+                            #  it searches through the stored triggers for a match
+                            if self.db.exists(TRIGGERS_LOCATION.format(match[1])):
+                                for trigger in self.db.lrange(TRIGGERS_LOCATION.format(match[1]), 0, -1):
+                                    if trigger == match_msg:
+                                        if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                            return False
+                                        self.trigger = key.split(":")[-1]
+                                        if match[1]:
+                                            self.soundFile = match[1]
+                                        return True
+                        except Exception as e:
+                            minqlxtended.console_print("^3myFun find sound trigger database Exception: {}\n{}"
+                                                 .format(type(e).__name__, traceback.format_exc()))
+                # if custom sound triggers have been added for the sound being examined
+                #  it searches through the stored triggers for a match
+                try:
+                    for file, triggers in self._custom_triggers.items():
+                        if msg_lower in triggers:
+                            if self.db.exists(DISABLED_SOUNDS.format(file)):
+                                return False
+                            self.trigger = msg_lower
+                            self.soundFile = file
+                            return True
+                except Exception as e:
+                    minqlxtended.console_print("^3myFun find Custom sound trigger Exception: {}\n{}"
+                                         .format(type(e).__name__, traceback.format_exc()))
+            sound_dict += 1
+        return False
+
+    def add_trigger(self, player, msg, channel):
+        self.add_custom_trigger(player, msg)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    def add_custom_trigger(self, player, msg):
+        if len(msg) < 3:
+            player.tell("^3usage^7: ^1{}addtrigger ^7<^2default trigger^7> ^1= ^7<^4added trigger^7>"
+                        .format(self._command_prefix))
+            return minqlxtended.Return.STOP_ALL
+        msg_lower = [x.lower() for x in msg]
+        split = 0
+        count = 0
+        for item in msg_lower[1:]:
+            count += 1
+            if item == "=":
+                split = count
+                break
+        if split == 0:
+            player.tell("^7You MUST include a ^1= ^7sign in to separate the default trigger from the desired trigger.")
+            player.tell("^3usage^7: ^1{}addtrigger ^7<^2default trigger^7> ^1= ^7<^4added trigger^7>"
+                        .format(self._command_prefix))
+        else:
+            trigger = " ".join(msg_lower[1:split])
+            add_trigger = " ".join(msg_lower[split + 1:])
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(TRIGGERS_LOCATION.format(found_path)):
+                    for existing_trigger in self.db.lrange(TRIGGERS_LOCATION.format(found_path), 0, -1):
+                        if existing_trigger == add_trigger:
+                            player.tell("^3This trigger already exists")
+                            return minqlxtended.Return.STOP_ALL
+                self.db.rpush(TRIGGERS_LOCATION.format(found_path), add_trigger)
+                if self._enable_dictionary:
+                    try:
+                        if add_trigger not in self._custom_triggers[found_path]:
+                            self._custom_triggers[found_path].append(add_trigger)
+                    except KeyError:
+                        self._custom_triggers[found_path] = []
+                        self._custom_triggers[found_path].append(add_trigger)
+                    except Exception as e:
+                        minqlxtended.console_print("^3myFun add custom trigger Exception: {}\n{}"
+                                             .format(type(e).__name__, traceback.format_exc()))
+                player.tell("^3The sound trigger ^4{0} ^3has been added to the trigger list for ^2{1}."
+                            .format(add_trigger, trigger))
+                return minqlxtended.Return.STOP_ALL
+            else:
+                player.tell("^3usage^7: ^1{}addtrigger ^7<^2default trigger^7> ^1= ^7<^4added trigger^7>"
+                            .format(self._command_prefix))
+        return minqlxtended.Return.STOP_ALL
+
+    def del_trigger(self, player, msg, channel):
+        self.del_custom_trigger(player, msg)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    def del_custom_trigger(self, player, msg):
+        if len(msg) < 3:
+            player.tell("^3usage^7: ^1!deltrigger ^7<^2default trigger^7> ^1= ^7<^4delete trigger^7>")
+            return minqlxtended.Return.STOP_ALL
+        msg_lower = [x.lower() for x in msg]
+        split = 0
+        count = 0
+        for item in msg_lower[1:]:
+            count += 1
+            if item == "=":
+                split = count
+                break
+        if split == 0:
+            player.tell("^7You MUST include a ^1= ^7sign in to separate the default trigger from the desired trigger.")
+            player.tell("^3usage^7: ^1{}deltrigger ^7<^2default trigger^7> ^1= ^7<^4del trigger^7>"
+                        .format(self._command_prefix))
+        else:
+            trigger = " ".join(msg_lower[1:split])
+            del_trigger = " ".join(msg_lower[split + 1:])
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(TRIGGERS_LOCATION.format(found_path)):
+                    self.db.lrem(TRIGGERS_LOCATION.format(found_path), 0, del_trigger)
+                    if self._enable_dictionary:
+                        try:
+                            if del_trigger in self._custom_triggers[found_path]:
+                                self._custom_triggers[found_path].remove(del_trigger)
+                        except ValueError:
+                            pass
+                        except Exception as e:
+                            minqlxtended.console_print("^3myFun del custom trigger Exception: {}\n{}"
+                                                 .format(type(e).__name__, traceback.format_exc()))
+                    player.tell("^3The sound trigger ^4{0} ^3has been deleted from the trigger list for ^2{1}."
+                                .format(del_trigger, trigger))
+                else:
+                    player.tell("^3There are no custom triggers saved for ^4{}".format(trigger))
+            else:
+                player.tell("^3usage^7: ^1{}deltrigger ^7<^2default trigger^7> ^1= ^7<^4del trigger^7>"
+                            .format(self._command_prefix))
+        return minqlxtended.Return.STOP_ALL
+
+    def request_triggers(self, player, msg, channel):
+        self.list_triggers(player, msg)
+
+    @minqlxtended.thread
+    def list_triggers(self, player, msg):
+        if len(msg) > 1:
+            msg_lower = [x.lower() for x in msg]
+            trigger = " ".join(msg_lower[1:])
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(TRIGGERS_LOCATION.format(found_path)):
+                    if self.db.llen(TRIGGERS_LOCATION.format(found_path)) == 0:
+                        player.tell("^3There are no custom triggers saved for ^4{}".format(trigger))
+                        return minqlxtended.Return.STOP_ALL
+                    else:
+                        triggers = self.db.lrange(TRIGGERS_LOCATION.format(found_path), 0, -1)
+                        self.msg("^3The custom sound triggers for ^4{0}^7: ^2{1}".format(trigger, ", ".join(triggers)))
+                        return
+                else:
+                    player.tell("^3There are no custom triggers saved for ^4{}".format(trigger))
+            else:
+                player.tell("^3There are no custom sound triggers for ^2{}^7.".format(trigger))
+            return minqlxtended.Return.STOP_ALL
+        else:
+            message = ["^3Custom Triggers:"]
+            triggers = self.db.keys(TRIGGERS_LOCATION.format("*"))
+            for item in triggers:
+                trigger = self.sound_trigger(item.split(":")[3])
+                custom_triggers = self.db.lrange(item, 0, 100)
+                message.append("^1{}:\n^2   {}".format(trigger, "^7, ^2".join(custom_triggers)))
+            player.tell("\n".join(message))
+            return minqlxtended.Return.STOP_ALL
+
+    # players can turn off individual sounds for only themselves
+    def sound_off(self, player, msg, channel):
+        self.cmd_sound_off(player, msg)
+
+    @minqlxtended.thread
+    def cmd_sound_off(self, player, msg):
+        if len(msg) < 2:
+            if self.soundFile:
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, self.soundFile)):
+                    player.tell("^3The sound ^4{0} ^3is already disabled. Use ^1{1}on ^4{0} ^3to enable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(self.trigger, self._command_prefix))
+                else:
+                    self.db.set(PLAYERS_SOUNDS.format(player.steam_id, self.soundFile), 1)
+                    if not self.trigger:
+                        self.find_sound_trigger(self.soundFile)
+                    player.tell("^3The sound ^4{0} ^3has been disabled. Use ^1{1}on ^4{0} ^3to enable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(self.trigger, self._command_prefix))
+            else:
+                player.tell("^1{0}off <sound call> ^7use ^6{0}listsounds #help ^7to find triggers"
+                            .format(self._command_prefix))
+
+        else:
+            trigger = " ".join(msg[1:]).lower()
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, found_path)):
+                    player.tell("^3The sound ^4{0} ^3is already disabled. Use ^1{1}on ^4{0} ^3to enable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(trigger, self._command_prefix))
+                else:
+                    self.db.set(PLAYERS_SOUNDS.format(player.steam_id, found_path), 1)
+                    player.tell("^3The sound ^4{0} ^3has been disabled. Use ^1{1}on ^4{0} ^3to enable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(trigger, self._command_prefix))
+            else:
+                player.tell("^3usage: ^1{0}off <sound call> ^7use ^1{0}listsounds #help ^7to find triggers"
+                            .format(self._command_prefix))
+        return
+
+    # players can re-enable sounds that they previously disabled for themselves
+    def sound_on(self, player, msg, channel):
+        self.cmd_sound_on(player, msg)
+
+    @minqlxtended.thread
+    def cmd_sound_on(self, player, msg):
+        if len(msg) < 2:
+            if self.soundFile:
+                if not self.trigger:
+                    self.find_sound_trigger(self.soundFile)
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, self.soundFile)):
+                    del self.db[PLAYERS_SOUNDS.format(player.steam_id, self.soundFile)]
+                    player.tell("^3The sound ^4{0} ^3has been enabled. Use ^1{1}off ^4{0} ^3to disable."
+                                .format(self.trigger, self._command_prefix))
+                else:
+                    player.tell("^3The sound ^4{0} ^3is not disabled. Use ^1{1}off ^4{0} ^3to disable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(self.trigger, self._command_prefix))
+            else:
+                player.tell("^1{0}on <sound call> ^7use ^1{0}listsounds #help ^7to find triggers"
+                            .format(self._command_prefix))
+
+        else:
+            trigger = " ".join(msg[1:]).lower()
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, found_path)):
+                    del self.db[PLAYERS_SOUNDS.format(player.steam_id, found_path)]
+                    player.tell("^3The sound ^4{0} ^3has been enabled. Use ^1{1}off ^4{0} ^3to disable."
+                                .format(trigger, self._command_prefix))
+                else:
+                    player.tell("^3The sound ^4{0} ^3is not disabled. Use ^1{1}off ^4{0} ^3to disable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(trigger, self._command_prefix))
+            else:
+                player.tell("^3usage: ^1{0}on <sound call> ^7use ^1{0}listsounds #help ^7to find triggers"
+                            .format(self._command_prefix))
+        return
+
+    # return the path to the supplied sound trigger
+    def find_sound_path(self, trigger):
+        sound_dict = 0
+        while sound_dict < len(self.Enabled_SoundPacks):
+            if self.Enabled_SoundPacks[sound_dict]:
+                keys = self.db.keys(SOUND_TRIGGERS.format(sound_dict, "*"))
+                for key in keys:
+                    if key.split(":")[4] == trigger:
+                        return self.db.get(key).split(";")[1]
+            sound_dict += 1
+
+        return False
+
+    # return the sound trigger for the sound at the supplied path
+    def sound_trigger(self, _path, disabled_lookup=False):
+        sound_dict = 0
+        while sound_dict < len(self.Enabled_SoundPacks):
+            if self.Enabled_SoundPacks[sound_dict]:
+                if not self._enable_dictionary or disabled_lookup:
+                    keys = self.db.keys(SOUND_TRIGGERS.format(sound_dict, "*"))
+                    for key in keys:
+                        if self.db.get(key).split(";")[1] == _path:
+                            return key.split(":")[4]
+                else:
+                    for sub, triggers in self._sound_dictionary[sound_dict].items():
+                        for sound, item in self._sound_dictionary[sound_dict][sub].items():
+                            if item.split(";")[1] == _path:
+                                return sound
+            sound_dict += 1
+
+        return None
+
+    def cmd_sound_off_list(self, player, msg, channel):
+        self.sound_off_list(player)
+
+    @minqlxtended.thread
+    # list the disabled sound to the requesting player
+    def sound_off_list(self, player):
+        try:
+            disabled_key = "minqlx:players:{0}:flags:myFun".format(player.steam_id)
+            sound_list = []
+            count = 0
+            _list = self.db.keys(disabled_key + ":*")
+            for key in _list:
+                trigger = self.sound_trigger(key.split(":")[-1])
+                if trigger:
+                    trigger = trigger.replace('?', '')
+                    sound_list.append(trigger)
+                    count += 1
+            player.tell("^3You have ^4{0} ^3sounds disabled: ^1{1}".format(count, "^7, ^1".join(sound_list)))
+            return
+        except Exception as e:
+            player.tell("^1Sound off list exception. See minqlxtended log for details")
+            minqlxtended.console_print("^1myFun sound_off_list exception: {}\n{}"
+                                 .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_disable_sound(self, player, msg, channel):
+        self.disable_sound(player, msg, channel)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    # disable the specified sound on the server
+    def disable_sound(self, player, msg, channel):
+        try:
+            if len(msg) < 2:
+                return
+            trigger = " ".join(msg[1:]).lower()
+            sound_path = self.find_sound_path(trigger)
+            if sound_path:
+                self.db.set(DISABLED_SOUNDS.format(sound_path), 1)
+                player.tell("^3The sound ^4{} ^3is now disabled.".format(trigger))
+                self.populate_sound_lists()
+            else:
+                player.tell("^3Invalid sound trigger. Use ^1{}ls ^7<^1search string^7>"
+                            " ^3to find the correct sound trigger.".format(self._command_prefix))
+            return
+        except Exception as e:
+            player.tell("^1Disable sound exception. See minqlxtended log for details")
+            minqlxtended.console_print("^1myFun disable_sound exception: {}\n{}"
+                                 .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_enable_sound(self, player, msg, channel):
+        self.enable_sound(player, msg)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    # enable the specified sound on the server
+    def enable_sound(self, player, msg):
+        if len(msg) < 2:
+            return
+        trigger = " ".join(msg[1:]).lower()
+        sound_path = self.find_sound_path(trigger)
+        if sound_path:
+            try:
+                if self.db.exists(DISABLED_SOUNDS.format(sound_path)):
+                    del self.db[DISABLED_SOUNDS.format(sound_path)]
+                    self.populate_sound_lists()
+                    player.tell("^3The sound ^1{} ^3is now enabled".format(trigger))
+                else:
+                    player.tell("^3The sound ^1{} ^3is not disabled. ^1{}ld ^3to see the disabled sounds."
+                                .format(trigger, self._command_prefix))
+            except Exception as e:
+                player.tell("^1Enable sound exception when finding trigger {}. See minqlxtended log for details"
+                            .format(trigger))
+                minqlxtended.console_print("^1myFun enable_sound exception: {}\n{}"
+                                     .format(type(e).__name__, traceback.format_exc()))
+        else:
+            player.tell("^3The sound trigger ^4{} ^3was not found. Ensure the trigger supplied is correct."
+                        " ^1{}ld ^3to see the disabled sounds."
+                        .format(trigger, self._command_prefix))
+        return minqlxtended.Return.STOP_ALL
+
+    def cmd_list_disabled(self, player, msg, channel):
+        player.tell("^2Retrieving Disabled Sounds from the database.")
+        self.list_disabled(player)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    # list the sounds disabled on the server for the requesting player
+    def list_disabled(self, player):
+        try:
+            sound_list = []
+            count = 0
+            for key in self.db.keys("minqlx:myFun:disabled:*"):
+                sound_path = key.split(":")[-1]
+                trigger = self.sound_trigger(sound_path, True)
+                if not trigger:
+                    continue
+                sound_list.append(trigger)
+                count += 1
+            if count:
+                player.tell("^3There {} ^4{} ^3sound{} disabled on the server:\n^1{}"
+                            .format('is' if count == 1 else 'are', count, '' if count == 1 else 's',
+                                    "\n^1".join(sound_list)))
+            else:
+                player.tell("^3There are ^4No ^3disabled sounds on this server.")
+            return
+        except Exception as e:
+            player.tell("^1myFun exception listing disabled sounds.\n"
+                        "^7You may want to erase stored disabled sounds with {}ed"
+                        .format(self._command_prefix))
+            minqlxtended.console_print("^1myFun list_disabled exception (? erase stored disabled sounds with {}ed ?): {}\n{}"
+                                 .format(self._command_prefix, type(e).__name__, traceback.format_exc()))
+
+    def erase_disabled(self, player, msg, channel):
+        player.tell("^3Erasing all Disabled sounds from the database.")
+        self.fix_disabled(player, True)
+        return minqlxtended.Return.STOP_ALL
+
+    # function to change the way the disabled sounds are stored in the database
+    @minqlxtended.thread
+    def fix_disabled(self, player=None, erase_all=False):
+        try:
+            if erase_all:
+                for key in self.db.keys("minqlx:myFun:disabled:*"):
+                    del self.db[key]
+                self.populate_sound_lists()
+                if player:
+                    player.tell("^2All Disabled sounds have been removed from the database.")
+                minqlxtended.console_print("^3All Disabled sounds have been removed from the database.")
+            else:
+                for key in self.db.keys("minqlx:myFun:disabled:*"):
+                    try:
+                        trigger = key.split(":")[-1]
+                        sound_path = self.find_sound_path(trigger)
+                        if sound_path:
+                            self.db.set(DISABLED_SOUNDS.format(sound_path), 1)
+                        del self.db[DISABLED_SOUNDS.format(trigger)]
+                    except:
+                        continue
+        except Exception as e:
+            minqlxtended.console_print("^1myFun fix_disabled exception: {}\n{}"
+                                 .format(type(e).__name__, traceback.format_exc()))
+
+    # play the sound at the supplied path
+    def cmd_sound(self, player, msg, channel):
+        self.exec_sound(player, msg, channel)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    def exec_sound(self, player, msg, channel):
+        if len(msg) < 2:
+            player.tell("^3Include a path/sound to play.")
+            return
+
+        if "console" != channel and not self.db.get_flag(player, "essentials:sounds_enabled", default=True):
+            player.tell("^1Your sounds are disabled. Use ^6{}sounds ^1to enable them again."
+                        .format(self._command_prefix))
+            minqlxtended.console_print("^3Admin {} tried calling sound {} but player's sounds are disabled."
+                                 .format(player, msg[1]))
+            return
+
+        try:
+            play_time = time.time() - self.admin_limiting[player.steam_id]
+            if play_time >= self.get_cvar("qlx_funAdminSoundCall", int):
+                stop = False
+            else:
+                stop = self.get_cvar("qlx_funAdminSoundCall", int) - play_time
+        except KeyError:
+            stop = False
+
+        if stop is not False:
+            minqlxtended.console_print("^3Admin {} tried calling sound {} before timeout expired.".format(player, msg[1]))
+            player.tell("^3You have {} seconds before you can call another sound.".format(int(stop)))
+        else:
+            # check for a valid sound file
+            self.checking_file = True
+            self.file_status = False
+            minqlxtended.console_command("fdir {}".format(msg[1]))
+            count = 0
+            while count < 10 and not self.file_status:
+                count += 1
+                time.sleep(0.1)
+            self.checking_file = False
+            if not self.file_status:
+                player.tell("^1Sound ^4{} ^1is not valid.".format(msg[1]))
+                return
+
+            if "console" == channel:
+                minqlxtended.console_print("^1Playing sound^7: ^4{}".format(msg[1]))
+                self.play_sound(msg[1])
+                return
+            minqlxtended.console_print("^3Admin {} called sound {}".format(player, msg[1]))
+            self.admin_limiting[player.steam_id] = time.time()
+            self.play_sound(msg[1])
+        return
+
+    def cmd_play_trigger(self, player, msg, channel):
+        self.play_trigger(player, msg, channel)
+        return minqlxtended.Return.STOP_ALL
+
+    # play the sound associated with the trigger
+    @minqlxtended.thread
+    def play_trigger(self, player, msg, channel):
+        if len(msg) < 2:
+            player.tell("Include a sound trigger.")
+            return
+
+        msg_lower = " ".join(msg[1:]).lower()
+
+        if "console" != channel and not self.db.get_flag(player, "essentials:sounds_enabled", default=True):
+            player.tell("Your sounds are disabled. Use ^6{}sounds^7 to enable them again."
+                        .format(self._command_prefix))
+            return
+
+        sound = self.get_sound_trigger(msg_lower)
+
+        # Play locally to validate.
+        if not sound or "console" != channel and not super().play_sound(sound, player):
+            player.tell("^1Invalid sound.")
+            return
+
+        if "console" == channel:
+            minqlxtended.console_print("^1Playing sound^7: ^4{}".format(msg_lower))
+
+        self.play_sound(sound)
+
+        return
+
+    # Compares the msg with the sound triggers to determine if there is a match
+    def get_sound_trigger(self, msg_lower):
+        sound_dict = 0
+        while sound_dict < len(self.Enabled_SoundPacks):
+            if self.Enabled_SoundPacks[sound_dict]:
+                keys = self.db.keys(SOUND_TRIGGERS.format(sound_dict, "*"))
+                for key in keys:
+                    match = self.db.get(key).split(";")
+                    # if sound trigger matches set self.trigger to the trigger,
+                    #  self.soundFile to the location of the sound
+                    try:
+                        if self.match_string(match[0], msg_lower):
+                            if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                return None
+                            return match[1]
+                        # if custom sound triggers have been added for the sound being examined
+                        #  it searches through the stored triggers for a match
+                        if self.db.exists(TRIGGERS_LOCATION.format(match[1])):
+                            for trigger in self.db.lrange(TRIGGERS_LOCATION.format(match[1]), 0, -1):
+                                if trigger == msg_lower:
+                                    if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                        return None
+                                    return match[1]
+                    except Exception as e:
+                        minqlxtended.console_print("^3myFun get_sound_trigger Exception: {}\n{}"
+                                             .format(type(e).__name__, traceback.format_exc()))
+            sound_dict += 1
+        return None
+
+    # plays the supplied sound for the players on the server (if the player has the sound(s) enabled)
+    def play_sound(self, _path, player=None):
+        play = self.last_2_sound()
+        active = self.game.state in ["in_progress", "countdown"]
+        if play == 3 or not active:
+            self.played = True
+            self.last_sound = time.time()
+            targets = [p for p in self.players()
+                       if self.db.get_flag(p, "essentials:sounds_enabled", default=True)
+                       and not self.db.exists(PLAYERS_SOUNDS.format(p.steam_id, _path))]
+        elif play == 1 or (play == 2 and active):
+            self.played = True
+            self.last_sound = time.time()
+            teams = self.teams()
+            targets = [p for p in teams["red"] + teams["blue"] + teams["free"]
+                       if not p.is_alive
+                       and self.db.get_flag(p, "essentials:sounds_enabled", default=True)
+                       and not self.db.exists(PLAYERS_SOUNDS.format(p.steam_id, _path))]
+            targets += [p for p in teams["spectator"]
+                        if self.db.get_flag(p, "essentials:sounds_enabled", default=True)
+                        and not self.db.exists(PLAYERS_SOUNDS.format(p.steam_id, _path))]
+        else:
+            return
+
+        # dispatch send_server_command to the game frame — must not be called from a background thread
+        @minqlxtended.next_frame
+        def _send(pts=targets, path=_path):
+            for p in pts:
+                super(myFun, self).play_sound(path, p)
+        _send()
+
+    def last_2_sound(self):
+        # 0 = don't play sound for anyone when the last 2 (or  1 on either team of a team based game) remains
+        # 1 = play sound for all except those alive when the last 2 (or  1 on either team of a team based game) remains
+        # 2 = only play sounds for people who are dead/spectating when game is active
+        # 3 = play sound for everyone with sounds enabled
+        play_last2 = self.get_cvar("qlx_funLast2Sound", int)
+        if play_last2 in [2, 3]:
+            return play_last2
+        teams = self.teams()
+        remaining = 0
+        if self.game.type_short in TEAM_BASED_GAMETYPES:
+            r_remaining = 0
+            b_remaining = 0
+            for r in teams["red"]:
+                if r.is_alive:
+                    r_remaining += 1
+            for b in teams["blue"]:
+                if b.is_alive:
+                    b_remaining += 1
+            if r_remaining == 1 or b_remaining == 1:
+                remaining = 2
+        else:
+            for p in teams["free"]:
+                if p.is_alive:
+                    remaining += 1
+        if remaining == 2:
+            return play_last2
+        else:
+            return 3
+
+    # populates the sound list that is used to list the available sounds on the server
+    # All calls to this function are called in sub-threads
+    def populate_sound_lists(self, player=None):
+        try:
+            if not self.populating:
+                self.populating = True
+                self.soundLists = [[] if x else None for x in self.Enabled_SoundPacks]
+                self.sound_list_count = 0
+                self._total_sounds = 0
+                self.help_msg = []
+                custom_triggers = {}
+                for slot, value in enumerate(self.Enabled_SoundPacks):
+                    if self.Enabled_SoundPacks[slot]:
+                        self.sound_list_count += 1
+                        self.help_msg.append(self.categories[slot])
+                        keys = self.db.keys(SOUND_TRIGGERS.format(slot, "*"))
+                        for key in keys:
+                            db_value = self.db.get(key)
+                            self._total_sounds += 1
+                            entry = db_value.split(';')
+                            if len(entry) < 2:
+                                del self.db[key]
+                                continue
+                            if self.db.exists(DISABLED_SOUNDS.format(entry[1])):
+                                continue
+                            trigger = key.split(":")[4]
+                            self.soundLists[slot].append(trigger)
+                            if self._enable_dictionary:
+                                matches = entry[0].split('|')
+                                for match in matches:
+                                    if not match:
+                                        continue
+                                    _m = match[0].lower()
+                                    if not _m.isalpha():
+                                        custom_triggers[match] = entry[1]
+                                        continue
+                                    if _m not in self._sound_dictionary[slot]:
+                                        self._sound_dictionary[slot][_m] = {}
+                                    self._sound_dictionary[slot][_m][match] = "{};{}".format(match, entry[1])
+                                if self.db.exists(TRIGGERS_LOCATION.format(entry[1])):
+                                    self._custom_triggers[entry[1]] = self.db.lrange(TRIGGERS_LOCATION.format(entry[1]), 0, -1)
+                        self.soundLists[slot].sort()
+                        self.category_loaded(slot, 'Quick Lookup Dictionary', player)
+                if custom_triggers:
+                    for match, entry in custom_triggers.items():
+                        if entry not in self._custom_triggers:
+                            self._custom_triggers[entry] = []
+                        self._custom_triggers[entry].append(match)
+            sound_packs = []
+            count = 0
+            while count < len(self.Enabled_SoundPacks):
+                if self.Enabled_SoundPacks[count]:
+                    sound_packs.append(self.soundPacks[count])
+                count += 1
+            if player:
+                player.tell("Enabled Sound Packs are: ^3{}".format(", ".join(sound_packs)))
+                player.tell("Completed Sound Pack reload.")
+            else:
+                minqlxtended.console_print("Enabled Sound Packs are: ^3{}".format(", ".join(sound_packs)))
+                minqlxtended.console_print("Completed Sound Pack reload.")
+        except Exception as e:
+            minqlxtended.console_print("myFun populate_sound_lists Exception: {}\n{}"
+                                 .format(type(e).__name__, traceback.format_exc()))
+        finally:
+            self.populating = False
+
+    def cmd_cookies(self, player, msg, channel):
+        x = random.randint(0, 100)
+        if not x:
+            channel.reply("^6♥ ^7Here you go, {}. I baked these just for you! ^6♥".format(player))
+        elif x == 1:
+            channel.reply("What, you thought ^6you^7 would get cookies from me, {}? Hah, think again.".format(player))
+        elif x < 50:
+            channel.reply("For me? Thank you, {}!".format(player))
+        else:
+            channel.reply("I'm out of cookies right now, {}. Sorry!".format(player))
+
+    ''' Here in case the essentials plugin is not loaded '''
+    def cmd_enable_sounds(self, player, msg, channel):
+        if "essentials" not in self._loaded_plugins:
+            flag = self.db.get_flag(player, "essentials:sounds_enabled", default=True)
+            self.db.set_flag(player, "essentials:sounds_enabled", not flag)
+
+            if flag:
+                player.tell("Sounds have been disabled. Use ^6{}sounds^7 to enable them again."
+                            .format(self._command_prefix))
+            else:
+                player.tell("Sounds have been enabled. Use ^6{}sounds^7 to disable them again."
+                            .format(self._command_prefix))
+
+            return minqlxtended.Return.STOP_ALL
+
+    def check_time(self, player):
+        if self.get_cvar("qlx_funUnrestrictAdmin", bool) and self.db.get_permission(player.steam_id) == 5:
+            return False
+        try:
+            saved_time = self.sound_limiting[player.steam_id]
+            play_time = time.time() - saved_time
+            if play_time > self.get_cvar("qlx_funPlayerSoundRepeat", int):
+                return False
+            else:
+                return int(self.get_cvar("qlx_funPlayerSoundRepeat", int) - play_time)
+        except KeyError:
+            return False
+
+    # list the command usage for !listsounds
+    def cmd_help(self, player, msg=None, channel=None):
+        count = 0
+        help_msg = ''
+        for msg in self.help_msg:
+            if not help_msg:
+                help_msg = msg
+            elif not count % 6:
+                help_msg = help_msg + "^7,\n^2" + msg
+            else:
+                help_msg = help_msg + "^7, ^2" + msg
+            count += 1
+        player.tell("^1myFun Version {0}\n"
+                    "^6{1}myFun ^3to quickly pull up this help menu.\n"
+                    "^6{1}listsounds ^3shows all sounds\n^6{1}listsounds #sound-pack ^3 to see just one sound"
+                    " pack\n^6{1}listsounds #sound-pack search-term ^3to see sounds in that sound pack that"
+                    " have the search term\n^6{1}listsounds search-term ^3to search all sound packs for sounds"
+                    " with that search term\n^2EXAMPLES^7:\n^6{1}listsounds #Default ^3 will display all"
+                    " ^4Default Quake Live Sounds\n^6{1}lsitsounds #Default yeah ^3 will search ^4#Default"
+                    " ^3for sounds containing ^4yeah\n^6{1}listsounds yeah ^3 will search all the sound packs"
+                    " for sounds containing ^4yeah\n^3Search terms can be multiple words\n"
+                    "^3Valid sound-pack(s) are^7:\n^2{2}\n^6{1}sounds ^3to disable^7/^3enable"
+                    " all sound playing for yourself."
+                    "\n^6{1}off^7/^6{1}on trigger ^3to disable^7/^3enable a specific sound\n^6{1}offlist ^3to see a"
+                    " list of sounds you have disabled."
+                    .format(VERSION, self._command_prefix, help_msg))
+        return
+
+    # list the command usage for !listsounds
+    def listsounds_usage(self, player):
+        if self._total_sounds:
+            count = 0
+            help_msg = ''
+            for msg in self.help_msg:
+                if not help_msg:
+                    help_msg = msg
+                elif not count % 6:
+                    help_msg = help_msg + "^7,\n^2" + msg
+                else:
+                    help_msg = help_msg + "^7, ^2" + msg
+                count += 1
+            player.tell("^1There are {2} sounds available to play.\n"
+                        "^4Include a category and/or search value for {0}listsounds\n"
+                        "^5Ex: ^4{0}listsounds #default pain\n"
+                        "^3Valid sound-pack(s) are^7:\n^2{1}\n"
+                        .format(self._command_prefix, help_msg, self._total_sounds))
+        else:
+            player.tell("^1There are no sounds loaded")
+        return
+
+    # list the available sounds to the requesting player
+    def list_sounds(self, player, msg, channel):
+        self.cmd_list_sounds(player, msg, channel)
+
+    @minqlxtended.thread
+    def cmd_list_sounds(self, player, msg, channel):
+        sounds = ["^4SOUNDS^7: ^3Type these words/phrases in normal chat to play a sound on the server.\n"]
+        length = len(msg)
+        count = 0
+        category = None
+        search = None
+        if length == 2 and msg[1]:
+            if msg[1].startswith("#"):
+                category = msg[1]
+            else:
+                search = msg[1]
+        elif length > 2 and msg[1]:
+            if msg[1].startswith("#"):
+                category = msg[1]
+                search = " ".join(msg[2:])
+            else:
+                search = " ".join(msg[1:])
+        else:
+            self.listsounds_usage(player)
+            return
+
+        if category:
+            category = category.lower()
+            if category == "#help":
+                self.cmd_help(player)
+                return
+            elif any(s.lower() == category for s in self.help_msg):
+                category_num = -1
+                cat_num = 0
+                while cat_num < len(self.categories):
+                    if self.match_string(self.categories[cat_num].lower(), category):
+                        category_num = cat_num
+                    cat_num += 1
+
+                if -1 < category_num < len(self.Enabled_SoundPacks):
+                    sounds_line = ""
+                    sounds.append("^4" + self.soundPacks[category_num] + "\n")
+                    for item in self.soundLists[category_num]:
+                        if search and search not in item:
+                            continue
+                        add_sound, status = self.line_up(sounds_line, item)
+                        if status == 1:
+                            sounds.append("^1" + sounds_line + "\n")
+                            sounds_line = add_sound
+                        elif status == 2:
+                            sounds_line += add_sound
+                            sounds.append("^1" + sounds_line + "\n")
+                            sounds_line = ""
+                        else:
+                            sounds_line += add_sound
+                        count += 1
+                    if len(sounds_line):
+                        sounds.append("^1" + sounds_line + "\n")
+
+                if count == 0:
+                    sounds.append("^3No Matches\n")
+            else:
+                if self.sound_list_count == 1:
+                    player.tell("^3INVALID ^2Category ^7given. Valid category is ^2" + "^7, ^2".join(self.help_msg))
+                else:
+                    player.tell("^3INVALID ^2Category ^7given. Valid categories are ^2" + "^7, ^2".join(self.help_msg))
+                return
+
+        else:
+            slot = 0
+            while slot < len(self.Enabled_SoundPacks):
+                sounds_line = ""
+                if self.Enabled_SoundPacks[slot]:
+                    found = 0
+                    if self.soundLists[slot]:
+                        sounds.append("^4" + self.soundPacks[slot] + "\n")
+                        for item in self.soundLists[slot]:
+                            if search and search not in item:
+                                continue
+                            add_sound, status = self.line_up(sounds_line, item)
+                            if status == 1:
+                                sounds.append("^1" + sounds_line + "\n")
+                                sounds_line = add_sound
+                            elif status == 2:
+                                sounds_line += add_sound
+                                sounds.append("^1" + sounds_line + "\n")
+                                sounds_line = ""
+                            else:
+                                sounds_line += add_sound
+                            count += 1
+                            found += 1
+                    if len(sounds_line):
+                        sounds.append("^1" + sounds_line + "\n")
+                    if found == 0:
+                        sounds.append("^3No Matches\n")
+                slot += 1
+
+            if count == 0 and search:
+                player.tell("^4Server^7: No sounds contain the search string ^1{}^7.".format(search))
+                return
+            if count == 0:
+                player.tell("^4Server^7: No sounds were found")
+                return
+
+            if self.sound_list_count > 1 and not category and not search:
+                sounds.append("^3Type ^4{}listsounds #help ^3 to get instructions on narrowing your search results.\n"
+                              .format(self._command_prefix))
+            elif not search:
+                sounds.append("^3Add a search string to further narrow results:\n^2{0}listsounds ^7<^2category^7>"
+                              " <^2search string^7>".format(self._command_prefix))
+
+        sounds.append("^2{} ^4SOUND{}^7: ^3Type these words/phrases in normal chat to trigger a sound on the server.\n"
+                      .format(count, 'S' if count > 1 else ''))
+
+        if "console" == channel:
+            for line in sounds:
+                minqlxtended.console_print(line.strip())
+        else:
+            player.tell("".join(sounds))
+        return
+
+    # puts the list of sounds in a column style format for easier reading
+    def line_up(self, sound_line, add_sound):
+        length = len(sound_line)
+        # 0 = add to line, 1 = add to new line, 2 = add current sound and start new line
+        status = 0
+        if length + len(add_sound) > 78:
+            append = add_sound
+            status = 1
+        elif length == 0:
+            append = add_sound
+        elif length < 16:
+            append = " " * (18 - length) + add_sound
+        elif length < 36:
+            append = " " * (38 - length) + add_sound
+        elif length < 56:
+            append = " " * (58 - length) + add_sound
+        elif length < 76:
+            append = " " * (78 - length) + add_sound
+            status = 2
+        else:
+            append = add_sound
+            status = 1
+        return append, status
+
+    def category_loaded(self, cat_index, target, player=None):
+        if len(self.categories) > cat_index:
+            if player:
+                player.tell("^2Category {} loaded to {}".format(self.categories[cat_index], target))
+            else:
+                minqlxtended.console_print("^2Category {} loaded to {}".format(self.categories[cat_index], target))
+
+    # These are the sounds available on the server put into the dictionaries used to search for a sound trigger match
+    #  when processing normal chat messages
+    def populate_database(self, player=None):
+        old_version = 0.0
+        if self.db.exists("minqlx:myFun:version"):
+            old_version = self.db.get("minqlx:myFun:version")
+        self.db.set("minqlx:myFun:version", VERSION)
+        self.db.set("minqlx:myFun:enabled", self.get_cvar("qlx_funEnableSoundPacks"))
+        if float(old_version) < 4.2:
+            self.fix_disabled()
+        if self.Enabled_SoundPacks[0]:
+            self.db.set(SOUND_TRIGGERS.format(0, "battlesuit"), "battlesuit;sound/vo/battlesuit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(0, "bite"), "bite;sound/vo/bite.ogg")
+            self.db.set(SOUND_TRIGGERS.format(0, "combo kill"), "combo kill;sound/vo/combokill2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(0, "haha"), "haha;sound/player/lucy/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "haha yeah haha"), "haha,? yeah?,? haha;sound/player/biker/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "yeah hahaha"), "yeah?,? haha(ha)?;sound/player/razor/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death"), "death;sound/player/biker/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death2"), "death2;sound/player/bitterman/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death3"), "death3;sound/player/bones/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death4"), "death4;sound/player/doom/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death5"), "death5;sound/player/grunt/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death6"), "death6;sound/player/hunter/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death7"), "death7;sound/player/james/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death8"), "death8;sound/player/janet/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death9"), "death9;sound/player/keel/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death10"), "death10;sound/player/klesk/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death11"), "death11;sound/player/major/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death12"), "death12;sound/player/orbb/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death13"), "death13;sound/player/santa/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death14"), "death14;sound/player/sarge/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death15"), "death15;sound/player/slash/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death16"), "death16;sound/player/sorlag/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death17"), "death17;sound/player/tankjr/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death18"), "death18;sound/player/uriel/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death19"), "death19;sound/player/visor/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death20"), "death20;sound/player/xaero/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "duahahaha"), "duahaha(?:ha)?;sound/player/keel/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "denied"), "denied;sound/vo/denied")
+            self.db.set(SOUND_TRIGGERS.format(0, "headshot"), "headshot;sound/vo/headshot")
+            self.db.set(SOUND_TRIGGERS.format(0, "hahaha"), "hahaha;sound/player/santa/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "glhf"), "gl ?hf|hf;sound/vo/crash_new/39_01.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "fall2"), "fall2;sound/player/santa/falling1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "f3"), "f3|press f3|ready( up)?;sound/vo/crash_new/36_04.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "holy shit"), "holy shit;sound/vo_female/holy_shit")
+            self.db.set(SOUND_TRIGGERS.format(0, "welcome to quake live"), "welcome to q(uake )?l(ive)?;sound/vo_evil/welcome")
+            self.db.set(SOUND_TRIGGERS.format(0, "gasp"), "gasp;sound/player/anarki/gasp.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "go"), "go;sound/vo/go")
+            self.db.set(SOUND_TRIGGERS.format(0, "beep boop"), "beep boop;sound/player/tankjr/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "you win"), "you win;sound/vo_female/you_win.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "you lose"), "you lose;sound/vo/you_lose.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "impressive"), "impressive;sound/vo_female/impressive1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "excellent"), "excellent;sound/vo_evil/excellent1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "balls out"), "ball'?s out;sound/vo_female/balls_out")
+            self.db.set(SOUND_TRIGGERS.format(0, "one frag left"), "one frag left;sound/vo/1_frag.ogg")
+            self.db.set(SOUND_TRIGGERS.format(0, "one"), "one;sound/vo_female/one")
+            self.db.set(SOUND_TRIGGERS.format(0, "two"), "two;sound/vo_female/two")
+            self.db.set(SOUND_TRIGGERS.format(0, "three"), "three;sound/vo_female/three")
+            self.db.set(SOUND_TRIGGERS.format(0, "fight"), "fight;sound/vo_evil/fight")
+            self.db.set(SOUND_TRIGGERS.format(0, "gauntlet"), "gauntlet;sound/vo_evil/gauntlet")
+            self.db.set(SOUND_TRIGGERS.format(0, "humiliation"), "humiliation;sound/vo_evil/humiliation1")
+            self.db.set(SOUND_TRIGGERS.format(0, "perfect"), "perfect;sound/vo_evil/perfect")
+            self.db.set(SOUND_TRIGGERS.format(0, "wah wah wah wah"), "wah wah wah( wah)?;sound/misc/yousuck")
+            self.db.set(SOUND_TRIGGERS.format(0, "ah ah ah ah"), "ah ah ah( ah)?;sound/player/slash/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "oink"), "oink;sound/player/sorlag/pain50_1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "argh"), "a+rgh;sound/player/doom/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "hah haha"), "hah haha;sound/player/hunter/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "woohoo"), "woohoo;sound/player/janet/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "quake live"), "ql|quake live;sound/vo_female/quake_live")
+            self.db.set(SOUND_TRIGGERS.format(0, "chaching"), "€|£|$|chaching;sound/misc/chaching")
+            self.db.set(SOUND_TRIGGERS.format(0, "uh ah"), "uh ah;sound/player/mynx/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "oohwee"), "ooh+wee;sound/player/anarki/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "erah"), "erah;sound/player/bitterman/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "yeahhh"), "yeahhh;sound/player/major/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "scream"), "scream;sound/player/bones/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "salute"), "salute;sound/player/sarge/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "squish"), "squish;sound/player/orbb/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "oh god"), "oh god;sound/player/ranger/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "pain"), "pain;sound/player/anarki/pain25_1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "pain2"), "pain2;sound/player/orbb/pain25_1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "pain3"), "pain3;sound/player/keel/pain50_1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "snarl"), "snarl;sound/player/sorlag/taunt.wav")
+            self.category_loaded(0, 'database', player)
+        if self.Enabled_SoundPacks[1]:
+            self.db.set(SOUND_TRIGGERS.format(1, "assholes"), "assholes;soundbank/assholes.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "assshafter"), "assshafter|asshafter|ass shafter;soundbank/assshafterloud.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "babydoll"), "babydoll;soundbank/babydoll.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "barelymissed"), "barelymissed|barely;soundbank/barelymissed.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "belly"), "belly;soundbank/belly.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "bitch"), "bitch;soundbank/bitch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "blud"), "dtblud|blud;soundbank/dtblud.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "boats"), "boats;soundbank/boats.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "bobg"), "bobg|bob;soundbank/bobg.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "bogdog"), "bogdog;soundbank/bogdog.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "boom"), "boom;soundbank/boom.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "boom2"), "boom2;soundbank/boom2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "buk"), "buk|ibbukn;soundbank/buk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "bullshit"), "bull ?shit|bs;soundbank/bullshit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "butthole"), "butthole;soundbank/butthole.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "buttsex"), "buttsex;soundbank/buttsex.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cheeks"), "cheeks;soundbank/cheeks.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cocksucker"), "cocksucker|cs;soundbank/cocksucker.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "conquer"), "conquer;soundbank/conquer.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "countdown"), "countdown;soundbank/countdown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cum"), "cum;soundbank/cum.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cumming"), "cumming;soundbank/cumming.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cunt"), "cunt;soundbank/cunt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "dirkfunk"), "dirkfunk|dirk;soundbank/dirkfunk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "disappointment"), "disappointment;soundbank/disappointment.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "drumset"), "drumset;soundbank/drumset.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "eat"), "eat;soundbank/eat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "eat me"), "eatme|eat me|byte me;soundbank/eatme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "fag"), "fag|homo(sexual)?;soundbank/fag.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "fingerass"), "fingerass;soundbank/fingerass.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "flash"), "flash(soul)?;soundbank/flash.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "fuckface"), "fuckface;soundbank/fuckface.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "fuckyou"), "fuckyou;soundbank/fuckyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "get emm"), "get ?emm?;soundbank/getemm.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "gonads"), "gonads|nads;soundbank/gonads.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "gtfo"), "gtfo;soundbank/gtfo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "hug it out"), "hug it out;soundbank/hugitout.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "idiot"), "idiot|andycreep|d3phx|gladiat0r;soundbank/idiot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "idiot2"), "idiot2;soundbank/idiot2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "it's time"), "it'?s time;soundbank/itstime.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "jeopardy"), "jeopardy;soundbank/jeopardy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "jerk off"), "jerk( ?off)?;soundbank/jerkoff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "killo"), "killo;soundbank/killo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "knocked"), "knocked;soundbank/knocked.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "ld3"), "die|ld3;soundbank/ld3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "liquidswords"), "liquid(swords)?;soundbank/liquid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "massacre"), "massacre;soundbank/massacre.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "mixer"), "mixer;soundbank/mixer.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "mjman"), "mjman|marijuanaman;soundbank/mjman.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "mmmm"), "mmmm;soundbank/mmmm.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "monty"), "monty;soundbank/monty.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "n8"), "n8;soundbank/n8.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "nikon"), "nikon?(guru)?;soundbank/nikon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "nina"), "nina;soundbank/nina.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "nthreem"), "nthreem;sound/vo_female/impressive1.wav")
+            self.db.set(SOUND_TRIGGERS.format(1, "olhip"), "olhip|hip;soundbank/hip.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "organic"), "org(anic)?;soundbank/organic.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "paintball"), "paintball;soundbank/paintball.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "pigfucker"), "pig ?fucker|pig fucker;soundbank/pigfer.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "popeye"), "popeye;soundbank/popeye.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "rosie"), "rosie;soundbank/rosie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "seaweed"), "seaweed;soundbank/seaweed.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "shit"), "shit;soundbank/shit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "sit"), "sit;soundbank/sit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "soulianis"), "soul(ianis)?;soundbank/soulianis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "spam"), "spam;soundbank/spam3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "stalin"), "stalin;soundbank/ussr.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "stfu"), "stfu;soundbank/stfu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "suck a dick"), "suck a dick;soundbank/suckadick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "suckit"), "suckit;soundbank/suckit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "suck my dick"), "suck my dick;soundbank/suckmydick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "teapot"), "teapot;soundbank/teapot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "thank god"), "thank ?god;soundbank/thankgod.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "traxion"), "traxion;soundbank/traxion.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "trixy"), "trixy;soundbank/trixy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "twoon"), "twoon|2pows;soundbank/twoon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "ty"), "ty|thanks|thank you;soundbank/thankyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "venny"), "venny;soundbank/venny.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "viewaskewer"), "view(askewer)?;soundbank/view.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "what's that"), "what'?s that;soundbank/whatsthat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "who are you"), "who are you;soundbank/whoareyou.ogg")
+            self.category_loaded(1, 'database', player)
+        if self.Enabled_SoundPacks[2]:
+            self.db.set(SOUND_TRIGGERS.format(2, "007"), "007;sound/funnysounds/007.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "A Scratch"), "scratch|a scratch|just a scratch;sound/funnysounds/AScratch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "adams family"), "adams family;sound/funnysounds/adamsfamily.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "All The Things"), "all the things;sound/funnysounds/AllTheThings.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "allahuakbar"), "allahuakbar;sound/funnysounds/allahuakbar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "allstar"), "allstar;sound/funnysounds/allstar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Amazing"), "amazing;sound/funnysounds/Amazing.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Ameno"), "ameno;sound/funnysounds/Ameno.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "America"), "america;sound/funnysounds/America.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Amerika"), "amerika;sound/funnysounds/Amerika.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "And Nothing Else"), "and nothing else;sound/funnysounds/AndNothingElse.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Animals"), "animals;sound/funnysounds/Animals.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "asskicking"), "asskicking;sound/funnysounds/asskicking.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ave"), "ave;sound/funnysounds/ave.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "baby baby"), "baby baby;sound/funnysounds/babybaby.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "baby evil"), "baby evil;sound/funnysounds/babyevillaugh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "baby laughing"), "baby( laughing)?;sound/funnysounds/babylaughing.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "bad boys"), "bad boys;sound/funnysounds/badboys.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Banana Boat"), "banana boat;sound/funnysounds/BananaBoatSong.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "benny hill"), "benny hill;sound/funnysounds/bennyhill.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "benzin"), "benzin;sound/funnysounds/benzin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "blue wins"), "blue ?wins;sound/funnysounds/bluewins.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "bonkers"), "bonkers;sound/funnysounds/bonkers.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "boom headshot"), "boom headshot;sound/funnysounds/boomheadshot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "booo"), "booo?;sound/funnysounds/booo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "boring"), "boring;sound/funnysounds/boring.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "boze"), "boze;sound/funnysounds/boze.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "bright side of life"), "bright ?side ?of ?life;sound/funnysounds/brightsideoflife.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "buckdich"), "buckdich;sound/funnysounds/buckdich.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "bullshitter"), "bullshitter;sound/funnysounds/bullshitter.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "burns burns"), "burns burns;sound/funnysounds/burnsburns.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "camel toe"), "camel toe;sound/funnysounds/cameltoe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "can't touch this"), "can'?t touch this;sound/funnysounds/canttouchthis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "cccp"), "cccp|ussr;sound/funnysounds/cccp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "champions"), "champions;sound/funnysounds/champions.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "chicken"), "chicken;sound/funnysounds/chicken.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "chocolate rain"), "chocolate rain;sound/funnysounds/chocolaterain.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "coin"), "coin;sound/funnysounds/coin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "come"), "come;sound/funnysounds/come.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Come With Me Now"), "come with me now;sound/funnysounds/ComeWithMeNow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Count down"), "count down;sound/funnysounds/Countdown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "cowards"), "cowards;sound/funnysounds/cowards.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "crazy"), "crazy;sound/funnysounds/crazy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "damnit"), "damnit;sound/funnysounds/damnit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Danger Zone"), "danger zone;sound/funnysounds/DangerZone.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "dead soon"), "dead ?soon;sound/funnysounds/deadsoon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "defeated"), "defeated;sound/funnysounds/defeated.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "devil"), "devil;sound/funnysounds/devil.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "doesn't love you"), "doesn'?t love you;sound/funnysounds/doesntloveyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "du bist"), "du bist;sound/funnysounds/dubist.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "du hast"), "du hast;sound/funnysounds/duhast.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "dumb ways"), "dumb ways;sound/funnysounds/dumbways.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Eat Pussy"), "eat pussy;sound/funnysounds/EatPussy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "education"), "education;sound/funnysounds/education.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "einschrei"), "einschrei;sound/funnysounds/einschrei.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Eins Zwei"), "eins zwei;sound/funnysounds/EinsZwei.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "electro"), "electro;sound/funnysounds/electro.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "elementary"), "elementary;sound/funnysounds/elementary.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "engel"), "engel;sound/funnysounds/engel.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "erstwenn"), "erstwenn;sound/funnysounds/erstwenn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "exit light"), "exit ?light;sound/funnysounds/exitlight.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "faint"), "faint;sound/funnysounds/faint.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "fatality"), "fatality;sound/funnysounds/fatality.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Feel Good"), "feel good;sound/funnysounds/FeelGood.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "flesh wound"), "flesh wound;sound/funnysounds/fleshwound.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "for you"), "for you;sound/funnysounds/foryou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "freestyler"), "freestyler;sound/funnysounds/freestyler.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "fuckfuck"), "fuckfuck;sound/funnysounds/fuckfuck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "fucking burger"), "fucking burger;sound/funnysounds/fuckingburger.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "fucking kids"), "fucking kids;sound/funnysounds/fuckingkids.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "gangnam"), "gangnam;sound/funnysounds/gangnam.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ganjaman"), "ganjaman;sound/funnysounds/ganjaman.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "gay"), "gay;sound/funnysounds/gay.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "get crowbar"), "get crowbar;sound/funnysounds/getcrowbar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "get out the way"), "get out the way;sound/funnysounds/getouttheway.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ghostbusters"), "ghostbusters;sound/funnysounds/ghostbusters.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "girl look"), "girl look;sound/funnysounds/girllook.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "girly"), "girly;sound/funnysounds/girly.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "gnr guitar"), "gnr guitar;sound/funnysounds/gnrguitar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "goddamn right"), "goddamn right;sound/funnysounds/goddamnright.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "goodbye andrea"), "goodbye andrea;sound/funnysounds/goodbyeandrea.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "goodbye sarah"), "goodbye sarah;sound/funnysounds/goodbyesarah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "gotcha"), "gotcha;sound/funnysounds/gotcha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hakunamatata"), "hakunamatata;sound/funnysounds/hakunamatata.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hammertime"), "hammertime;sound/funnysounds/hammertime.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hello"), "hello;sound/funnysounds/hello.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hellstestern"), "hellstestern;sound/funnysounds/hellstestern.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "holy"), "holy;sound/funnysounds/holy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hoppereiter"), "hoppereiter;sound/funnysounds/hoppereiter.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "how are you"), "how are you;sound/funnysounds/howareyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hush"), "hush;sound/funnysounds/hush.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i bet"), "i ?bet;sound/funnysounds/ibet.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i can't believe"), "i can'?t believe;sound/funnysounds/icantbelieve.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ichtuedieweh"), "ichtuedieweh;sound/funnysounds/ichtuedieweh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i do parkour"), "i do parkour;sound/funnysounds/idoparkour.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i hate all"), "i hate all;sound/funnysounds/ihateall.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ill be back"), "i'?ll be back;sound/funnysounds/beback.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "imperial"), "imperial;sound/funnysounds/imperial.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i'm sexy"), "i'?m sexy;sound/funnysounds/imsexy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i'm your father"), "i'?m your father;sound/funnysounds/imyourfather.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "incoming"), "incoming;sound/funnysounds/incoming.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "indiana jones"), "indiana jones;sound/funnysounds/indianajones.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "in your head zombie"), "in your head zombie;sound/funnysounds/inyourheadzombie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i see assholes"), "i see assholes;sound/funnysounds/iseeassholes.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i see dead people"), "i see dead people;sound/funnysounds/iseedeadpeople.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "it's my life"), "it'?s my life;sound/funnysounds/itsmylife.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "it's not"), "it'?s not;sound/funnysounds/itsnot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "jackpot"), "jackpot;sound/funnysounds/jackpot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "jesus"), "jesus;sound/funnysounds/jesus.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Jesus Oh"), "jesus oh;sound/funnysounds/JesusOh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "john cena"), "john ?cena;sound/funnysounds/johncena.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "jump motherfucker"), "jump motherfucker;sound/funnysounds/jumpmotherfucker.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "just do it"), "just do it;sound/funnysounds/justdoit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "kamehameha"), "kamehameha;sound/funnysounds/kamehameha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "keep on fighting"), "keep on fighting;sound/funnysounds/keeponfighting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "keep your shirt on"), "keep your shirt on;sound/funnysounds/keepyourshirton.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Knocked Down"), "knocked down;sound/funnysounds/KnockedDown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "kommtdiesonne"), "kommtdiesonne;sound/funnysounds/kommtdiesonne.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "kung fu"), "kung ?fu;sound/funnysounds/kungfu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "lately"), "lately;sound/funnysounds/lately.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Legitness"), "legitness;sound/funnysounds/Legitness.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "let's get ready"), "let'?s get ready;sound/funnysounds/letsgetready.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "let's put a smile"), "let'?s put a smile;sound/funnysounds/letsputasmile.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "lights out"), "lights out;sound/funnysounds/lightsout.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "lion king"), "lion king;sound/funnysounds/lionking.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "live to win"), "live to win;sound/funnysounds/livetowin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "losing my religion"), "losing my religion;sound/funnysounds/losingmyreligion.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "love me"), "love ?me;sound/funnysounds/loveme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "low"), "low;sound/funnysounds/low.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "luck"), "luck;sound/funnysounds/luck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "lust"), "lust;sound/funnysounds/lust.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mahnamahna"), "mahnamahna;sound/funnysounds/mahnamahna.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mario"), "mario;sound/funnysounds/mario.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Me"), "me;sound/funnysounds/Me.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "meinland"), "meinland;sound/funnysounds/meinland.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "message"), "message;sound/funnysounds/message.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mimimi"), "mimimi;sound/funnysounds/mimimi.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mission"), "mission;sound/funnysounds/mission.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "moan"), "moan;sound/funnysounds/moan.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mortal kombat"), "mortal kombat;sound/funnysounds/mortalkombat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "move ass"), "move ass;sound/funnysounds/moveass.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "muppet opening"), "muppet opening;sound/funnysounds/muppetopening.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "my little pony"), "my little pony;sound/funnysounds/mylittlepony.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "my name"), "my name;sound/funnysounds/myname.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "never seen"), "never seen;sound/funnysounds/neverseen.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nightmare"), "nightmare;sound/funnysounds/nightmare.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nobody likes you"), "nobody likes you;sound/funnysounds/nobodylikesyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nonie"), "nonie;sound/funnysounds/nonie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nooo"), "nooo+;sound/funnysounds/nooo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "no time for loosers"), "no time for loosers;sound/funnysounds/notimeforloosers.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "numanuma"), "numanuma;sound/funnysounds/numanuma.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nyancat"), "nyancat;sound/funnysounds/nyancat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "o fuck"), "o fuck;sound/funnysounds/ofuck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "oh my god"), "oh my god;sound/funnysounds/ohmygod.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Oh My Gosh"), "oh my gosh;sound/funnysounds/OhMyGosh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ohnedich"), "ohnedich;sound/funnysounds/ohnedich.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "oh no"), "oh no;sound/funnysounds/ohno.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "oh noe"), "oh noe;sound/funnysounds/ohnoe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pacman"), "pacman;sound/funnysounds/pacman.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pick me up"), "pick me up;sound/funnysounds/pickmeup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pikachu"), "pikachu;sound/funnysounds/pikachu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pinkiepie"), "pinkiepie;sound/funnysounds/pinkiepie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Pink Panther"), "pink panther;sound/funnysounds/PinkPanther.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pipe"), "pipe;sound/funnysounds/pipe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "piss me off"), "piss me off;sound/funnysounds/pissmeoff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "play a game"), "play a game;sound/funnysounds/playagame.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pooping"), "pooping;sound/funnysounds/pooping.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "powerpuff"), "powerpuff;sound/funnysounds/powerpuff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "radioactive"), "radioactive;sound/funnysounds/radioactive.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "rammsteinriff"), "rammsteinriff;sound/funnysounds/rammsteinriff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "red wins"), "red ?wins;sound/funnysounds/redwins.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "renegade"), "renegade;sound/funnysounds/renegade.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "retard"), "retard;sound/funnysounds/Retard.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "rocky"), "rocky;sound/funnysounds/rocky")
+            self.db.set(SOUND_TRIGGERS.format(2, "rock you guitar"), "rock ?you ?guitar;sound/funnysounds/rockyouguitar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sail"), "sail;sound/funnysounds/sail.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Salil"), "salil;sound/funnysounds/Salil.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "samba"), "samba;sound/funnysounds/samba.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sandstorm"), "sandstorm;sound/funnysounds/sandstorm.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "saymyname"), "saymyname;sound/funnysounds/saymyname.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "scatman"), "scatman;sound/funnysounds/scatman.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sell you all"), "sell you all;sound/funnysounds/sellyouall.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sense of humor"), "sense of humor;sound/funnysounds/senseofhumor.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "shakesenora"), "shakesenora;sound/funnysounds/shakesenora.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "shut the fuck up"), "shut the fuck up;sound/funnysounds/shutthefuckup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "shut your fucking mouth"), "shut your fucking mouth;sound/funnysounds/shutyourfuckingmouth.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "silence"), "silence;sound/funnysounds/silence.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Skeet Skeet"), "skeet skeet;sound/funnysounds/AllSkeetSkeet.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "smooth criminal"), "smooth criminal;sound/funnysounds/smoothcriminal.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "socobatevira"), "socobatevira;sound/funnysounds/socobatevira.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "socobatevira end"), "socobatevira end;sound/funnysounds/socobateviraend.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "socobatevira fast"), "socobatevira fast;sound/funnysounds/socobatevirafast.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "socobatevira slow"), "socobatevira slow;sound/funnysounds/socobateviraslow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sogivemereason"), "sogivemereason;sound/funnysounds/sogivemereason.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "so stupid"), "so stupid;sound/funnysounds/sostupid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Space Jam"), "space jam;sound/funnysounds/SpaceJam.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "space unicorn"), "space unicorn;sound/funnysounds/spaceunicorn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "spierdalaj"), "spierdalaj;sound/funnysounds/spierdalaj.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "stamp on"), "stamp on;sound/funnysounds/stampon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "star wars"), "star wars;sound/funnysounds/starwars.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "stayin alive"), "stayin alive;sound/funnysounds/stayinalive.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "stoning"), "stoning;sound/funnysounds/stoning.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "stop"), "stop;sound/funnysounds/Stop.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "story"), "story;sound/funnysounds/story.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "surprise"), "surprise;sound/funnysounds/surprise.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "swedish chef"), "swedish chef;sound/funnysounds/swedishchef.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sweet dreams"), "sweet dreams;sound/funnysounds/sweetdreams.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "take me down"), "take me down;sound/funnysounds/takemedown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "talk scotish"), "talk scotish;sound/funnysounds/talkscotish.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "teamwork"), "teamwork;sound/funnysounds/teamwork.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "technology"), "technology;sound/funnysounds/technology.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "this is sparta"), "this is sparta;sound/funnysounds/thisissparta.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "thunderstruck"), "thunderstruck;sound/funnysounds/thunderstruck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "to church"), "to church;sound/funnysounds/tochurch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "tsunami"), "tsunami;sound/funnysounds/tsunami.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "tuturu"), "tuturu;sound/funnysounds/tuturu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "tututu"), "tututu;sound/funnysounds/tututu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "unbelievable"), "unbelievable;sound/funnysounds/unbelievable.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "undderhaifisch"), "undderhaifisch;sound/funnysounds/undderhaifisch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "up town girl"), "up town girl;sound/funnysounds/uptowngirl.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "valkyries"), "valkyries;sound/funnysounds/valkyries.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wahwahwah"), "wahwahwah|dcmattic|mattic;sound/funnysounds/wahwahwah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "want you"), "want you;sound/funnysounds/wantyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wazzup"), "wazzup;sound/funnysounds/wazzup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wehmirohweh"), "wehmirohweh;sound/funnysounds/wehmirohweh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "what is love"), "what is love;sound/funnysounds/whatislove.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "when angels"), "when angels;sound/funnysounds/whenangels.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "where are you"), "where are you;sound/funnysounds/whereareyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "whistle"), "whistle;sound/funnysounds/whistle.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Will Be Singing"), "will be singing;sound/funnysounds/WillBeSinging.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wimbaway"), "wimbaway;sound/funnysounds/wimbaway.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "windows"), "windows;sound/funnysounds/windows.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "would you like"), "would you like;sound/funnysounds/wouldyoulike.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wtf"), "wtf;sound/funnysounds/wtf.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "yeee"), "yeee;sound/funnysounds/yeee.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "yes master"), "yes master;sound/funnysounds/yesmaster.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "yhehehe"), "yhehehe;sound/funnysounds/yhehehe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ymca"), "ymca;sound/funnysounds/ymca.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "you"), "you;sound/funnysounds/You.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "you are a cunt"), "you are a cunt;sound/funnysounds/cunt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "you fucked my wife"), "wife|my wife|you fucked my wife;sound/funnysounds/youfuckedmywife.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "You Realise"), "you realise;sound/funnysounds/YouRealise.ogg")
+            self.category_loaded(2, 'database', player)
+        if self.Enabled_SoundPacks[3]:
+            self.db.set(SOUND_TRIGGERS.format(3, "my ride"), "my ride;sound/duke/2ride06.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "abort"), "abort;sound/duke/abort01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "ahhh"), "ahhh;sound/duke/ahh04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "much better"), "much better;sound/duke/ahmuch03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "aisle 4"), "aisle ?4;sound/duke/aisle402.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "a mess"), "a mess;sound/duke/amess06.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "annoying"), "annoying;sound/duke/annoy03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "bitchin"), "bitchin;sound/duke/bitchn04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "blow it out"), "blow it out;sound/duke/blowit01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "booby trap"), "booby trap;sound/duke/booby04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "bookem"), "bookem;sound/duke/bookem03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "born to be wild"), "born to be wild;sound/duke/born01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "chew gum"), "chew gum;sound/duke/chew05.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "come on"), "come on;sound/duke/comeon02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "the con"), "the con;sound/duke/con03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "cool"), "cool;sound/duke/cool01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "not crying"), "not crying;sound/duke/cry01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "daamn"), "daa?mn;sound/duke/damn03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "damit"), "damit;sound/duke/damnit04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "dance"), "dance;sound/duke/dance01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "diesob"), "diesob;sound/duke/diesob03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "doomed"), "doomed;sound/duke/doomed16.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "eyye"), "eyye;sound/duke/dscrem38.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "duke nukem"), "duke nukem;sound/duke/duknuk14.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "no way"), "no way;sound/duke/eat08.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "eat shit"), "eat shit;sound/duke/eatsht01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "escape"), "escape;sound/duke/escape01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "face ass"), "face ass;sound/duke/face01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "a force"), "a force;sound/duke/force01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "get that crap"), "get that crap;sound/duke/getcrap1.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "get some"), "get some;sound/duke/getsom1a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "game over"), "game over;sound/duke/gmeovr05.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "gotta hurt"), "gotta hurt;sound/duke/gothrt01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "groovy"), "groovy;sound/duke/groovy02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "you guys suck"), "you guys suck;sound/duke/guysuk01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "hail king"), "hail king;sound/duke/hail01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "shit happens"), "shit happens;sound/duke/happen01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "holy cow"), "holy cow;sound/duke/holycw01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "duke holy shit"), "duke holy ?shit;sound/duke/holysh02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "im good"), "im good;sound/duke/imgood12.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "independence"), "independence;sound/duke/indpnc01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "in hell"), "in ?hell;sound/duke/inhell01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "going in"), "going ?in;sound/duke/introc.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "dr jones"), "dr jones;sound/duke/jones04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "kick your ass"), "your ass|kick your ass;sound/duke/kick01-i.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "ktit"), "ktit;sound/duke/ktitx.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "let god"), "let god;sound/duke/letgod01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "let's rock"), "let'?s rock;sound/duke/letsrk03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "lookin' good"), "lookin'? good;sound/duke/lookin01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "make my day"), "make my day;sound/duke/makeday1.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "midevil"), "midevil;sound/duke/mdevl01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "my meat"), "my meat;sound/duke/meat04-n.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "no time"), "no time;sound/duke/myself3a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "i needed that"), "i needed that;sound/duke/needed03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "nobody"), "nobody;sound/duke/nobody01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "only one"), "only one;sound/duke/onlyon03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "my kinda party"), "my kinda party;sound/duke/party03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "gonna pay"), "gonna pay;sound/duke/pay02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "pisses me off"), "pisses me off;sound/duke/pisses01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "pissin me off"), "pissin me off;sound/duke/pissin01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "postal"), "postal;sound/duke/postal01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "aint afraid"), "aint ?afraid;sound/duke/quake06.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "r and r"), "r and r;sound/duke/r&r01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "ready for action"), "ready for action;sound/duke/ready2a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "rip your head off"), "rip your head off;sound/duke/rip01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "rip em"), "rip em;sound/duke/ripem08.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "rockin"), "rockin;sound/duke/rockin02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "shake it"), "shake ?it;sound/duke/shake2a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "slacker"), "slacker;sound/duke/slacker1.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "smack dab"), "smack dab;sound/duke/smack02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "so help me"), "so help me;sound/duke/sohelp02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "suck it down"), "suck it down;sound/duke/sukit01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "terminated"), "terminated;sound/duke/termin01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "this sucks"), "this sucks;sound/duke/thsuk13a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "vacation"), "vacation;sound/duke/vacatn01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "christmas"), "christmas;sound/duke/waitin03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "wants some"), "wants some;sound/duke/wansom4a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "you and me"), "you and me;sound/duke/whipyu01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "where"), "where;sound/duke/whrsit05.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "yippie kai yay"), "yippie kai yay;sound/duke/yippie01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "bottle of jack"), "bottle of jack;sound/duke/yohoho01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "long walk"), "long walk;sound/duke/yohoho09.wav")
+            self.category_loaded(3, 'database', player)
+        if self.Enabled_SoundPacks[4]:
+            self.db.set(SOUND_TRIGGERS.format(4, "aiming"), "aiming;sound/warp/aiming.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "always open"), "always open;sound/warp/always_open.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "thanks for the advice"), "thanks for the advice;sound/warp/ash_advice.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "angry cat"), "angry cat;sound/warp/angry_cat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "appreciate"), "appreciate;sound/warp/ash_appreciate.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "looking forward to it"), "looking forward to it;sound/warp/ash_lookingforwardtoit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "make me"), "make me;sound/warp/ash_makeme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pessimist"), "pessimist;sound/warp/ash_pessimist.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "shoot me now"), "shoot me now;sound/warp/ash_shootmenow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "shoot on sight"), "shoot on sight;sound/warp/ash_shootonsight.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "won't happen again"), "won'?t happen again;sound/warp/ash_wonthappenagain.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "attractive"), "attractive;sound/warp/attractive.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "awesome"), "awesome;sound/warp/awesome.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "awkward"), "awkward;sound/warp/awkward.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bad feeling"), "bad feeling;sound/warp/badfeeling.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bad idea"), "bad idea;sound/warp/badidea.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ballbag"), "ballbag;sound/warp/ballbag.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bburp"), "bburp;sound/warp/bburp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bburpp"), "bburpp;sound/warp/bburpp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "believe"), "believe;sound/warp/believe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bend me over"), "bend me over;sound/warp/bend_me_over.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "big leagues"), "big leagues;sound/warp/bigleagues.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bike horn"), "bike horn;sound/warp/bike_horn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bj"), "bj;sound/warp/bj.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "kill you with my brain"), "kill you with my brain;sound/warp/brain.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bravery"), "bravery;sound/warp/bravery.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "broke"), "broke;sound/warp/broke.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "space bugs"), "space bugs;sound/warp/bugs.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bunk"), "bunk;sound/warp/bunk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "burp"), "burp;sound/warp/burp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "burpp"), "burpp;sound/warp/burpp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cover your butt"), "cover your butt;sound/warp/butt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "came out"), "came out;sound/warp/cameout.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "anybody care"), "anybody care;sound/warp/care.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "catch"), "catch;sound/warp/catch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "castrate"), "castrate;sound/warp/castrate.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cat scream"), "cat scream;sound/warp/cat_scream.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "hello2"), "hello2;sound/warp/coach_hello.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "corny"), "corny;sound/warp/corny.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cock push ups"), "cock push ups;sound/warp/cockpushups.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "code"), "code;sound/warp/code.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cold"), "cold;sound/warp/cold.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "college student"), "college student;sound/warp/college.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "conanapalooza"), "conana(palooza)?;sound/warp/conanana.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "confident"), "confident;sound/warp/confident.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cooperation"), "cooperation;sound/warp/cooperation.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cow dick"), "cow dick;sound/warp/cowdick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "crush your enemies"), "crush( your enemies)?;sound/warp/crushyourenemies.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "crusher"), "crusher;sound/warp/crusher.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cucumber"), "cucumber;sound/warp/cucumber.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "go crazy"), "go crazy;sound/warp/crazy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "crowded"), "crowded;sound/warp/crowded.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dance off"), "dance off;sound/warp/danceoff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dead"), "dead;sound/warp/dead.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dead guy"), "dead guy;sound/warp/deadguy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dick message"), "dick message;sound/warp/dickmessage.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dick slip"), "dick slip;sound/warp/dick_slip.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dink bag"), "dink bag;sound/warp/dinkbag.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dirty"), "dirty;sound/warp/dirty.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "do as you're told"), "do as you'?re told;sound/warp/doasyouretold.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what have we done"), "what have we done;sound/warp/done.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "done for the day"), "done( for the)?( day)?;sound/warp/done_for_the_day.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "done it"), "done it;sound/warp/doneit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "do now"), "do now;sound/warp/donow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "don't like vaginas"), "don'?t like vaginas;sound/warp/dontlikevaginas.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "do you feel special"), "(do you feel )?special;sound/warp/doyoufeelspecial.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "drawing"), "drawing;sound/warp/drawing.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "eat it"), "eat it;sound/warp/eat_it.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "eat my grenade"), "grenade|eat my grenade;sound/warp/eatmygrenade.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "eat my"), "eat my;sound/warp/eatmytits.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "electricity"), "electricity;sound/warp/electricity.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "enima"), "enima;sound/warp/enima.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "face"), "face;sound/warp/face.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "face2"), "face2;sound/warp/face2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fart"), "fart;sound/warp/fart.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fartt"), "fartt;sound/warp/fartt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "farttt"), "farttt;sound/warp/farttt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ffart"), "ffart;sound/warp/ffart.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ffartt"), "ffartt;sound/warp/ffartt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ffarttt"), "ffarttt;sound/warp/ffarttt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fffartt"), "fffartt;sound/warp/fffartt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fffarttt"), "fffarttt;sound/warp/fffarttt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "not fair"), "not fair;sound/warp/fair.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "falcon pawnch"), "falcon pawnch;sound/warp/falcon_pawnch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fall"), "fall;sound/warp/fall.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "favor"), "favor;sound/warp/favor.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "feel"), "feel;sound/warp/feel.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "feels"), "feels;sound/warp/feels.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fragile"), "fragile;sound/warp/fragile.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "something wrong"), "something wrong\\??;sound/warp/femaleshepherd_somethingwrong.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "suspense"), "suspense;sound/warp/femaleshepherd_suspense.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fog horn"), "fog horn;sound/warp/fog_horn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "found them"), "found them;sound/warp/found_them.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fuku"), "fuku;sound/warp/fuku.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fuck me"), "fuck me;sound/warp/fuck_me.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fuck ugly"), "fuck ugly;sound/warp/fuck_ugly.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "awaiting orders"), "awaiting orders;sound/warp/garrus_awaitingorders.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "got your back"), "got your back;sound/warp/garrus_gotyourback.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "keep moving"), "keep moving;sound/warp/garrus_keepmoving.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nice work"), "nice work;sound/warp/garrus_nicework.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "get away cat"), "cat|get away cat;sound/warp/getawaycat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "get off"), "get off;sound/warp/getoff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "wasting my time"), "wasting my time;sound/warp/glados_wasting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "just go crazy"), "just go crazy;sound/warp/go_crazy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "grows"), "grows;sound/warp/grows.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ha ha"), "ha ha;sound/warp/haha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "heroics"), "heroics;sound/warp/heroics.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "hit or miss"), "hit or miss;sound/warp/hitormiss.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ho bags"), "ho ?bags;sound/warp/hobags.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "hop"), "hop;sound/warp/hop.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "horrible"), "horrible;sound/warp/horrible.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "huge vagina"), "huge vagina;sound/warp/hugevagina.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "hunting"), "hunting;sound/warp/hunting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i am the law"), "i am the law;sound/warp/iamthelaw.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "implied"), "implied;sound/warp/implied.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i died"), "i died;sound/warp/i_died.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i farted"), "i farted;sound/warp/i_farted.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i don't trust you"), "i don'?t trust you|leaf(green)?;sound/warp/idonttrustyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i have a plan"), "i have a plan;sound/warp/ihaveaplan.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i like you"), "i like you;sound/warp/ilikeyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "intensify"), "intensify;sound/warp/intensify.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "in the ass"), "in ?the ?ass;sound/warp/intheass.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i will eat"), "i will eat( your)?;sound/warp/iwilleatyour.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "jail"), "jail;sound/warp/jail.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "jump pad"), "jump pad;sound/warp/jump_pad.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "just the tip"), "just the tip|tippy(touch)?;sound/warp/just_the_tip.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "kevin bacon"), "kevin bacon;sound/warp/kevinbacon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "kill"), "kill;sound/warp/kill.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "kizuna"), "kizuna;sound/warp/kizuna.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "need to kill"), "need to kill;sound/warp/krogan_kill.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ladybug"), "ladybug;sound/warp/ladybug.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "legend"), "legend|ere( ?bux)?;sound/warp/legend.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "lego maniac"), "lego maniac|zach|stukey;sound/warp/lego_maniac.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "human relationships"), "human relationships?;sound/warp/liara_humanrelationships.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "incredible"), "incredible;sound/warp/liara_incredible.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "never happened"), "never happened;sound/warp/liara_neverhappened.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "lick me"), "lick me;sound/warp/lick_me.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "like this thing"), "like this thing;sound/warp/like.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "wasn't listening"), "wasn'?t listening;sound/warp/listening.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "listen up"), "listen( up)?;sound/warp/listenup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "look fine"), "look fine;sound/warp/lookfine.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "lovely"), "lovely;sound/warp/lovely.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "your luck"), "your luck;sound/warp/luck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "maggot"), "maggot;sound/warp/maggot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "like an idiot"), "like an idiot;sound/warp/makes_you_look_like_idiot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "this beat"), "this beat;sound/warp/marg_tongue.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "killed with math"), "(killed )?(with )?math;sound/warp/math.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "me me me"), "me me( ?me)?;sound/warp/mememe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "metaphor"), "metaphor;sound/warp/metaphor.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "misdirection"), "misdirection;sound/warp/misdirection.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nobody move"), "nobody move;sound/warp/move.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "muuddy"), "muuddy(creek)?;sound/warp/muuddy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "mwahaha"), "mwahaha;sound/warp/mwahaha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "my friends"), "my friends;sound/warp/my_friends.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "my gun's bigger"), "my gun'?s bigger;sound/warp/mygunsbigger.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nades"), "nades;sound/warp/nades.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "never look back"), "never look back|muddy(creek)?;sound/warp/neverlookback.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nonono"), "no ?no ?no;sound/warp/nonono.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nutsack"), "nutsack;sound/warp/nutsack.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "my god"), "my god;sound/warp/oh_my_god.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "oh fudge"), "fudge|oh fudge;sound/warp/ohfudge.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "on me"), "on me;sound/warp/onme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "on my mom"), "on my mom;sound/warp/onmymom.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ow what the"), "what the|ow what the;sound/warp/owwhatthe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pain in the ass"), "pain in the ass;sound/warp/pain.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pan out"), "pan out;sound/warp/panout.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pee bad"), "pee bad;sound/warp/pee_bad.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pee myself"), "pee myself;sound/warp/pee_myself.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "petty"), "petty;sound/warp/petty.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pie intro"), "pie intro;sound/warp/pie_intro4.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pile of shit"), "pile( of shit)?;sound/warp/pile.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pizza time"), "pizza time;sound/warp/pizza_time.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "plasma"), "plasma|respect the plasma;sound/warp/plasma.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "plus back"), "plus back;sound/warp/plus_back.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "poop myself"), "poop myself;sound/warp/poop_myself.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "good point"), "good point;sound/warp/point.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "quarter"), "quarter;sound/warp/quarter.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "question"), "question;sound/warp/question.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "rage"), "rage;sound/warp/rage.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "real me"), "real me;sound/warp/realme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "roll with"), "roll with;sound/warp/roll_with.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "no longer require"), "no longer require;sound/warp/require.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ready for this"), "ready for this;sound/warp/rochelle_ready.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "rock this"), "rock this;sound/warp/rockthis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "santa"), "santa;sound/warp/santa.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "say my name"), "say my name;sound/warp/saymyname.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "you can scream"), "you can scream;sound/warp/scream.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "shart"), "shart;sound/warp/shart.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "shartt"), "shartt;sound/warp/shartt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "smiley face"), "smiley face;sound/warp/smileyface.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "oh snap"), "snap|oh snap;sound/warp/snap.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sneezed"), "sneezed;sound/warp/sneezed.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "solitude"), "solitude;sound/warp/solitude.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sorry"), "sorry;sound/warp/sorry.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "spaghetti"), "spagh?etti;sound/warp/spagetti.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "human speech"), "speech|human speech;sound/warp/speech.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sprechen sie dick"), "sprechen sie dick;sound/warp/sprechensiedick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "start over"), "start over;sound/warp/startover.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "stfu cunt"), "stfu cunt;sound/warp/stfu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "study harder"), "study harder;sound/warp/study_harder.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "stunned our ride"), "stunned our ride;sound/warp/stunned.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sure"), "sure;sound/warp/sure.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "swallow"), "swallow;sound/warp/swallow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "take a break"), "take a break|wally;sound/warp/takeabreaknow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "take down"), "take down;sound/warp/takedown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "the creeps"), "the creeps;sound/warp/tali_creeps.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "used to living"), "used to living;sound/warp/tali_usedtoliving.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "talk to me"), "talk to me;sound/warp/talk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "tnt"), "tnt;sound/warp/tnt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "asshole"), "asshole;sound/warp/tastless_asshole.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "tears"), "tears;sound/warp/tears.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "that's right"), "that'?s right;sound/warp/thatsright.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "the talk"), "the talk;sound/warp/the_talk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "think"), "think;sound/warp/think.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "tricked"), "tricked;sound/warp/tricked.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "trusted"), "trusted;sound/warp/trusted.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "trust me"), "trust me;sound/warp/trustme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "target"), "target;sound/warp/turret_target.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ugly stick"), "ugly stick;sound/warp/ugly.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "unfair"), "unfair;sound/warp/unfair.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "unicorn"), "unicorn;sound/warp/unicorn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "v3"), "v3|vestek;sound/warp/v3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "valid"), "valid;sound/warp/valid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "very nice"), "very nice;sound/warp/very_nice.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "vewy angwy"), "vewy angwy;sound/warp/vewy_angwy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "volunteer"), "volunteer;sound/warp/volunteer.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "waiting"), "waiting;sound/warp/waiting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "walk"), "walk;sound/warp/walk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what i want"), "what i want;sound/warp/want.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "at war"), "at war;sound/warp/war.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "warp server intro"), "(warp server intro)|(quality);sound/warp/warpserverintro.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "wednesday"), "wednesday;sound/warp/wednesday.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "wee lamb"), "wee lamb;sound/warp/weelamb.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "well"), "well;sound/warp/well.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "we're grownups"), "we'?re grownups;sound/warp/weregrownups.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what happened"), "what happened;sound/warp/whathappened.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what is this"), "what is this;sound/warp/whatisthis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what now"), "what now;sound/warp/whatnow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what the"), "what the;sound/warp/whatthe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "where the fuck"), "where the( fuck)?;sound/warp/where_the_fuck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "winnie the pew"), "winnie( the pew)?;sound/warp/winnie_the_pew.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "with my fist"), "my fist|with my fist;sound/warp/withmyfist.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "busy"), "busy;sound/warp/wrex_busy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sometimes crazy"), "sometimes crazy;sound/warp/wrex_crazy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i like"), "i like;sound/warp/wrex_like.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "orders"), "orders;sound/warp/wrex_orders.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "right behind you"), "right behind you;sound/warp/wrex_rightbehindyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what can i do"), "what can i do;sound/warp/wrex_whatcanido.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "your mom"), "your mom|pug(ster)?;sound/warp/yourmom.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "yarg"), "yarg;sound/warp/yarg.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "zooma"), "zooma?|xuma;sound/warp/zooma.ogg")
+            self.category_loaded(4, 'database', player)
+        if self.Enabled_SoundPacks[5]:
+            self.db.set(SOUND_TRIGGERS.format(5, "2ez"), "2ez|too easy;sound/westcoastcrew/2ez.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ability"), "ability;sound/westcoastcrew/ability.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ahsi"), "ahsi;sound/westcoastcrew/ahsi.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "all dead"), "all ?dead;sound/westcoastcrew/alldead.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "kinrazed"), "kinrazed;sound/westcoastcrew/alright.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "another one bites the dustt"), "bites the dustt|another one bites the dustt;sound/westcoastcrew/anotherbitesdust.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "another one bites the dust"), "bites the dust|another one bites the dust;sound/westcoastcrew/anotheronebitesthedust.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "and another one gone"), "and another one gone;sound/westcoastcrew/anotheronegone.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "atustamena"), "atustamena;sound/westcoastcrew/atustamena.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ay caramba"), "ay caramba;sound/westcoastcrew/aycaramba.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "baby back"), "baby ?back;sound/westcoastcrew/babyback.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "badabababa"), "badababa(ba)?;sound/westcoastcrew/badabababa.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "baiting"), "baitin'?g?;sound/westcoastcrew/baiting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ballin"), "ballin'?g?;sound/westcoastcrew/ballin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bender"), "bender;sound/westcoastcrew/bender.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "biff"), "biff;sound/westcoastcrew/biff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "outro"), "outro;sound/westcoastcrew/biggerlove.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bigpippin"), "bigpippin'?g?;sound/westcoastcrew/bigpippin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "big whoop"), "big wh?oop;sound/westcoastcrew/bigwhoop.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bite my shiny metal ass"), "bite my shiny metal ass;sound/westcoastcrew/bitemyshinymetalass.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bofumballs"), "bofumb(alls)?;sound/westcoastcrew/bofumballs.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "boomshakalaka"), "boomshakalaka;sound/westcoastcrew/boomshakalaka.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "borracho"), "borracho;sound/westcoastcrew/borracho.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bumblebee tuna"), "your balls are showing|bumblebee tuna;sound/westcoastcrew/bumblebeetuna.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bum bum"), "bum ?bum;sound/westcoastcrew/bumbum.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bweenabwaana"), "bweena(bwaana)?;sound/westcoastcrew/bweenabwaana.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "c3"), "c3;sound/westcoastcrew/c3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "campingtroll"), "campingtroll|baby got back;sound/westcoastcrew/campingtroll.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cann"), "cann;sound/westcoastcrew/cann.ogg")
+            # repeat of FunnySounds
+            #self.db.set(SOUND_TRIGGERS.format(5, "can't touch this"), "can'?t touch this;sound/westcoastcrew/CantTouchThis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "captains draft"), "captains ?draft;sound/westcoastcrew/captainsdraft.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cheers"), "cheers;sound/westcoastcrew/cheers.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cheers2"), "cheers2;sound/westcoastcrew/cheers2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "chocosaurus"), "chocosaurus;sound/westcoastcrew/chocosaurus.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "clear"), "clear;sound/westcoastcrew/clear.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "clever girl"), "clever girl;sound/westcoastcrew/clevergirl.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "clr"), "clr;sound/westcoastcrew/clr.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "clr2"), "clr2;sound/westcoastcrew/clr2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "counting on you"), "counting on you;sound/westcoastcrew/countingonyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "g1bbles"), "g1bbles;sound/westcoastcrew/crymeariver.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cry me a river"), "cry me a river;sound/westcoastcrew/crymeariver1.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cry me a riverr"), "cry me a riverr;sound/westcoastcrew/crymeariver2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cthree"), "cthree;sound/westcoastcrew/cuttingedge.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "damn im good"), "damn i'?m good;sound/westcoastcrew/damnimgood.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dead last"), "yeah,? how'?d he finish again|dead ?last;sound/westcoastcrew/deadlast.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "did i do that"), "did i do that;sound/westcoastcrew/dididothat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dddid i do that"), "ddd?id i do that;sound/westcoastcrew/dididothat2.ogg")
+            # repeat of Prestige Sounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "die"), "die;sound/westcoastcrew/die.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "die already"), "die already;sound/westcoastcrew/diealready.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "die mothafuckas"), "die mothafuckas;sound/westcoastcrew/diemothafuckas.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "die motherfucker"), "die motherfucker;sound/westcoastcrew/diemotherfucker.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "it's a disastah"), "disastah|it'?s a disastah;sound/westcoastcrew/disastah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dominating"), "dominating;sound/westcoastcrew/dominating.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "you're doomed"), "you'?re doome?d;sound/westcoastcrew/doomed.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dr1nya"), "dr1nya;sound/westcoastcrew/dr1nya.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "drunk"), "drunk|always smokin'? blunts|gettin'? drunk;sound/westcoastcrew/drunk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dundun"), "dun ?dun;sound/westcoastcrew/dundun.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dundundun"), "dun dun dun|dundundun;sound/westcoastcrew/dundundun.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dundundundun"), "dun dun dun dun|dundundundun;sound/westcoastcrew/dundundundun.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "easy as"), "easy as;sound/westcoastcrew/easyas.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "easy come easy go"), "easy come easy go;sound/westcoastcrew/easycomeeasygo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ehtogg"), "ehtogg;sound/westcoastcrew/ehtogg.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "elo"), "elo;sound/westcoastcrew/elo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "enemy pick"), "enemy ?pick;sound/westcoastcrew/enemypick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ez"), "ez|easy$|so easy|that was easy|that was ez;sound/westcoastcrew/ez.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "f33"), "f33;sound/westcoastcrew/f3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "facial"), "facial;sound/westcoastcrew/facial.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "feroz"), "feroz;sound/westcoastcrew/feroz.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "filthy zealot"), "keep the change|filthy zealot;sound/westcoastcrew/filthyzealot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "flush"), "flush;sound/westcoastcrew/flush.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "fox"), "fox;sound/westcoastcrew/fox.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "fuckin bitch"), "fuckin bitch;sound/westcoastcrew/fuckinbitch.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "Gay"), "Gay;sound/westcoastcrew/Gay.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "get outta here"), "get outta here;sound/westcoastcrew/getouttahere.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gibbles"), "gibbles;sound/westcoastcrew/gibbles.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "giggs"), "giggs;sound/westcoastcrew/giggs.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gimme a break"), "gimme a break;sound/westcoastcrew/gimmeabreak.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "give up and die"), "give up and die;sound/westcoastcrew/giveupanddie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "godlike"), "godlike;sound/westcoastcrew/godlike.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gojira"), "gojira;sound/westcoastcrew/gojira.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "great shot"), "g(reat)? ?(shot)?;sound/westcoastcrew/greatshot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gs"), "gs;sound/westcoastcrew/gs.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "h2o"), "h2o;sound/westcoastcrew/h2o.ogg")
+            # repeat of Warp Sounds for Quake Live
+            # self.db.set(SOUND_TRIGGERS.format(5, "haha"), "haha;sound/westcoastcrew/haha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hahaha2"), "hahaha2;sound/westcoastcrew/hahaha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hahahaha"), "hahahaha;sound/westcoastcrew/hahahaha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "happy hour"), "happy hour|it'?s happy hour;sound/westcoastcrew/happyhour.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "he's heating up"), "he'?s heating up;sound/westcoastcrew/heatingup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hehe"), "hehe;sound/westcoastcrew/hehe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hehehe"), "hehehe;sound/westcoastcrew/hehehe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hehe yeah"), "hehe yeah;sound/westcoastcrew/heheyeah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hot steppah"), "hot ?steppah;sound/westcoastcrew/hotsteppah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "i'm lovin it"), "i'?m loving? ?it;sound/westcoastcrew/imlovinit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "im on fire"), "i'?m on fire;sound/westcoastcrew/imonfire.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "im stephan"), "i'?m stephan;sound/westcoastcrew/imstephan.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "inspector gadget"), "inspector( gadget)?;sound/westcoastcrew/inspectornorse.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "it's in the bag"), "it'?s in the bag;sound/westcoastcrew/inthebag1.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the bag"), "in the bag;sound/westcoastcrew/inthebag2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the bagg"), "in the bagg;sound/westcoastcrew/inthebag3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the baggg"), "in the baggg;sound/westcoastcrew/inthebag4.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the face"), "in the face;sound/westcoastcrew/intheface.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the zone"), "in the zone|i'?m in the zone;sound/westcoastcrew/inthezone.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "doom2"), "doom2|tell me what you came here for;sound/westcoastcrew/intoyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "introtoo"), "introtoo;sound/westcoastcrew/intro2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "isabadmutha"), "isabadmutha;sound/westcoastcrew/isabadmutha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "jdub"), "jdub;sound/westcoastcrew/jdub.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "jsss"), "jsss;sound/westcoastcrew/jsss.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "killswitch"), "killswitch;sound/westcoastcrew/killswitch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "kinraze"), "kinraze;sound/westcoastcrew/kinraze.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "lakad"), "lakad;sound/westcoastcrew/lakad.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "lg"), "lg;sound/westcoastcrew/lg.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "lol loser"), "(lol )?loser;sound/westcoastcrew/lolloser.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "look what you did"), "look what you did;sound/westcoastcrew/lookwhatyoudid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "look what you've done"), "look what you'?ve done;sound/westcoastcrew/lookwhatyouvedone.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "los"), "los;sound/westcoastcrew/los.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "lovin' it"), "lovin'? it;sound/westcoastcrew/lovinit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "makaveli"), "makaveli;sound/westcoastcrew/makaveli.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "martin"), "martin;sound/westcoastcrew/martin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "pizza pizza"), "pizza pizza|meetzah meetzah|heetzah peetzah;sound/westcoastcrew/meetzah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "mirai"), "mirai;sound/westcoastcrew/mirai.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "did you miss me"), "did you miss me;sound/westcoastcrew/missme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "mobil"), "mobil;sound/westcoastcrew/mobil.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "i'm a motherfuckin monster"), "i'?m a motherfuckin monst(er)?;sound/westcoastcrew/monster.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "monster kill"), "monster kill;sound/westcoastcrew/monsterkill.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "muthafucka"), "muthafucka;sound/westcoastcrew/muthafucka.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "nanana"), "nanana;sound/westcoastcrew/nanana.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "next level"), "next ?level;sound/westcoastcrew/nextlevel.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "no no no no no"), "no no no( no)?( no)?;sound/westcoastcrew/nonononono.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "nonsense"), "nonsense;sound/westcoastcrew/nonsense.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "nooo"), "nooo;sound/westcoastcrew/Nooo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "not tonight"), "not ?tonight;sound/westcoastcrew/nottonight.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "no way"), "no ?way;sound/westcoastcrew/noway.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "oblivion"), "oblivion;sound/westcoastcrew/obliv.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "obliv"), "obliv(ious)?;sound/westcoastcrew/obliv2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "oh boy"), "oh boy;sound/westcoastcrew/ohboy.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "oh no"), "oh no;sound/westcoastcrew/OhNo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "he's on fire"), "he'?s on fire;sound/westcoastcrew/onfire.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ooom"), "ooom;sound/westcoastcrew/oomwhatyousay.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "opinion"), "opinion|well, you know, that'?s;sound/westcoastcrew/opinion.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "oshikia"), "oshikia;sound/westcoastcrew/oshikia.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "oy"), "oy;sound/westcoastcrew/oy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "papabalyo"), "papabalyo;sound/westcoastcrew/papabaylo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gotta pay the troll"), "gotta pay the troll;sound/westcoastcrew/paytrolltoll.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "pick music"), "pick ?music;sound/westcoastcrew/pickmusic.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "littlemeezers"), "littlemeezers;sound/westcoastcrew/pizzaguy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "psygib"), "psygib;sound/westcoastcrew/psygib.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "puff"), "puff;sound/westcoastcrew/puff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "qaaq"), "qaaq;sound/westcoastcrew/qaaq.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "qibuqi"), "qibuqi;sound/westcoastcrew/qibuqi.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "qqaaq"), "qqaaq;sound/westcoastcrew/qqaaq.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "questionable"), "questionable;sound/westcoastcrew/questionable.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rage quit"), "rage quit;sound/westcoastcrew/ragequit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "let's get ready to rumble"), "let'?s get ready to rumble;sound/westcoastcrew/readytorumble.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "really"), "really;sound/westcoastcrew/really.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "reflexes"), "reflexes|it'?s all in the reflexes;sound/westcoastcrew/reflexes.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rekt"), "rekt;sound/westcoastcrew/rekt.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "retard"), "retard;sound/westcoastcrew/Retard.ogg")
+            #self.db.set(SOUND_TRIGGERS.format(5, "rockyouguitar"), "rockyouguitar;sound/westcoastcrew/RockYouGuitar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rothkoo"), "rothkoo;sound/westcoastcrew/rothko.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rothko"), "rothko;sound/westcoastcrew/rothko_theme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rugged"), "rugged|like a rock;sound/westcoastcrew/rugged.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "santa town"), "santa ?town;sound/westcoastcrew/santatown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "saved"), "saved;sound/westcoastcrew/saved.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "scrub"), "scrub;sound/westcoastcrew/scrub.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "senth"), "senth;sound/westcoastcrew/senth.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "shaft"), "shaft;sound/westcoastcrew/shaft.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "shenookies cookies"), "shenookie'?s cookies;sound/westcoastcrew/shenook.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "shenookie"), "shenookie;sound/westcoastcrew/shenookies.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "you show that turd"), "turd|you show that turd|show that turd;sound/westcoastcrew/showthatturd.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "shufflenufiguess"), "shufflenufiguess;sound/westcoastcrew/shufflenufflegus.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "skadoosh"), "skadoosh;sound/westcoastcrew/skadoosh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "slime"), "slime;sound/westcoastcrew/slime.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "snort"), "snort;sound/westcoastcrew/snort.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "snpete"), "snpete;sound/westcoastcrew/SNpete.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "snpete2"), "snpete2|chick chicky boom;sound/westcoastcrew/SNpete2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "so is your face"), "so is your face;sound/westcoastcrew/soisyourface.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "solis"), "solis;sound/westcoastcrew/solis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "spank you"), "spank you;sound/westcoastcrew/spankyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "stfu2"), "stfu2;sound/westcoastcrew/stfu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "still feel like you're mad"), "still feel like you'?re mad;sound/westcoastcrew/stillmad.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "stitch"), "stitch;sound/westcoastcrew/stitch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "somebody stop me"), "somebody stop me;sound/westcoastcrew/stopme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "survey said"), "survey said;sound/westcoastcrew/surveysaid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "swish"), "swish;sound/westcoastcrew/swish.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "team complete"), "team ?complete;sound/westcoastcrew/teamcomplete2.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "teamwork"), "teamwork;sound/westcoastcrew/Teamwork.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "that's all folks"), "that'?s all folks;sound/westcoastcrew/thatsallfolks.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "thetealduck"), "the ?teal ?duck;sound/westcoastcrew/thetealduck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "thriller"), "thriller;sound/westcoastcrew/thriller.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "tooold"), "too?o?ld;sound/westcoastcrew/tooold.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "troll toll"), "troll ?toll;sound/westcoastcrew/trolltoll.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "turple"), "turple;sound/westcoastcrew/turpled.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "tustamena"), "tustamena;sound/westcoastcrew/tustamena.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ty2"), "thanks2|ty2;sound/westcoastcrew/ty.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "unstoppable"), "unstoppable;sound/westcoastcrew/unstoppable.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ventt"), "ventt;sound/westcoastcrew/v3ntt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "vacuum"), "vacuum;sound/westcoastcrew/vacuum.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "vks"), "vks|bow;sound/westcoastcrew/vks.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "w3rd"), "w3rd;sound/westcoastcrew/w3rd.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "wanerbuliao"), "wanerbuliao;sound/westcoastcrew/wanerbuliao.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "waow"), "waow;sound/westcoastcrew/waow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "what did you do"), "what did you do;sound/westcoastcrew/whatdidyoudo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "what just happened"), "what ?just ?happened;sound/westcoastcrew/whatjusthappened.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "why you little"), "why you little;sound/westcoastcrew/whyyoulittle.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "wolf"), "wolf;sound/westcoastcrew/wolf.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "wow"), "wow;sound/westcoastcrew/wow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "woww"), "woww;sound/westcoastcrew/wow2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "wuyoga"), "wuyoga;sound/westcoastcrew/wuyoga.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "xxx"), "xxx;sound/westcoastcrew/xxx.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ya basic"), "ya ?basic;sound/westcoastcrew/yabasic.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "jdub"), "jdub|y'?all ready for this;sound/westcoastcrew/yallreadyforthis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "yawn"), "yawn;sound/westcoastcrew/yawn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "yawnn"), "yawnn+;sound/westcoastcrew/yawnn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "yeah baby"), "yeah baby;sound/westcoastcrew/yeahbaby.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "yhehehe"), "yhehehe;sound/westcoastcrew/YHehehe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "you can do it"), "you can do( it)?;sound/westcoastcrew/youcandoit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "youlose"), "youlose;sound/westcoastcrew/youlose.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "your pick"), "your ?pick;sound/westcoastcrew/yourpick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "zebby"), "zebby;sound/westcoastcrew/zebby.ogg")
+            self.category_loaded(5, 'database', player)
+
+            if ADDITIONAL_SOUNDPACKS:
+                base_path = self.get_cvar("fs_basepath")
+                next_num = len(self.Enabled_SoundPacks)
+                for item in ADDITIONAL_SOUNDPACKS:
+                    file = "{}/baseq3/{}".format(base_path, item)
+                    if path.isfile(file):
+                        sounds = ZipFile(file).namelist()
+                        pack_name = item.split('.')[0]
+                        self.Enabled_SoundPacks.append(1)
+                        self.soundPacks.append(pack_name.replace('_', ' '))
+                        self.categories.append('#{}'.format(pack_name))
+                        for sound in sounds:
+                            try:
+                                sf = path.split(sound)
+                                if sf[1]:
+                                    name = self.convert(sf[1].split('.')[0])
+                                    append = 1
+                                    exists = True
+                                    while exists:
+                                        exists = False
+                                        for x in range(0, next_num):
+                                            if self.db.exists(SOUND_TRIGGERS.format(x, name)):
+                                                exists = True
+                                        if exists:
+                                            name = '{}{}'.format(name, append) if append == 1 else \
+                                                '{}{}'.format(name[:-1], append)
+                                            append += 1
+                                    self.db.set(SOUND_TRIGGERS.format(next_num, name), "{};{}".format(name, sound))
+                            except:
+                                continue
+                        if self._enable_dictionary:
+                            self._sound_dictionary[next_num] = {}
+                        if player:
+                            count = 0
+                            while not self.db.keys(SOUND_TRIGGERS.format(next_num, "*")):
+                                time.sleep(1)
+                                if count > 10:
+                                    break
+                                count += 1
+                        self.category_loaded(next_num, 'database', player)
+                        next_num += 1
+
+        self.populate_sound_lists(player)
+        return

--- a/configs/presets/_builtin/default-minqlxtended/scripts/player_info.py
+++ b/configs/presets/_builtin/default-minqlxtended/scripts/player_info.py
@@ -398,8 +398,11 @@ class player_info(minqlxtended.Plugin):
             ban = {"expires": expires, "reason": "deactivated account", "issued": now, "issued_by": "player_info"}
             db.hmset(base_key + ":{}".format(ban_id), ban)
             db.execute()
-            self.kick(player.id, "banned from this server because of deactivated account.")
+            # Plugin has no kick method on either runtime, so the minqlx original's
+            # call here was an AttributeError waiting to happen. Player.kick takes the
+            # reason directly (_player.py:926).
+            player.kick("banned from this server because of deactivated account.")
         except:
             n = player.name
-            self.kick(player.id, "kicked because of deactivated account.")
+            player.kick("kicked because of deactivated account.")
             self.msg("{} has been kicked, but could not be banned. Contact iouonegirl".format(n))

--- a/configs/presets/_builtin/default-minqlxtended/scripts/player_info.py
+++ b/configs/presets/_builtin/default-minqlxtended/scripts/player_info.py
@@ -1,0 +1,405 @@
+﻿# This is a plugin created by iouonegirl(@gmail.com)
+# Copyright (c) 2016 iouonegirl + Minkyn
+# https://github.com/dsverdlo/minqlx-plugins
+#
+# You are free to modify this plugin to your custom,
+# except for the version command related code.
+#
+# Its purpose is to display some information about the players.
+# When players fall off the scoreboard, they are now also able
+# to view their information
+#
+# Players deactivated on qlstats can be banned or just
+# trigger a server warning.
+# Can also use a different elo rating site by changing
+# cvar qlx_balanceUrl
+#
+# Uses:
+# - set qlx_pinfo_display_auto "0"
+# - set qlx_pinfo_show_deactivated "1"
+#          ^ (If this is 1 then a warning will be shown of players who are deactivated on qlstats/other)
+# - set qlx_pinfo_ban_deactivated "0"
+# - set qlx_pinfo_ban_duration_weeks "1"
+#       ^ If ban_deactivated is "1", then this var will specify for how many weeks the ban will last
+#         (please only use integers (no decimals) here)
+
+import minqlxtended
+import requests
+import itertools
+import threading
+import datetime
+import random
+import time
+import os
+import re
+from redis.exceptions import RedisError as _RedisError
+
+# On minqlx this plugin subclasses the iouonegirl abstract base, which installs itself
+# at import time by fetching its module from github.com/dsverdlo/minqlx-plugins.
+# That base is deliberately not carried across:
+#
+#   - it is not in the minqlxtended baseline, and everything it auto-updates is
+#     minqlx-API code, which would not load on this runtime anyway;
+#   - it downloads at import, so every plugin load depends on the game server having
+#     outbound access to GitHub and on that repository still serving the file.
+#
+# player_info used exactly one thing from it — find_by_name_or_id — which is inlined
+# below. Nothing else it inherited was ever called from this file.
+
+VERSION = "v0.36"
+
+PLAYER_KEY = "minqlx:players:{}"
+COMPLETED_KEY = PLAYER_KEY + ":games_completed"
+LEFT_KEY = PLAYER_KEY + ":games_left"
+LENGTH_REGEX = re.compile(r"(?P<number>[0-9]+) (?P<scale>seconds?|minutes?|hours?|days?|weeks?|months?|years?)")
+TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+# Elo retrieval vars
+EXT_SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm", "duel", "ffa")
+RATING_KEY = "minqlx:players:{0}:ratings:{1}" # 0 == steam_id, 1 == short gametype.
+MAX_ATTEMPTS = 3
+CACHE_EXPIRE = 60*30 # 30 minutes TTL.
+DEFAULT_RATING = 1500
+SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm")
+
+
+def zadd_compat(db, key, member, score):
+    """Support both redis-py 2.x (raises RedisError) and 3.x+ (dict mapping) zadd signatures."""
+    try:
+        return db.zadd(key, {member: score})
+    except (TypeError, _RedisError):
+        return db.zadd(key, score, member)
+
+
+class player_info(minqlxtended.Plugin):
+    def __init__(self):
+        super().__init__()
+
+        # set cvars once. EDIT THESE IN SERVER.CFG
+        self.set_cvar_once("qlx_balanceApi", "elo")
+        self.set_cvar_once("qlx_balanceUrl", "qlstats.net")
+        self.set_cvar_once("qlx_pinfo_display_auto", "0")
+        self.set_cvar_once("qlx_pinfo_show_deactivated", "1")
+        self.set_cvar_once("qlx_pinfo_ban_deactivated", "0")
+        self.set_cvar_once("qlx_pinfo_ban_duration_weeks", "1")
+
+        self.add_command("info", self.cmd_player_info,  usage="[<id>|<name>]")
+        self.add_command("scoreboard", self.cmd_scoreboard, usage="[<id>|<name>]")
+        self.add_command(("allelo", "allelos", "aelo", "eloall"), self.cmd_all_elos, usage="[<id>|<name>]")
+
+        self.add_hook("player_connect", self.handle_player_connect, priority=minqlxtended.Priority.LOWEST)
+        
+        self.cache_cvars()
+
+    
+    def cache_cvars(self):
+        self.balanceApiUrl = self.get_cvar("qlx_balanceUrl")
+        self.api_url = "http://{}/{}/".format(self.balanceApiUrl, self.get_cvar("qlx_balanceApi"))
+
+
+    def handle_player_connect(self, player, is_bot):
+        # player_connect gained `is_bot` on this runtime (_events.py:586). It replaces
+        # the steam-id heuristic the minqlx version used to guess the same thing: a
+        # bot has no qlstats history to look up.
+        if is_bot:
+            return
+
+        cond = self.get_cvar("qlx_pinfo_display_auto", int)
+        cond += self.get_cvar("qlx_pinfo_show_deactivated", int)
+        cond += self.get_cvar("qlx_pinfo_ban_deactivated", int)
+
+        if cond:
+            self.fetch(player, self.game.type_short, None)
+
+    def find_by_name_or_id(self, player, target):
+        """Resolve `target` to a single connected player, or tell `player` why not.
+
+        Inlined from iouonegirl.py's abstract base, which this port does not carry
+        (see the note above the class). Behaviour is unchanged from the original.
+        """
+        # Find players returns a list of name-matching players
+        def find_players(query):
+            players = []
+            for p in self.find_player(query):
+                if p not in players:
+                    players.append(p)
+            return players
+
+        # Tell a player which players matched
+        def list_alternatives(players, indent=2):
+            player.tell("A total of ^6{}^7 players matched for {}:".format(len(players), target))
+            out = ""
+            for p in players:
+                out += " " * indent
+                out += "{}^6:^7 {}\n".format(p.id, p.name)
+            player.tell(out[:-1])
+
+        # Get the list of matching players on name
+        target_players = find_players(target)
+
+        # If id:X is given and it amounts to a player, give it precedence.
+        # This is to avoid deadlocks
+        match = re.search("(id[=:][0-9]{1,2})", target)
+        if match and match.group() == target:
+            try:
+                match_id = re.search("([0-9]{1,2})", target)
+                player = self.player(int(match_id.group()))
+                if player.steam_id:
+                    return player
+            except:
+                pass
+
+        # even if we get only 1 person, we need to check if the input was meant as an ID
+        # if we also get an ID we should return with ambiguity
+
+        try:
+            i = int(target)
+            target_player = self.player(i)
+            if not (0 <= i < 64) or not target_player:
+                raise ValueError
+            # Add the found ID if the player was not already found
+            if not target_player in target_players:
+                target_players.append(target_player)
+        except ValueError:
+            pass
+
+        # If there were absolutely no matches
+        if not target_players:
+            player.tell("Sorry, but no players matched your tokens: {}.".format(target))
+            return None
+
+        # If there were more than 1 matches
+        if len(target_players) > 1:
+            list_alternatives(target_players)
+            return None
+
+        # By now there can only be one person left
+        return target_players.pop()
+
+
+
+
+    def cmd_player_info(self, player, msg, channel):
+        if len(msg) > 2:
+            return minqlxtended.Return.USAGE
+
+        if len(msg) < 2:
+            target_player = player
+        else:
+            try:
+                sid = int(msg[1])
+                assert len(msg[1]) == 17
+                target_player = sid
+            except:
+                target_player = self.find_by_name_or_id(player, msg[1])
+                if not target_player: return minqlxtended.Return.STOP_EVENT
+
+        # If there is a duel going on and a spec called the command,
+        # ensure that the playing players don't see it
+        if self.game.type_short == "duel" and self.game.state == "in_progress":
+            if player.team != "free":
+                channel = minqlxtended.SPECTATOR_CHAT_CHANNEL
+
+        # go fetch his elo
+        self.fetch(target_player, self.game.type_short, channel)
+
+
+    def cmd_all_elos(self, player, msg, channel):
+        if len(msg) > 2:
+            return minqlxtended.Return.USAGE
+
+        if len(msg) < 2:
+            target_player = player
+        else:
+            try:
+                sid = int(msg[1])
+                assert len(msg[1]) == 17
+                target_player = sid
+            except:
+                target_player = self.find_by_name_or_id(player, msg[1])
+                if not target_player: return minqlxtended.Return.STOP_EVENT
+
+        # go fetch his elo
+        self.fetch(target_player, None, channel)
+
+    # Show info of people fallen off the scoreboard
+    def cmd_scoreboard(self, player, msg, channel):
+        def show(target):
+            _n = target.name
+            _s = target.stats.score
+            _k = target.stats.kills
+            _d = target.stats.deaths
+            try:
+                _p = target.stats.ping
+            except:
+                _p = "--" # in case of older minqlx version
+
+            _tm = int(target.stats.time / 60000 )
+            _ts = int((target.stats.time % 60000) / 1000)
+            _dd = target.stats.damage_dealt
+            _t = target.team
+            _ad = "{}^2ALIVE" if target.is_alive else "{}^1DEAD"
+            _hc = int(target.cvars.get('handicap', 100))
+            _c = '^7,'
+            if _t == 'blue': _c = '^4,'
+            if _t == 'red': _c = '^1,'
+            _hc = "^3{}％^7-".format(_hc) if (_hc < 100) else ''
+            _ad = _ad.format(_hc)
+
+
+            message = "{}^7({}^7) {k}score ^7{}{c} {k}k/d ^7{}/{}{c} {k}dmg ^7{}{c} {k}time ^7{}m{}s{c} {k}ping ^7{}"
+            message = message.format(_n, _ad, _s, _k, _d, _dd, _tm, _ts, _p, c=_c, k=_c[0:-1])
+            channel.reply("^7" + message)
+
+        teams = self.teams()
+        scoreboard_length = 8
+
+        players = []
+        if len(teams['red']) > scoreboard_length:
+            sorted_red = sorted(teams["red"], key=lambda p: p.score, reverse=True)
+            for p in sorted_red[scoreboard_length:]:
+                players.append(p)
+        if len(teams['blue']) > scoreboard_length:
+            sorted_blue = sorted(teams['blue'], key=lambda p: p.score, reverse=True)
+            for p in sorted_blue[scoreboard_length:]:
+                players.append(p)
+
+        if not players:
+            channel.reply("^7No players falling off the scoreboard...")
+            return
+
+        for p in players:
+            show(p)
+
+
+
+
+
+    @minqlxtended.thread
+    def fetch(self, player, gt, channel):
+        try:
+            sid = player.steam_id
+        except:
+            sid = player
+
+        attempts = 0
+        last_status = 0
+        while attempts < MAX_ATTEMPTS:
+            attempts += 1
+            url = f"{self.api_url}{sid}"
+            res = requests.get(url)
+            last_status = res.status_code
+            if res.status_code != requests.codes.ok:
+                continue
+
+            js = res.json()
+            if "players" not in js:
+                last_status = -1
+                continue
+
+            if "deactivated" in js and js["deactivated"]:
+
+                # If we notice deactivated, ban player (auto or cmd initiated)
+                if self.get_cvar("qlx_pinfo_ban_deactivated", int):
+                    self.ban_deactivated(player)
+                    return
+
+                elif self.get_cvar("qlx_pinfo_show_deactivated", int):
+                    @minqlxtended.next_frame
+                    def warn():
+                        self.msg("^3SERVER WARNING^7! {}^7's account has been ^1DEACTIVATED^7 on {}.".format(player.name, self.balanceApiUrl))
+                    warn()
+
+            # if we came here from a connect trigger, for a server that doesnt want auto info, return
+            if not channel and not self.get_cvar("qlx_pinfo_display_auto", int):
+                return
+
+            if not channel:
+                channel = minqlxtended.CHAT_CHANNEL
+                if self.game.state == "in_progress":
+                    channel = minqlxtended.SPECTATOR_CHAT_CHANNEL
+
+
+            for p in js["players"]:
+                _sid = int(p["steamid"])
+                if _sid == sid: # got our player
+                    # If they want all the elos
+                    if not gt: return self.callback_all(player, p, channel)
+                    # If the request gametype is found
+                    if gt in p: return self.callback(player, p[gt]["elo"], p[gt]["games"], channel)
+                    # If the gametype was not found
+                    else: return self.callback(player, 0,0, channel)
+
+
+
+        return self.callback(player, 0, 0, channel)
+
+
+    def callback_all(self, player, modes, channel):
+        info = []
+        for mode in modes:
+            if mode not in EXT_SUPPORTED_GAMETYPES: continue
+            elo = modes[mode]['elo']
+            games = modes[mode]["games"]
+            info.append(" ^3{}^7: {} ({} games)".format(mode.upper(), elo, games))
+
+        if not info:
+            channel.reply("^6{}^7 has no tracked elos.".format(player.name))
+        else:
+            b = 'b' if self.get_cvar('qlx_balanceApi') == 'elo_b' else ''
+            channel.reply("^6{}^7's {}ELO's: {}".format(player.name, b, ", ".join(info)))
+
+
+    def callback(self, target_player, elo, games, channel):
+
+        try:
+            ident = target_player.steam_id
+            name = target_player.name
+        except:
+            ident = target_player
+            name = target_player
+
+        try:
+            completed = int(self.db[COMPLETED_KEY.format(ident)])
+        except:
+            completed = 0
+        try:
+            left = int(self.db[LEFT_KEY.format(ident)])
+        except:
+            left = 0
+
+
+        if left + completed == 0:
+            games_here_p = 1
+        else:
+            games_here_p = left + completed
+
+
+        info = ["^6{} ^7games here".format(completed + left)]
+        info[0] = info[0] + " ^7(^6{}^7 tracked {})".format(games, self.game.type_short)
+
+        info.append("^7quit ^6{}^7％".format(round(left/(games_here_p)*100)))
+
+        info.append("^3{} ^7{}ELO: ^6{}^7".format(self.game.type_short.upper(),'b' if self.get_cvar('qlx_balanceApi') == 'elo_b' else '', elo, games))
+
+        return channel.reply("^6{}^7: ".format(name) + "^7, ".join(info) + "^7.")
+
+    @minqlxtended.delay(2)
+    def ban_deactivated(self, player):
+        try:
+            duration = self.get_cvar("qlx_pinfo_ban_duration_weeks", int)
+            td = datetime.timedelta(weeks=duration)
+            now = datetime.datetime.now().strftime(TIME_FORMAT)
+            expires = (datetime.datetime.now() + td).strftime(TIME_FORMAT)
+            base_key = PLAYER_KEY.format(player.steam_id) + ":bans"
+            ban_id = self.db.zcard(base_key)
+            db = self.db.pipeline()
+            zadd_compat(db, base_key, ban_id, time.time() + td.total_seconds())
+            ban = {"expires": expires, "reason": "deactivated account", "issued": now, "issued_by": "player_info"}
+            db.hmset(base_key + ":{}".format(ban_id), ban)
+            db.execute()
+            self.kick(player.id, "banned from this server because of deactivated account.")
+        except:
+            n = player.name
+            self.kick(player.id, "kicked because of deactivated account.")
+            self.msg("{} has been kicked, but could not be banned. Contact iouonegirl".format(n))

--- a/configs/presets/_builtin/default-minqlxtended/scripts/specqueue.py
+++ b/configs/presets/_builtin/default-minqlxtended/scripts/specqueue.py
@@ -1,0 +1,2441 @@
+# This is an extension plugin  for minqlxtended.
+# Copyright (C) 2018 BarelyMiSSeD (github)
+
+# You can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+
+# You should have received a copy of the GNU General Public License
+# along with minqlxtended. If not, see <http://www.gnu.org/licenses/>.
+
+# This is a queueing plugin for the minqlx admin bot.
+# This plugin can be used alone or with the serverBDM.py plugin.
+# Player placement into teams can be done using skill ratings (BDM 0r ELO) or used as a simple queue.
+#
+# This plugin is intended to help keep the game as enjoyable as possible,
+#  without the hassles of people making teams uneven, or someone joining later than others,
+#  but happening to hit the join button first and cutting in line when a play spot opens.
+#
+# The plugin will also attempt to keep team games even, when adding 2 players at once,
+#  by putting players into the most appropriate team, based on team scores or player BDMs/ELOs.
+#
+# This plugin will spectate people when teams are uneven. It will, by default settings,
+#  first look at player times then player scores to determine who, on the team with more players,
+#  gets put to spectate. When a player gets put to spectate they will automatically get put into the
+#  queue at the beginning of the line.
+#
+# There is also the option to have the players in spectate for too long (set with qlx_queueMaxSpecTime)
+#  to be kicked. This will only kick the player, not do any kind of ban, so the player can reconnect immediately.
+# This feature will not kick people with permission levels at or above the qlx_queueAdmin level,
+#  or people who are in the queue.
+#
+# Use the command '!fix' to fix a player that is shown as sarge and not seen as an enemy or a teammate.
+# This will set each player's model to the model recorded when they joined the server.
+#
+# See the following section for the meaning of the specqueue server cvars. The section can be copied as-is
+# into a server config file and edited as desired.
+
+# *** NOTE ****
+# This plugin will unload any "set_configstring" hooks loaded by other scripts.
+# The remove action is logged by printing the action to the console, check the minqlxtended.log.
+# If this is not desired comment the self.remove_conflicting_hooks() line.
+# Use minqlxtended.configstring(index) to be able to parse information from the config string.
+
+"""
+//set the minqlx permission level needed to admin this script
+set qlx_queueAdmin "3"
+//enable to use BDM/ELO in placement into teams when 2 players are put in together
+//disable to use as generic queue system (0=off, 1=on)
+set qlx_queueUseSkillPlacement "1"
+//if pacing by skill rating (see qlx_queueUseSkillPlacement), use BDM or ELO (0=ELO, 1=BDM)
+set qlx_queueUseRating "1"
+//The script will try to place players in by BDM/ELO ranking, if this is set on (0=off 1=on) it will
+// put the higher BDM/ELO player in the losing team if the score is greater than the qlx_queueTeamScoresDiff setting
+set qlx_queuePlaceByTeamScores "1"
+//Set the score difference used if qlx_queuePlaceByTeamScores is on
+set qlx_queueTeamScoresDiff "3"
+//Display the Queue message at the start of each round (0=off, 1=on, 2=display every 5th round)
+set qlx_queueQueueMsg "1"
+//Display the Spectate message at the start of each round
+set qlx_queueSpecMsg "1"
+//the minimum amount of players before the teams will be kept player number balanced
+set qlx_queueMinPlayers "2"
+//the maximum amount of players after which the teams will not be kept player number balanced
+set qlx_queueMaxPlayers "30"
+//use time played as a choosing factor to decide which player to spectate
+set qlx_queueSpecByTime "1"
+//use score played as a choosing factor to decide which player to spectate
+set qlx_queueSpecByScore "1"
+//set to either "score" or "time" to set which to use as the primary deciding factor in choosing a player to spectate
+set qlx_queueSpecByPrimary "time"
+//set to an amount of minutes a player is allowed to remain in spectate (while not in the queue) before the server will
+// kick the player to make room for people who want to play. (valid values are greater than "0" and less than "9999")
+set qlx_queueMaxSpecTime "9999"
+// Set the maximum admin spectate time: 0=no Limit, Not 0=setting * qlx_queueMaxSpecTime
+set qlx_queueAdminSpec "2"
+// The amount of time in NO_COUNTDOWN_TEAM_GAMES it will give when teams are detected
+//  as uneven before putting a player in spectate
+set qlx_queueCheckTeamsDelay "5"
+// Enable the fix the sarge player bug to execute at the start of a game
+//  This will wait 2 seconds after the start of the game and set everyone's player model to the model being reported by
+//   the server. It will not change what the player has set unless the server did not correctly receive the
+//   player model information on player connect. This is an attempt to fix any occurrence of a player showing up as
+//   the Sarge character of brown color, appearing like they are not on a team. (0=disable, 1=enable)
+set qlx_queueResetPlayerModels "0"
+// Enable to shuffle teams whenever the map changes, even if the same map is loaded again, or when a game is aborted
+// (0=disable, 1=enable) (enabling not recommended if server is set to auto balance teams)
+set qlx_queueShuffleOnMapChange "0"
+// If shuffle on map change is enabled, sets the amount of time to wait before shuffling teams
+// (must have qlx_queueShuffleOnMapChange enabled to work and a min of 10 and max of 30 seconds is required)
+set qlx_queueShuffleTime "10"
+// If shuffle on map change is enabled, displays a message to players counting down to the shuffle
+// (0=disable, 1=center print every second, 2=center print every 5 seconds,
+//    3=chat message every second, 4=chat message every 5 seconds)
+set qlx_queueShuffleMessage "2"
+// This will enable/disable the labeling of spectators with their spec/queue status (0=disable, 1=enable)
+set qlx_queueShowQPosition "1"
+// Chose the style of character surrounding the spec/queue label (default is brackets [] , ex. [1] )
+// Start counting at 0 and chose the character position from the POSITION_LABEL list, so {} would
+// be set qlx_queuePositionLabel "2". Set qlx_queuePositionLabel to one of these numbers or set it to a
+// custom string, custom setting must have only two positions in, contained in quotes.
+// 0="[]", 1="()", 2="{}", 3="<>", 4="--", 5="==", 6="||", 7="!!", 8="''", 9="..", 10="**", 11="〔〕", 12="《》"
+// 13="〚〛", 14="  " (spaces)
+set qlx_queuePositionLabel "0"  // custom ex: set qlx_queuePositionLabel "~~"
+// This setting will perform check the clan tags saved in the database. Set it to the desired action.
+// 0=Do Nothing, 1=Delete clan tags with special characters, 2=Delete all saved clan tags
+set qlx_queueCleanClanTags "0"
+// Will enforce even teams if enabled (0=disabled, 1=enabled)
+set qlx_queueEnforceEvenTeams "1"
+// Saves the retrieved player ELOs to the database. (0=disable, 1=enable)
+// NOTE: Will overwrite any rankings set if blalance.py's !setelo is used. Makes balance.py get rankings faster.
+set qlx_queueSaveEloToDatabase "1"
+// Will request rankings from ELO_URL each map change. (0=disable, 1=enable)
+set qlx_queueGetEloRatingsEachMap "1"
+"""
+
+import minqlxtended
+import time
+import traceback
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from threading import RLock, Event
+from random import randrange
+import re
+import requests
+
+VERSION = "2.13.6"
+
+# Add allowed spectator tags to this list. Tags can only be 5 characters long.
+SPEC_TAGS = ("afk", "food", "away", "phone")
+
+SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm", "ad", "1f", "har", "ffa", "race", "rr")
+TEAM_BASED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm", "ad", "1f", "har")
+NONTEAM_BASED_GAMETYPES = ("ffa", "race", "rr")
+NO_COUNTDOWN_TEAM_GAMES = ("ft", "1f", "ad", "dom", "ctf")
+RANKING_GAMETYPES = ("ft", "ca", "ctf", "ffa", "ictf", "tdm")
+NON_ROUND_BASED_GAMETYPES = ("ffa", "race", "tdm", "ctf", "har", "dom", "rr")
+BDM_KEY = "minqlx:players:{0}:bdm:{1}:{2}"
+ELO_KEY = "minqlx:players:{0}:ratings:{1}"  # 0 == steam_id, 1 == short game type.
+POSITION_LABELS = ("[]", "()", "{}", "<>", "--", "==", "||", "!!", "''", "..", "**", "〔〕", "《》", "〚〛", "  ")
+ELO_URL = "qlstats.net"
+DEFAULT_ELO = 1122
+ELO_REQUEST_TIMEOUT = 5.0
+
+ENABLE_LOG = True  # set to True/False to enable/disable logging
+
+
+
+# This is the class used to manage the player queue. I tried using the Queue that comes with python
+# and tried just using a simple list, but both of those options had problems with the QL server's stability.
+# I found that making my own queueing class eliminated the problems I was seeing as well as being able to make
+# more efficient code to speed up execution time.
+class PlayerQueue:
+    def __init__(self):
+        self._queue = []
+        self._queue_player = []
+        self._queue_times = {}
+        self._q_count = 0
+        self._lock = RLock()
+
+    def __contains__(self, value):
+        if self._q_count > 0:
+            try:
+                if isinstance(value, int):
+                    return value in self._queue
+                elif value.isdecimal():
+                    return value in self._queue_times
+                else:
+                    return value in self._queue_player
+            except:
+                pass
+        else:
+            return False
+
+    def __getitem__(self, value):
+        if self._q_count > 0:
+            try:
+                if isinstance(value, int):
+                    return self._queue[value]
+                elif value.isdecimal():
+                    if len(value) == 17:
+                        return self._queue_times[value]
+                    else:
+                        return self._queue_player[int(value)]
+            except:
+                pass
+        return None
+
+    def __bool__(self):
+        return self._q_count > 0
+
+    def __len__(self):
+        return self._q_count
+
+    def size(self):
+        return self._q_count
+
+    @property
+    def count(self):
+        return self._q_count
+
+    @property
+    def next(self):
+        return [self._queue[0], self._queue_player[0]]
+
+    @next.setter
+    def next(self, player):
+        self.add_to_queue(player.steam_id, player, 0)
+
+    def empty_queue(self):
+        self.clear()
+
+    def in_queue(self, sid=None, player=None):
+        if not sid and not player:
+            return False
+        if player and not sid:
+            sid = player.steam_id
+        return self._q_count > 0 and sid in self._queue
+
+    def add_to_queue(self, sid, player, pos=None):
+        with self._lock:
+            added = False
+            if sid not in self._queue:
+                if pos is None:
+                    self._queue.append(sid)
+                    self._queue_player.append(player)
+                else:
+                    self._queue.insert(pos, sid)
+                    self._queue_player.insert(pos, player)
+                self._q_count += 1
+                self._queue_times[str(sid)] = time.time()
+                added = True
+            else:
+                if pos is not None:
+                    index = self.get_queue_position(sid)
+                    if sid != index:
+                        self._queue.remove(sid)
+                        self._queue_player.remove(player)
+                        self._queue.insert(pos, sid)
+                        self._queue_player.insert(pos, player)
+                        added = True
+                    if str(sid) not in self._queue_times:
+                        self._queue_times[str(sid)] = time.time()
+            return added
+
+    def get_next(self):
+        return self.get_from_index()
+
+    def get_from_queue(self, pos=None):
+        if self._q_count > 0:
+            pos = 0 if pos is None or pos <= 0 else pos - 1
+            if pos >= self._q_count:
+                pos = self._q_count - 1
+            return self.get_from_index(pos)
+
+    def get_from_index(self, pos=None):
+        if self._q_count > 0:
+            with self._lock:
+                pos = 0 if pos is None or pos < 0 else pos
+                if pos >= self._q_count:
+                    pos = self._q_count - 1
+                self._q_count -= 1
+                sid = self._queue.pop(pos)
+                player = self._queue_player.pop(pos)
+                try:
+                    ptime = self._queue_times.pop(str(sid))
+                except IndexError:
+                    ptime = 0
+                return [sid, player, ptime]
+
+    def get_two(self):
+        if self._q_count > 1:
+            with self._lock:
+                self._q_count -= 2
+                sid1 = self._queue.pop(0)
+                player1 = self._queue_player.pop(0)
+                p1time = None
+                try:
+                    p1time = self._queue_times.pop(str(sid1))
+                except KeyError:
+                    pass
+                sid2 = self._queue.pop(0)
+                player2 = self._queue_player.pop(0)
+                p2time = None
+                try:
+                    p2time = self._queue_times.pop(str(sid2))
+                except KeyError:
+                    pass
+                return [sid1, player1, sid2, player2, p1time, p2time]
+
+    def remove_from_queue(self, sid, player):
+        if self._q_count > 0:
+            with self._lock:
+                if sid in self._queue:
+                    self._q_count -= 1
+                    self._queue.remove(sid)
+                    self._queue_player.remove(player)
+                    try:
+                        del self._queue_times[str(sid)]
+                    except KeyError:
+                        pass
+
+    def get_queue_position(self, player):
+        if player in self._queue:
+            return self._queue.index(player)
+        if player in self._queue_player:
+            return self._queue_player.index(player)
+        else:
+            return -1
+
+    def get_queue_time(self, sid):
+        if str(sid) in self._queue_times:
+            return self._queue_times[str(sid)]
+        else:
+            return None
+
+    def add_to_times(self, sid):
+        with self._lock:
+            sid = str(sid)
+            if sid not in self._queue_times:
+                self._queue_times[sid] = time.time()
+                self._q_count += 1
+
+    def remove_from_times(self, sid):
+        if self._q_count > 0:
+            with self._lock:
+                sid = str(sid)
+                if sid in self._queue_times:
+                    del self._queue_times[sid]
+                    self._q_count -= 1
+
+    def get_time(self, sid):
+        sid = str(sid)
+        if sid in self._queue_times:
+            return self._queue_times[sid]
+        else:
+            return None
+
+    def clear(self):
+        self._queue = []
+        self._queue_player = []
+        self._queue_times = {}
+        self._q_count = 0
+
+    def queue(self):
+        with self._lock:
+            return [self._queue.copy(), self._queue_player.copy(), self._queue_times.copy()]
+
+    def sids(self):
+        with self._lock:
+            return self._queue.copy()
+
+    def players(self):
+        with self._lock:
+            return self._queue_player.copy()
+
+    def times(self):
+        with self._lock:
+            return self._queue_times.copy()
+
+
+class specqueue(minqlxtended.Plugin):
+    def __init__(self):
+        self._queue_label = "[]"
+        if ENABLE_LOG:
+            self.queue_log = logging.Logger(__name__)
+            file_dir = os.path.join(minqlxtended.get_cvar("fs_homepath"), "logs")
+            if not os.path.isdir(file_dir):
+                os.makedirs(file_dir)
+
+            file_path = os.path.join(file_dir, "specqueue.log")
+            file_fmt = logging.Formatter("[%(asctime)s] %(message)s", "%Y-%m-%d %H:%M:%S")
+            file_handler = RotatingFileHandler(file_path, encoding="utf-8", maxBytes=3000000, backupCount=5)
+            file_handler.setFormatter(file_fmt)
+            self.queue_log.addHandler(file_handler)
+            self.queue_log.info("============================= Logger started =============================")
+
+        # queue cvars
+        self.set_cvar_once("qlx_queueAdmin", "3")
+        self.set_cvar_once("qlx_queueUseSkillPlacement", "1")
+        self.set_cvar_once("qlx_queueUseRating", "1")
+        self.set_cvar_once("qlx_queuePlaceByTeamScores", "1")
+        self.set_cvar_once("qlx_queueTeamScoresDiff", "3")
+        self.set_cvar_once("qlx_queueQueueMsg", "1")
+        self.set_cvar_once("qlx_queueSpecMsg", "1")
+        self.set_cvar_once("qlx_queueMinPlayers", "2")
+        self.set_cvar_once("qlx_queueMaxPlayers", "30")
+        self.set_cvar_once("qlx_queueSpecByTime", "1")
+        self.set_cvar_once("qlx_queueSpecByScore", "1")
+        self.set_cvar_once("qlx_queueSpecByPrimary", "time")
+        self.set_cvar_once("qlx_queueMaxSpecTime", "9999")  # time in minutes
+        self.set_cvar_once("qlx_queueAdminSpec", "2")  # 0=no Limit, !0=setting * qlx_queueMaxSpecTime
+        self.set_cvar_once("qlx_queueCheckTeamsDelay", "5")
+        self.set_cvar_once("qlx_queueResetPlayerModels", "0")
+        self.set_cvar_once("qlx_queueShuffleOnMapChange", "0")
+        self.set_cvar_once("qlx_queueShuffleTime", "10")
+        self.set_cvar_once("qlx_queueShuffleMessage", "2")
+        self.set_cvar_once("qlx_queueAfkMoveTime", "0")        # seconds; 0 = disabled
+        self.set_cvar_once("qlx_queueAfkExemptLevel", "5")     # permission level exempt from auto-spec
+        self.set_cvar_once("qlx_queueShowQPosition", "1")
+        self.set_cvar_once("qlx_queuePositionLabel", "0")
+        self.set_cvar_once("qlx_queueCleanClanTags", "0")
+        self.set_cvar_once("qlx_queueEnforceEvenTeams", "1")
+        self.set_cvar_once("qlx_queueSaveEloToDatabase", "1")
+        self.set_cvar_once("qlx_queueGetEloRatingsEachMap", "1")
+
+        # Minqlx bot Hooks
+        self.add_hook("new_game", self.handle_new_game)
+        self.add_hook("game_start", self.handle_game_start)
+        self.add_hook("game_end", self.handle_game_end)
+        self.add_hook("round_countdown", self.handle_round_countdown)
+        self.add_hook("round_start", self.handle_round_start)
+        self.add_hook("round_end", self.handle_round_end)
+        self.add_hook("death", self.death_monitor)
+        self.add_hook("player_connect", self.handle_player_connect)
+        self.add_hook("player_loaded", self.handle_player_loaded, priority=minqlxtended.Priority.LOWEST)
+        self.add_hook("player_disconnect", self.handle_player_disconnect, priority=minqlxtended.Priority.HIGH)
+        self.add_hook("team_switch", self.handle_team_switch)
+        self.add_hook("team_switch_attempt", self.handle_team_switch_attempt, priority=minqlxtended.Priority.HIGH)
+        self.add_hook("set_configstring", self.handle_set_config_string, priority=minqlxtended.Priority.HIGHEST)
+        self.add_hook("client_command", self.handle_client_command)
+        self.add_hook("vote_ended", self.handle_vote_ended)
+        self.add_hook("console_print", self.handle_console_print)
+        self.add_hook("map", self.handle_map)
+
+        # Minqlx bot commands
+        self.add_command(("q", "queue"), self.cmd_list_queue)
+        self.add_command(("s", "specs"), self.cmd_list_specs)
+        self.add_command([x for x in SPEC_TAGS], self.cmd_go_afk)
+        self.add_command(("back", "here"), self.cmd_here)
+        self.add_command("tags", self.cmd_tags)
+        self.add_command(("addqueue", "addq"), self.cmd_queue_add)
+        self.add_command(("qversion", "qv"), self.cmd_qversion)
+        self.add_command("ignore", self.ignore_imbalance, self.get_cvar("qlx_queueAdmin", int))
+        self.add_command("latch", self.ignore_imbalance_latch, self.get_cvar("qlx_queueAdmin", int))
+        self.add_command("fix", self.reset_model, self.get_cvar("qlx_queueAdmin", int))
+        self.add_command(("resetqueue", "rq", "fq"), self.reset_queue, self.get_cvar("qlx_queueAdmin", int))
+        self.add_command(("queuestatus", "qs"), self.get_current_settings, 5)
+        self.add_command("getspec", self.get_spec, 5)
+
+        # Script Variables, Lists, and Dictionaries
+        self._queue = PlayerQueue()
+        self._spec = PlayerQueue()
+        self._join = PlayerQueue()
+        self._afk = PlayerQueue()
+        self._players = []
+        self.red_locked = False
+        self.blue_locked = False
+        self.free_locked = False
+        self.end_screen = False
+        self.displaying_queue = False
+        self.displaying_spec = False
+        self.in_countdown = False
+        self.death_count = 0
+        self.q_game_info = [self.game.type_short, self.get_cvar("teamsize", int), self.get_cvar("fraglimit", int)]
+        self._round = 0
+        self.uneven_teams_move_to_spec = {}
+        self._ignore = False
+        self._latch_ignore = False
+        self._ignore_msg_already_said = False
+        self._player_models = {}
+        self._checking_opening = None
+        self._countdown = False
+        self._queue_tags = False
+        self._specPlayer = []
+        self._afk_tag = {}
+        self._afk_last_pos = {}    # sid -> (x, y, z)
+        self._afk_last_moved = {}  # sid -> float timestamp
+        self._afk_pos_lock = RLock()
+        self._afk_poll_stop = Event()
+        self.retrieving_elo = False
+        self.elo_ratings = {}
+        self.elo_lock = RLock()
+
+        # Initialize Commands
+        self.add_spectators()
+        self.add_join_times()
+        self.record_player_models()
+        self.update_queue_tags()
+        self.check_clan_tags()
+        self.remove_conflicting_hooks()
+        self.set_queue_label()
+        self.get_cvars()
+        self._start_afk_position_poll()
+
+    def __del__(self):
+        self._afk_poll_stop.set()
+
+    # ==============================================
+    #               Event Handler's
+    # ==============================================
+    def handle_player_connect(self, player, is_bot):
+        # player_connect gained `is_bot` (_events.py:586).
+        self.process_player_connect(player)
+        return
+
+    def process_player_connect(self, player):
+        try:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process player connect: {}".format(player))
+            if not self._queue.in_queue(player=player):
+                self.add_to_spec(player)
+                self.remove_from_queue(player)
+                self.remove_from_join(player)
+            self.request_elo_rating(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_player_connect Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_player_loaded(self, player):
+        self.process_player_loaded(player)
+        return
+
+    def process_player_loaded(self, player):
+        try:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process player loaded: {}".format(player))
+            self._player_models[player.id] = player.model
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_player_loaded Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_player_disconnect(self, player, reason):
+        self.process_payer_disconnect(player)
+        return
+
+    def process_payer_disconnect(self, player):
+        try:
+            with self.elo_lock:
+                try:
+                    del self.elo_ratings[str(player.steam_id)]
+                except KeyError:
+                    pass
+            sid = str(player.steam_id)
+            with self._afk_pos_lock:
+                self._afk_last_pos.pop(sid, None)
+                self._afk_last_moved.pop(sid, None)
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process player disconnect: {}".format(player))
+            try:
+                self.remove_from_spec(player)
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue remove from spec on disconnect: {} Exception: {}".format(player, e))
+            try:
+                self.remove_from_queue(player)
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue remove from queue on disconnect: {} Exception: {}".format(player, e))
+            try:
+                self.remove_from_join(player)
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue remove from join on disconnect: {} Exception: {}".format(player, e))
+            try:
+                self.remove_from_afk(player, False)
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue remove from afk on disconnect: {} Exception: {}".format(player, e))
+
+            self.check_for_opening(0.5)
+            if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES and not self.end_screen and\
+                    not (self.red_locked or self.blue_locked or self.free_locked):
+                self.look_at_teams(1.0)
+            if player.id in self._player_models:
+                del self._player_models[player.id]
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_player_disconnect Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        self.update_queue_tags()
+
+    def handle_team_switch(self, player, old_team, new_team):
+        self.process_team_switch(player, new_team)
+        return
+
+    def process_team_switch(self, player, new_team):
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue process team switch: {} to {}".format(player, new_team))
+        if new_team != "spectator":
+            try:
+                self.remove_from_spec(player)
+                self.remove_from_queue(player)
+                if str(player.steam_id) not in self._join:
+                    self.add_to_join(player)
+                player.clan = player.clan
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue handle_team_switch not to spectator Exception: {}\n{}"
+                                        .format(type(e).__name__, traceback.format_exc()))
+        else:
+            try:
+                if not self.end_screen:
+                    self.check_for_opening(0.2)
+                    if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES and\
+                            not (self.red_locked or self.blue_locked or self.free_locked):
+                        self.look_at_teams(1.0)
+
+                @minqlxtended.delay(1)
+                def check_spectator():
+                    if not self._queue.in_queue(player=player):
+                        self.add_to_spec(player)
+                    self.remove_from_join(player)
+
+                if player.steam_id in self.uneven_teams_move_to_spec:
+                    del self.uneven_teams_move_to_spec[player.steam_id]
+                else:
+                    check_spectator()
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue handle_team_switch to spectator Exception: {}\n{}"
+                                        .format(type(e).__name__, traceback.format_exc()))
+        self.update_queue_tags()
+
+    def handle_team_switch_attempt(self, player, old_team, new_team, target):
+        # team_switch_attempt gained `target` (_events.py:771) — the player being
+        # moved when someone else initiated the switch. Not used: this plugin only
+        # gates a player's own join attempt.
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue handle team switch attempt: {} old_team={} new_team={}"
+                                .format(player, old_team, new_team))
+        if self.q_game_info[0] in SUPPORTED_GAMETYPES and new_team != "spectator" and old_team == "spectator":
+            teams = self.teams()
+            at_max_players = False
+            join_locked = False
+            self.remove_from_afk(player)
+            if self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                if len(teams["red"]) + len(teams["blue"]) >= self.get_max_players():
+                    at_max_players = True
+                join_locked = self.free_locked
+            elif self.q_game_info[0] in NONTEAM_BASED_GAMETYPES:
+                if len(self.teams()["free"]) >= self.get_max_players():
+                    at_max_players = True
+                join_locked = self.red_locked or self.blue_locked
+            if self._queue or join_locked or self.game and self.game.state in ["in_progress", "countdown"] or\
+                    at_max_players:
+                self.add_to_queue(player)
+                self.remove_from_spec(player)
+                self.check_for_opening(0.2)
+                self.update_queue_tags()
+                return minqlxtended.Return.STOP_ALL
+
+    def handle_set_config_string(self, index, values):
+        if not values:
+            return
+        if 529 <= index <= 592:
+            if not self.get_cvar("qlx_queueShowQPosition", bool):
+                return
+            args = minqlxtended.parse_infostring(values)
+            # If the config_string is not complete, don't allow it to be set on the server
+            if 'n' not in args:
+                return minqlxtended.Return.STOP_ALL
+            # This check is due to bots being added to the game, which don't have config_string steam ids
+            if 'st' in args:
+                s_id = args['st']
+                sid = int(s_id)
+            else:
+                sid = self.player(index - 529).steam_id
+                s_id = str(sid)
+            # If the player is in spectate and queue tags are on, process the spectator tag
+            if args['t'] == '3' and self._queue_tags:
+                if not self._queue_label:
+                    self._queue_label = "[]"
+                # if the player is in the queue, set the queue position tag
+                if sid in self._queue:
+                    args['xcn'] = args['cn'] = "{}{}{}" \
+                        .format(self._queue_label[0], self._queue.get_queue_position(sid) + 1, self._queue_label[1])
+                # otherwise set the spectator tag
+                else:
+                    clan = None
+                    location = "minqlx:players:{}:clantag".format(s_id)
+                    if location in self.db:
+                        clan = self.db[location]
+                    if s_id in self._afk and clan not in SPEC_TAGS:
+                        args['xcn'] = args['cn'] = "{}{}{}"\
+                            .format(self._queue_label[0], self._afk_tag[s_id], self._queue_label[1])
+                    elif clan in SPEC_TAGS:
+                        if 3 < len(clan):
+                            args['xcn'] = args['cn'] = "{}".format(clan)
+                        else:
+                            args['xcn'] = args['cn'] = "{}{}{}".format(self._queue_label[0], clan, self._queue_label[1])
+                    else:
+                        args['xcn'] = args['cn'] = "{}s{}".format(self._queue_label[0], self._queue_label[1])
+            # Otherwise set the clan tag, if a clan tag is saved
+            else:
+                location = "minqlx:players:{}:clantag".format(s_id)
+                if location in self.db:
+                    args['xcn'] = args['cn'] = self.db[location]
+                else:
+                    args.pop('xcn', None)
+                    args.pop('cn', None)
+            return ''.join(["\\{}\\{}".format(key, value) for key, value in args.items()]).lstrip("\\")
+        # process the server teamsize and fraglimit settings
+        elif index == 0:
+            args = minqlxtended.parse_infostring(values)
+            self.q_game_info[2] = int(args['fraglimit'])
+            teamsize = int(args['teamsize'])
+            if self.q_game_info[1] != teamsize:
+                self.q_game_info[1] = teamsize
+                if not self.end_screen:
+                    self.check_for_opening(1.5)
+
+    def update_queue_tags(self):
+        if self.get_cvar("qlx_queueShowQPosition", bool):
+            self._queue_tags = True
+            for player in self.teams()["spectator"]:
+                player.clan = player.clan
+        else:
+            self._queue_tags = False
+
+    def handle_client_command(self, player, command):
+        self.process_client_command(player, command)
+        return
+
+    def process_client_command(self, player, command):
+        try:
+            @minqlxtended.delay(0.2)
+            def spec_player():
+                if command == "team s" and player in self.teams()["spectator"]:
+                    self.add_to_spec(player)
+                    self.remove_from_queue(player)
+                    self.remove_from_join(player)
+                    if self.get_cvar("qlx_queueSpecMsg", bool):
+                        player.center_print("^6You are set to spectate only")
+            spec_player()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_client_command Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        self.update_queue_tags()
+
+    def handle_new_game(self):
+        self.process_new_game()
+        return
+
+    def process_new_game(self):
+        try:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process new game")
+            self.q_game_info = [self.game.type_short, self.get_cvar("teamsize", int), self.get_cvar("fraglimit", int)]
+            self.end_screen = False
+            self.displaying_queue = False
+            self.displaying_spec = False
+
+            if self.q_game_info[0] not in SUPPORTED_GAMETYPES:
+                self._queue.clear()
+                self.msg("^1This gametype is not supported by the queueing system. Queue functions are not available.")
+            else:
+                self.check_for_opening(0.5)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_new_game Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_game_start(self):
+        # game_start dispatches no arguments here (_events.py:698).
+        self.process_game_start()
+        return
+
+    def process_game_start(self):
+        try:
+            self.check_spec_time()
+
+            @minqlxtended.thread
+            def t():
+                if self.q_game_info[0] == "ft":
+                    countdown = self._specPlayer[5]
+                else:
+                    countdown = self._specPlayer[6]
+                time.sleep(max(countdown / 1000 - 0.8, 0))
+                if not (self.red_locked or self.blue_locked or self.free_locked):
+                    self.even_the_teams()
+
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process game start")
+
+            t()
+
+            if self.get_cvar("qlx_queueResetPlayerModels", bool):
+                self.reset_players_model(5)
+
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_game_start Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_map(self, mapname, factory):
+        self.process_map()
+        self.get_cvars()
+        return
+
+    @minqlxtended.delay(0.3)
+    def process_map(self):
+        try:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process map")
+            self.q_game_info = [self.game.type_short, self.get_cvar("teamsize", int), self.get_cvar("fraglimit", int)]
+            self._ignore = False
+            self._ignore_msg_already_said = False
+            with self._afk_pos_lock:
+                self._afk_last_pos.clear()
+                self._afk_last_moved.clear()
+            self.end_screen = False
+            self.check_spec_time()
+            self.death_count = 0
+            self.auto_shuffle_player_teams()
+            if self.get_cvar("qlx_queueGetEloRatingsEachMap", bool):
+                players_sid = [p.steam_id for p in self.players()]
+                self.request_elo_rating(players_sid)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_map Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_game_end(self, aborted):
+        # game_end passes the abort flag directly (_events.py:711), where minqlx
+        # passed a stats dict this read as data["ABORTED"].
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue handle game end: aborted={}".format(aborted))
+        if not aborted:
+            self.end_screen = True
+        return
+
+    def handle_round_countdown(self, round_num):
+        self.process_round_countdown(round_num)
+        return
+
+    def process_round_countdown(self, round_num):
+        try:
+            self._countdown = True
+            self._round = round_num
+            self._ignore = False
+            self._ignore_msg_already_said = False
+            self.check_for_opening(0.2)
+            if self.get_cvar("qlx_queueQueueMsg", bool):
+                self.cmd_list_queue()
+            if self.get_cvar("qlx_queueSpecMsg", bool):
+                self.cmd_list_specs()
+            self.check_queue(0.2)
+            self.check_spec(0.2)
+            if self.q_game_info[0] and not (self.red_locked or self.blue_locked or self.free_locked):
+                self.look_at_teams()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_round_countdown Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_round_start(self, number):
+        self.process_round_start()
+        return
+
+    def process_round_start(self):
+        try:
+            if not self._countdown and not (self.red_locked or self.blue_locked or self.free_locked):
+                self.even_the_teams()
+                self.check_queue(2)
+                self.check_spec(2)
+            self._countdown = False
+            self.check_for_opening(0.2)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_round_start Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_round_end(self, round_number, winning_team, time):
+        # round_end is three arguments here (_events.py:738); minqlx passed one
+        # dict. None of them was read then and none is needed now.
+        self.process_round_end()
+        return
+
+    def process_round_end(self):
+        try:
+            if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES:
+                self.check_for_opening(0.2)
+                if not (self.red_locked or self.blue_locked or self.free_locked):
+                    self.even_the_teams(True)
+                if self.get_cvar("qlx_queueQueueMsg", bool):
+                    self.cmd_list_queue()
+                if self.get_cvar("qlx_queueSpecMsg", bool):
+                    self.cmd_list_specs()
+            self.check_spec_time()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_round_end Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def death_monitor(self, victim, killer, mod):
+        # death dispatches the means of death (_events.py:812), not minqlx's stats
+        # dict. Neither was read; the handler only counts deaths.
+        self.process_death_monitor()
+        return
+
+    def process_death_monitor(self):
+        try:
+            if self.game and self.game.state in ["in_progress", "countdown"]:
+                if self.q_game_info[0] in NON_ROUND_BASED_GAMETYPES:
+                    self.death_count += 1
+                    if self.death_count > 5 and self.death_count > self.q_game_info[2] / 5:
+                        self.check_for_opening(0.2)
+                        if self.get_cvar("qlx_queueQueueMsg", bool):
+                            self.cmd_list_queue()
+                        if self.get_cvar("qlx_queueSpecMsg", bool):
+                            self.cmd_list_specs()
+                        self.check_queue(0.2)
+                        self.check_spec(0.2)
+                        self.death_count = 0
+                        self.check_spec_time()
+                if self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                    self.check_for_opening(0.2)
+        except Exception as e:
+            if "NoneType" not in str(e):
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue death_monitor Exception: {}\n{}"
+                                        .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_console_print(self, text):
+        self.process_console_print(text)
+        return
+
+    def process_console_print(self, text):
+        try:
+            if "locked" in text:
+                if text.find("The RED team is now locked") != -1:
+                    self.red_locked = True
+                elif text.find("The BLUE team is now locked") != -1:
+                    self.blue_locked = True
+                if text.find("The FREE team is now locked") != -1:
+                    self.free_locked = True
+                elif text.find("The RED team is now unlocked") != -1:
+                    self.red_locked = False
+                elif text.find("The BLUE team is now unlocked") != -1:
+                    self.blue_locked = False
+                elif text.find("The FREE team is now unlocked") != -1:
+                    self.free_locked = False
+                self.check_for_opening(0.2)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_console_print Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+
+    def handle_vote_ended(self, votes, vote, args, passed):
+        self.process_vote_ended(vote, passed)
+        return
+
+    def process_vote_ended(self, vote, passed):
+        try:
+            if passed and vote == "teamsize":
+                self.check_for_opening(2.5)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_vote_ended Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    # ==============================================
+    #               Plugin functions
+    # ==============================================
+    # set the label used for spectators, if enabled
+    def set_queue_label(self):
+        label = self.get_cvar("qlx_queuePositionLabel", str)
+        try:
+            self._queue_label = POSITION_LABELS[int(label)]
+        except ValueError:
+            self._queue_label = label
+        except IndexError:
+            self._queue_label = POSITION_LABELS[0]
+
+    # removes any set_configstring hooks used by other plugins
+    @minqlxtended.delay(2)
+    def remove_conflicting_hooks(self):
+        if self.get_cvar("qlx_queueShowQPosition", bool):
+            hook_events = ["set_configstring"]
+            remove_from = ["clan"]
+            loaded_scripts = self.plugins
+            loaded_scripts.pop(self.__class__.__name__)
+            for script, handler in loaded_scripts.items():
+                try:
+                    if script in remove_from:
+                        for hook in handler.hooks:
+                            for event in hook_events:
+                                if event == hook[0]:
+                                    if ENABLE_LOG:
+                                        self.queue_log.info("specqueue: Removing event hook ^7{}"
+                                                            " ^1used in ^7{} ^1plugin"
+                                                            .format(event, script))
+                                    handler.remove_hook(event, hook[1], hook[2])
+                except:
+                    continue
+
+    # Deletes saved clan tags that are not simple in formation
+    def check_clan_tags(self):
+        level = self.get_cvar("qlx_queueCleanClanTags", int)
+        if level:
+            keys = self.db.keys("minqlx:players:*:clantag")
+            for tag in keys:
+                clan_tag = self.db.get(tag)
+                if level == 1:
+                    check_tag = [ord(c) for c in clan_tag]
+                    for char in check_tag:
+                        if 0x20 > char or 0x7F < char:
+                            del self.db[tag]
+                            break
+                    length = len(re.sub(r"\^[0-9]", "", clan_tag))
+                    if length == 0 or length > 5:
+                        del self.db[tag]
+                else:
+                    del self.db[tag]
+
+    # Execute a shuffle command if the game is a team based game type
+    @minqlxtended.thread
+    def auto_shuffle_player_teams(self):
+        try:
+            if self.get_cvar("qlx_queueShuffleOnMapChange", bool) and self.q_game_info[0] in TEAM_BASED_GAMETYPES and\
+                    len(self.players()) > 2 and self.game.state == "warmup":
+                count = 0
+                saved_time = self.get_cvar("qlx_queueShuffleTime", int)
+                shuffle_time = saved_time if 10 <= saved_time <= 30 else 10
+                message_setting = self.get_cvar("qlx_queueShuffleMessage", int)
+                if message_setting:
+                    while count < shuffle_time:
+                        execute_time = shuffle_time - count
+                        if message_setting == 2:
+                            if not count % 5:
+                                self.center_print("^7Shuffling teams in {} second{}"
+                                                  .format(execute_time, "s" if execute_time > 1 else ""))
+                        elif message_setting == 3:
+                            self.msg("^6Shuffling teams in {} second{}"
+                                     .format(execute_time, "s" if execute_time > 1 else ""))
+                        elif message_setting == 4:
+                            if not count % 5:
+                                self.msg("^6Shuffling teams in {} second{}"
+                                         .format(execute_time, "s" if execute_time > 1 else ""))
+                        else:
+                            self.center_print("^7Shuffling teams in {} second{}"
+                                              .format(execute_time, "s" if execute_time > 1 else ""))
+                        count += 1
+                        time.sleep(1)
+                    if message_setting < 3:
+                        self.center_print("^7Shuffling teams")
+                    else:
+                        self.msg("^6Shuffling teams")
+                else:
+                    time.sleep(shuffle_time)
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue auto_shuffle_player_teams Teams")
+                self.shuffle_players()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue auto_shuffle_player_teams Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.next_frame
+    def shuffle_players(self):
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue Shuffling Teams")
+        minqlxtended.console_command("forceshuffle")
+
+    def get_max_players(self):
+        try:
+            max_players = self.get_cvar("teamsize", int)
+            if self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                max_players *= 2
+            if max_players == 0:
+                max_players = self.get_cvar("sv_maxClients", int)
+            return max_players
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get max players Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_queue_pos(self, player, pos):
+        try:
+            self.remove_from_spec(player)
+            if str(player.steam_id) not in self._join:
+                self.add_to_join(player)
+            self._queue.add_to_queue(player.steam_id, player, pos)
+            self.cmd_list_queue()
+            self.check_for_opening(0.5)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add to queue pos Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_queue(self, player):
+        try:
+            self.remove_from_spec(player)
+            if str(player.steam_id) not in self._join:
+                self.add_to_join(player)
+            self._queue.add_to_queue(player.steam_id, player)
+            position = self._queue.get_queue_position(player)
+            player.center_print("^7You are in the ^4Queue^7 position ^1{}^7\nType ^4{}q ^7to show the queue"
+                                .format(position + 1, self.get_cvar("qlx_commandPrefix")))
+            self.check_for_opening(0.2)
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add to queue: {}".format(player))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add to queue Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def remove_from_queue(self, player):
+        try:
+            if player and self._queue.in_queue(player=player):
+                self._queue.remove_from_queue(player.steam_id, player)
+        except Exception as e:
+            if ENABLE_LOG:
+                raise KeyError("remove from queue Exception: {}\n{}"
+                               .format(type(e).__name__, traceback.format_exc()))
+
+    def check_queue(self, delay=0.1):
+        try:
+            if not self.end_screen and not self.displaying_queue and self._queue\
+                    and self.get_cvar("qlx_queueQueueMsg", bool):
+                self.displaying_queue = True
+                self.queue_message(delay)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue check queue Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def queue_message(self, delay):
+        try:
+            n = self._queue.players()
+            time.sleep(delay)
+            queue_show = self.get_cvar("qlx_queueQueueMsg", int)
+            if queue_show == 2 and self._round % 5 != 0:
+                self.displaying_queue = False
+                return
+            count = 1
+            for p in n:
+                try:
+                    p.center_print("^7You are in ^4Queue ^7position ^1{}".format(count))
+                except Exception as e:
+                    if ENABLE_LOG:
+                        self.queue_log.info("specqueue Queue Message Exception: {}\n{}"
+                                            .format(type(e).__name__, traceback.format_exc()))
+                finally:
+                    count += 1
+            self.displaying_queue = False
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue queue message Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_spectators(self):
+        try:
+            for player in self.teams()["spectator"]:
+                self.add_to_spec(player)
+        except Exception as e:
+            raise KeyError("add spectators Exception: {}; {}"
+                           .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_spec(self, player):
+        try:
+            self._spec.add_to_times(player.steam_id)
+            if self.get_cvar("qlx_queueSpecMsg", bool):
+                player.center_print("^6Spectate Mode\n^7Type ^4!s ^7to show spectators.")
+        except Exception as e:
+            raise KeyError("add to spec Exception: {} ; {}"
+                           .format(type(e).__name__, traceback.format_exc()))
+
+    def remove_from_spec(self, player):
+        try:
+            if player:
+                self._spec.remove_from_times(player.steam_id)
+        except Exception as e:
+            raise KeyError("remove from spec Exception: {} ; {}"
+                           .format(type(e).__name__, traceback.format_exc()))
+
+    def check_spec(self, delay=0.0):
+        try:
+            if not self.end_screen and not self.displaying_spec and self._spec.count > 0\
+                    and self.get_cvar("qlx_queueSpecMsg", bool):
+                self.displaying_spec = True
+                self.spec_message(delay)
+        except Exception as e:
+            raise KeyError("check spec Exception: {} ; {}"
+                           .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def spec_message(self, delay=0.0):
+        try:
+            time.sleep(delay)
+            spec_show = self.get_cvar("qlx_queueSpecMsg", int)
+            spectators = self.teams()["spectator"]
+            if self._spec.count > 0 and len(spectators) > 0:
+                s = self._spec.times()
+                for p, t in s.items():
+                    spec = self.player(int(p))
+                    if spec in spectators:
+                        if spec_show == 2 and self._round % 5 != 0:
+                            continue
+                        time_in_spec = round((time.time() - t))
+                        if time_in_spec / 60 > 1:
+                            spec_time = "^7{}^4m^7:{}^4s^7".format(int(time_in_spec / 60), time_in_spec % 60)
+                        else:
+                            spec_time = "^7{}^4s^7".format(time_in_spec)
+                        max_spec_time = self.get_cvar("qlx_queueMaxSpecTime", int)
+                        admin = self.get_cvar("qlx_queueAdmin", int)
+                        admin_multiplier = self.get_cvar("qlx_queueAdminSpec", int)
+                        permission = self.db.get_permission(int(p))
+                        if 0 < max_spec_time < 9998 and permission < admin:
+                            spec.center_print("^6Spectate Mode for {}\n^7Join the game to ^1play ^7or enter the"
+                                              " ^4Queue.\nYou can remain in spectate for ^1{} ^7minutes."
+                                              .format(spec_time, max_spec_time))
+                        elif permission >= admin and admin_multiplier:
+                            spec.center_print("^6Spectate Mode for {}\n^7Join the game to ^1play ^7or enter the"
+                                              " ^4Queue.\nYou can remain in spectate for ^1{} ^7minutes."
+                                              .format(spec_time, max_spec_time * admin_multiplier))
+                        else:
+                            spec.center_print("^6Spectate Mode for {}\n^7Join the game to ^1play ^7or enter the ^4Queue"
+                                              .format(spec_time))
+            self.displaying_spec = False
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue spec message Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def check_queue_status(self):
+        if self._checking_opening and time.time() - self._checking_opening > 1:
+            self._checking_opening = None
+            self.check_for_opening(0.1)
+
+    @minqlxtended.thread
+    def check_for_opening(self, delay=0.0):
+        if self.end_screen:
+            return
+        if self._checking_opening or not self._queue:
+            self.check_queue_status()
+            return
+        self._checking_opening = time.time()
+        if delay > 0.0:
+            time.sleep(delay)
+        finished = False
+        try:
+            teams = self.teams()
+            state = self.game.state
+            max_players = self.get_max_players()
+            red_players = len(teams["red"])
+            blue_players = len(teams["blue"])
+            free_players = len(teams["free"])
+            if self.q_game_info[0] in NONTEAM_BASED_GAMETYPES:
+                if free_players < max_players and not self.free_locked:
+                    finished = self.place_in_team(max_players - free_players, "free")
+                elif state == "warmup" and free_players > max_players:
+                    fixed = self.fix_free(free_players, max_players, teams)
+                    if not fixed:
+                        if ENABLE_LOG:
+                            self.queue_log.info("specqueue check_for_opening Fix Free error.")
+
+            elif self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                team_size = int(max_players / 2)
+                if not self.red_locked and not self.blue_locked and (red_players + blue_players) < max_players:
+                    fix_teams = state == "warmup" and red_players > team_size or blue_players > team_size
+                    if fix_teams:
+                        fixed = self.fix_teams(red_players, blue_players, max_players, teams)
+                        if not fixed:
+                            if ENABLE_LOG:
+                                self.queue_log.info("specqueue check_for_opening Fix Teams error.")
+                    difference = red_players - blue_players
+                    if difference < 0:
+                        finished = self.place_in_team(abs(difference), "red")
+                    elif difference > 0:
+                        finished = self.place_in_team(difference, "blue")
+                    else:
+                        if self._queue.count > 1:
+                            if red_players < team_size and blue_players < team_size:
+                                finished = self.place_in_both()
+                        elif state == "warmup":
+                            if blue_players < team_size:
+                                finished = self.place_in_team(1, "blue")
+                            elif red_players < team_size:
+                                finished = self.place_in_team(1, "red")
+                elif state == "warmup" and (red_players + blue_players) >= max_players or\
+                        red_players > team_size or blue_players > team_size:
+                    self.fix_teams(red_players, blue_players, max_players, teams)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue check_for_opening Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        self._checking_opening = None
+        return finished
+
+    def place_in_team(self, amount, team):
+        try:
+            if not self.end_screen:
+                count = 0
+                teams = self.teams()
+                while count < amount and self._queue:
+                    p = self._queue.get_next()
+                    if p[1] in teams["spectator"]and p[1].connection_state == "active":
+                        self.team_placement(p[1], team)
+                        if team == "red":
+                            placement = "^1red ^7team"
+                        elif team == "blue":
+                            placement = "^4blue ^7team"
+                        else:
+                            placement = "^2battle"
+                        self.msg("{} ^7has joined the {}.".format(p[1], placement))
+                        count += 1
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue Place in Team Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+            for player in self.teams()["spectator"]:
+                player.tell("^1Error in player placement in team. ^6Check your position in the queue.")
+        return True
+
+    def place_in_both(self):
+        try:
+            if not self.end_screen and self._queue.count > 1:
+                teams = self.teams()
+                spectators = teams["spectator"]
+                players = self._queue.get_two()
+                p1 = None
+                p2 = None
+                if players[1].connection_state != "active" or players[1] not in spectators:
+                    p1 = self._queue.get_next()
+                if players[3].connection_state != "active" or players[3] not in spectators:
+                    p2 = self._queue.get_next()
+                if p1 and p2:
+                    players = [p1[0], p1[1], p2[0], p2[1], p1[2], p2[2]]
+                elif p1:
+                    players = [p1[0], p1[1], players[2], players[3], p1[2], players[5]]
+                elif p2:
+                    players = [players[0], players[1], p2[0], p2[1], players[4], p2[2]]
+                # Get red team's and blue team's score so the correct player placements can be executed
+                # Game.red_score / Game.blue_score do not exist on this runtime;
+                # scores come off team_scores, indexed by Team.index (_game.py:190).
+                # Guarded because team_scores reads the live level and raises
+                # NonexistentGameError once the game is gone (_game.py:55) — a bare
+                # Exception subclass, so catching ValueError alone would miss it.
+                try:
+                    scores = self.game.team_scores
+                    red_score = int(scores[minqlxtended.Team.RED.index])
+                    blue_score = int(scores[minqlxtended.Team.BLUE.index])
+                except (ValueError, TypeError, IndexError, AttributeError,
+                        minqlxtended.NonexistentGameError):
+                    red_score = blue_score = 0
+                score_diff = abs(red_score - blue_score) >= self.get_cvar("qlx_queueTeamScoresDiff", int)
+                if self.q_game_info[0] in RANKING_GAMETYPES and self.get_cvar("qlx_queueUseSkillPlacement", bool):
+                    red_rating, blue_rating, p1_rating, p2_rating = self.get_ratings(players[0], players[2], teams)
+                    self.msg('^2Placing players by ^3{} ^2Balance Used ^7Red: ^1{} ^7Blue: ^4{} '
+                             .format('BDM' if self.get_cvar("qlx_queueUseRating", bool) else 'ELO',
+                                     red_rating, blue_rating))
+                    # set team related variables initial values
+                    # If the team's score difference is over "qlx_queuesTeamScoresAmount" and
+                    #  "qlx_queuesPlaceByTeamScore" is enabled players will be placed with the higher BDM/ELO
+                    #  player going to the lower scoring team regardless of average team BDMs/ELOs
+                    place_by_team_scores = False
+                    if self.get_cvar("qlx_queuePlaceByTeamScores", bool) and score_diff:
+                        place_by_team_scores = True
+                        if p1_rating > p2_rating:
+                            placement = ["blue", "red"] if red_score > blue_score else ["red", "blue"]
+                        else:
+                            placement = ["red", "blue"] if red_score > blue_score else ["blue", "red"]
+                    # Executes if the 'place by team score' doesn't execute and sets player
+                    #   with higher BDM/ELO on the team with the lower average BDM/ELO.
+                    else:
+                        if red_rating > blue_rating:
+                            placement = ["blue", "red"] if p1_rating > p2_rating else ["red", "blue"]
+                        elif blue_rating > red_rating:
+                            placement = ["red", "blue"] if p1_rating > p2_rating else ["blue", "red"]
+                        else:
+                            if red_score > blue_score:
+                                placement = ["blue", "red"] if p1_rating > p2_rating else ["red", "blue"]
+                            else:
+                                placement = ["red", "blue"] if p1_rating > p2_rating else ["blue", "red"]
+                    if place_by_team_scores:
+                        self.msg("^3Due to team score difference, placing players based on team score, not {} balance."
+                                 .format('BDM' if self.get_cvar("qlx_queueUseRating", bool) else 'ELO'))
+                    self.team_placement(players[1], placement[0])
+                    self.msg("{0} ^7:{1}{3} ^7has joined the {1}{2} ^7team."
+                             .format(players[1], "^1" if placement[0] == "red" else "^4", placement[0], p1_rating))
+                    self.team_placement(players[3], placement[1])
+                    self.msg("{0} ^7:{1}{3} ^7has joined the {1}{2} ^7team."
+                             .format(players[3], "^1" if placement[1] == "red" else "^4", placement[1], p2_rating))
+                else:
+                    self.team_placement(players[1], "blue")
+                    self.msg("{} ^7has joined the ^4blue ^7team.".format(players[1]))
+                    self.team_placement(players[3], "red")
+                    self.msg("{} ^7has joined the ^1red ^7team.".format(players[3]))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue Place in Both Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+            for player in self.teams()["spectator"]:
+                player.tell("^1Error in player(s) placement in team. ^6Check your position in the queue.")
+        return True
+
+    def fix_teams(self, red, blue, max_players, player_teams):
+        try:
+            teams = player_teams.copy()
+            total = red + blue
+            team_size = int(max_players / 2)
+            while total > max_players:
+                if red > team_size:
+                    self.get_player_for_spec(teams["red"])
+                    self.team_placement(self._players[0], "spectator", True)
+                    red -= 1
+                    total -= 1
+                if blue > team_size:
+                    self.get_player_for_spec(teams["blue"])
+                    self.team_placement(self._players[0], "spectator", True)
+                    blue -= 1
+                    total -= 1
+            difference = red - blue
+            while difference > 0:
+                self.team_placement(teams["red"][0], "blue")
+                teams["blue"].append(teams["red"].pop(0))
+                difference -= 1
+            while difference < 0:
+                self.team_placement(teams["blue"][0], "red")
+                teams["red"].append(teams["blue"].pop(0))
+                difference += 1
+            return True
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue fix_teams Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def fix_free(self, free, max_players, player_teams):
+        try:
+            teams = player_teams.copy()
+            while free > max_players:
+                self.get_player_for_spec(teams["free"])
+                self.team_placement(self._players[0], "spectator", True)
+                teams["free"].remove(self._players[0])
+                free -= 1
+            return True
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue fix_free Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_ratings(self, p1, p2, teams):
+        bdm = self.get_cvar("qlx_queueUseRating", bool)
+        red_rating = self.team_average(teams["red"], bdm)
+        blue_rating = self.team_average(teams["blue"], bdm)
+        p1_rating = self.get_rating(p1, bdm)
+        p2_rating = self.get_rating(p2, bdm)
+        return red_rating, blue_rating, p1_rating, p2_rating
+
+    def team_average(self, team, bdm=True):
+        try:
+            """Calculates the average rating of a team."""
+            avg = 0
+            if team:
+                for p in team:
+                    r = self.get_rating(p.steam_id, bdm)
+                    avg += r
+                avg /= len(team)
+            return int(round(avg))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue team average Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_rating(self, sid, bdm=True):
+        if bdm:
+            return self.get_bdm_rating(sid)
+        else:
+            return self.get_elo_rating(sid)
+
+    def get_gametype(self):
+        if self.get_cvar("g_factory").lower() == "ictf":
+            game_type = "ictf"
+        else:
+            game_type = self.q_game_info[0]
+        return game_type
+
+    def get_bdm_rating(self, sid):
+        try:
+            game_type = self.get_gametype()
+            if self.db.exists(BDM_KEY.format(sid, game_type, "rating")):
+                try:
+                    rating = self.db.get(BDM_KEY.format(sid, game_type, "rating"))
+                    rating = int(float(rating))
+                except (ValueError, TypeError):
+                    rating = 0
+            else:
+                rating = 0
+            if rating == 0:
+                rating = self.get_cvar("qlx_bdmDefaultBDM", int)
+                if not rating or not isinstance(rating, int):
+                    rating = 1022
+            return rating
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get BDM rating Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_elo_rating(self, sid):
+        try:
+            game_type = self.get_gametype()
+            rating = 0
+            sid = str(sid)
+            with self.elo_lock:
+                if sid in self.elo_ratings and game_type in self.elo_ratings[sid]:
+                    rating = self.elo_ratings[sid][game_type]
+            if rating == 0 and self.db.exists(ELO_KEY.format(sid, self.get_gametype())):
+                try:
+                    rating = int(float(self.db.get(ELO_KEY.format(sid, game_type))))
+                    if rating == DEFAULT_ELO:
+                        self.request_elo_rating(sid)
+                except (ValueError, TypeError):
+                    rating = 0
+            if rating == 0:
+                rating = DEFAULT_ELO
+                self.request_elo_rating(sid)
+            return rating
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get ELO rating Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def request_elo_rating(self, sid):
+        with self.elo_lock:
+            if self.retrieving_elo or not sid:
+                return
+            self.retrieving_elo = True
+        if ENABLE_LOG:
+            self.queue_log.info("Requesting ELO rating information from {} for: {}".format(ELO_URL, sid))
+        try:
+            if isinstance(sid, list):
+                sid = '+'.join(str(x) for x in sid)
+            response = False
+            url = "http://{}/elo/{}".format(ELO_URL, sid)
+            attempts = 0
+            while attempts < 3:
+                attempts += 1
+                info = requests.get(url, timeout=ELO_REQUEST_TIMEOUT)
+                if info.status_code != requests.codes.ok:
+                    continue
+                info_js = info.json()
+                if "players" in info_js:
+                    response = True
+                    break
+                else:
+                    time.sleep(0.1)
+            if response:
+                now = int(time.time())
+                save_db = self.get_cvar("qlx_queueSaveEloToDatabase", bool)
+                with self.elo_lock:
+                    for record in info_js["players"]:
+                        p_sid = record['steamid']
+                        if p_sid not in self.elo_ratings:
+                            self.elo_ratings[p_sid] = {}
+                        self.elo_ratings[p_sid]['time'] = now
+                        for gt in SUPPORTED_GAMETYPES:
+                            if gt in record:
+                                elo = record[gt]["elo"]
+                                if save_db:
+                                    self.db.set(ELO_KEY.format(p_sid, gt), elo)
+                                self.elo_ratings[p_sid][gt] = elo
+                            else:
+                                try:
+                                    del self.elo_ratings[p_sid][gt]
+                                except KeyError:
+                                    pass
+                    if ENABLE_LOG:
+                        self.queue_log.info("ELO ratings: {}".format(self.elo_ratings))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue request_elo_rating Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        finally:
+            self.retrieving_elo = False
+
+    @minqlxtended.next_frame
+    def team_placement(self, player, team, add_queue=False):
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue team placement: {} put on team {}".format(player, team))
+        try:
+            player.put(team)
+            if add_queue:
+                self.add_to_queue_pos(player, 0)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue team placement Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def add_join_times(self):
+        try:
+            teams = self.teams()
+            for player in teams["red"] + teams["blue"] + teams["free"]:
+                self._join.add_to_times(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add join times Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def record_player_models(self):
+        try:
+            for player in self.players():
+                try:
+                    model = player.model
+                except KeyError:
+                    model = "sarge"
+                except Exception as e:
+                    model = "sarge"
+                    if ENABLE_LOG:
+                        self.queue_log.info("specqueue get_player_model Exception: {}\n{}"
+                                            .format(type(e).__name__, traceback.format_exc()))
+                self._player_models[player.id] = model
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue record_player_models Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_join(self, player):
+        try:
+            self._join.add_to_times(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add to join Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def remove_from_join(self, player):
+        try:
+            self._join.remove_from_times(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue remove from join Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_join_time(self, player):
+        try:
+            if str(player.steam_id) not in self._join:
+                self.add_to_join(player)
+                return time.time()
+            return self._join.get_time(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get join time Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_join_times(self):
+        try:
+            return self._join.times()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get join times Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def look_at_teams(self, delay=None):
+        try:
+            if self.game and self.game.state in ["in_progress", "countdown"] and\
+                    self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                if delay:
+                    time.sleep(delay)
+                teams = self.teams()
+                difference = len(teams["red"]) - len(teams["blue"])
+                abs_diff = abs(difference)
+                if abs_diff == 1 and not self.get_cvar("qlx_queueEnforceEvenTeams", bool):
+                    return
+                if abs_diff > 0 and self._latch_ignore or self._ignore:
+                    if not self._ignore_msg_already_said:
+                        self.msg("^6Uneven teams action^7: no action will be taken due to admin setting!")
+                        self._ignore_msg_already_said = True
+                    return
+                p_count = len(teams["red"]) + len(teams["blue"])
+                players = []
+                move_players = []
+                where = None
+                spec_player = None
+
+                if abs_diff > 0 and self._specPlayer[7] <= p_count <= self._specPlayer[8]:
+                    if difference == -1:
+                        self.get_player_for_spec(teams["blue"].copy())
+                        spec_player = self._players[0]
+                    elif difference == 1:
+                        self.get_player_for_spec(teams["red"].copy())
+                        spec_player = self._players[0]
+                    else:
+                        move = int(abs_diff / 2)
+                        if (difference % 2) == 0:
+                            spec = 0
+                        else:
+                            spec = 1
+                        if difference < 0:
+                            self.get_uneven_players(teams["blue"].copy(), move + spec)
+                            where = "red"
+                        else:
+                            self.get_uneven_players(teams["red"].copy(), move + spec)
+                            where = "blue"
+                        if (difference % 2) != 0:
+                            spec_player = self._players[0]
+                            self._players.pop(0)
+                        for p in self._players:
+                            players.append(p.name)
+                            move_players.append(p)
+                    if not delay:
+                        if len(move_players) > 0:
+                            self.msg("^3Uneven Teams Detected^7: {} ^7will be moved to {}^7."
+                                     .format("^7, ".join(players), where))
+                        if spec_player:
+                            self.msg("^3Uneven Teams Detected^7: {} ^7will be moved to ^3spectate^7."
+                                     .format(spec_player))
+                if delay:
+                    if len(players) > 0:
+                        self.msg("^3Uneven Teams Detected^7: {} ^7will be moved to {}^7."
+                                 .format("^7, ".join(players), where))
+                        self.even_the_teams(False)
+                    elif spec_player:
+                        self.msg("^3Uneven Teams Detected^7: {} ^7will be moved to ^3spectate ^7if not fixed."
+                                 .format(spec_player))
+                        self.msg("^2Looking at teams again in {} seconds to assess even status."
+                                 .format(self._specPlayer[9]))
+                        time.sleep(self._specPlayer[9])
+                        self.even_the_teams(False)
+                else:
+                    self.even_the_teams(True)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue look at teams Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def even_the_teams(self, delay=False):
+        if not self.get_cvar("qlx_queueEnforceEvenTeams", bool):
+            return
+        try:
+            if self.game and self.game.state in ["in_progress", "countdown"] and\
+                    self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                if delay:
+                    if self.game.type_short == "ft":
+                        countdown = self._specPlayer[5]
+                    else:
+                        countdown = self._specPlayer[6]
+                    time.sleep(max(countdown / 1000 - 0.3, 0))
+
+                teams = self.teams()
+                difference = len(teams["red"]) - len(teams["blue"])
+                if abs(difference) > 0 and self._latch_ignore or self._ignore:
+                    if not self._ignore_msg_already_said:
+                        self.msg("^6Uneven teams action^7: no action will be taken due to admin setting!")
+                        self._ignore_msg_already_said = True
+                    return
+                p_count = len(teams["red"] + teams["blue"])
+                players = []
+                move_players = []
+                where = None
+                spec_player = None
+
+                if abs(difference) > 0 and self._specPlayer[3] <= p_count <= self._specPlayer[4]:
+                    if difference == -1:
+                        self.get_player_for_spec(teams["blue"])
+                        spec_player = self._players[0]
+                        if ENABLE_LOG:
+                            self.queue_log.info("Spectating: {}, Settings: {} {} {}"
+                                                .format(spec_player, self.get_cvar("qlx_queueSpecByTime"),
+                                                        self.get_cvar("qlx_queueSpecByScore"),
+                                                        self.get_cvar("qlx_queueSpecByPrimary")))
+                    elif difference == 1:
+                        self.get_player_for_spec(teams["red"])
+                        spec_player = self._players[0]
+                        if ENABLE_LOG:
+                            self.queue_log.info("Spectating: {}, Settings: {} {} {}"
+                                                .format(spec_player, self.get_cvar("qlx_queueSpecByTime"),
+                                                        self.get_cvar("qlx_queueSpecByScore"),
+                                                        self.get_cvar("qlx_queueSpecByPrimary")))
+                    else:
+                        move = int(abs(difference) / 2)
+                        if (difference % 2) == 0:
+                            spec = 0
+                        else:
+                            spec = 1
+                        if difference < 0:
+                            self.get_uneven_players(teams["blue"].copy(), move + spec)
+                            where = "red"
+                        else:
+                            self.get_uneven_players(teams["red"].copy(), move + spec)
+                            where = "blue"
+                        if (difference % 2) != 0:
+                            spec_player = self._players[0]
+                            self._players.pop(0)
+                        for p in self._players:
+                            players.append(p.name)
+                            move_players.append(p)
+                    if len(move_players) > 0:
+                        for player in move_players:
+                            self.team_placement(player, where)
+                        self.msg("^3Uneven Teams Detected^7: {} ^7was moved to {}^7."
+                                 .format("^7, ".join(players), where))
+                    if spec_player:
+                        self.uneven_teams_move_to_spec[spec_player.steam_id] = True
+                        self.team_placement(spec_player, "spectator", True)
+                        self.msg("^3Uneven Teams Detected^7: {} ^7was moved to ^3spectate^7.".format(spec_player))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue even the teams Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_cvars(self):
+        self._specPlayer = [self.get_cvar("qlx_queueSpecByTime", bool), self.get_cvar("qlx_queueSpecByScore", bool),
+                            True if self.get_cvar("qlx_queueSpecByPrimary").lower() == "score" else False,
+                            self.get_cvar("qlx_queueMinPlayers", int), self.get_cvar("qlx_queueMaxPlayers", int),
+                            self.get_cvar("g_freezeRoundDelay", int), self.get_cvar("g_roundWarmupDelay", int),
+                            self.get_cvar("qlx_queueMinPlayers", int), self.get_cvar("qlx_queueMaxPlayers", int),
+                            self.get_cvar("qlx_queueCheckTeamsDelay", int)]
+
+    # Finds the player, that meets the set criteria, to move to spectate and returns that player
+    # Does not start its own thread
+    def get_player_for_spec(self, team):
+        try:
+            t_players = []
+            s_players = []
+            lowest_time = 0
+            lowest_score = 999
+            for player in team.copy():
+                try:
+                    player.update()
+                except minqlxtended.NonexistentPlayerError:
+                    continue
+                p_time = self.get_join_time(player)
+                if p_time > lowest_time:
+                    lowest_time = p_time
+                    t_players = [player]
+                elif p_time == lowest_time:
+                    t_players.append(player)
+                p_score = player.stats.score
+                if p_score < lowest_score:
+                    lowest_score = p_score
+                    s_players = [player]
+                elif p_score == lowest_score:
+                    s_players.append(player)
+            if self.game.state == "in_progress":
+                if self._specPlayer[0] and self._specPlayer[1]:
+                    if self._specPlayer[2]:
+                        if len(s_players) > 1:
+                            lowest_time = 0
+                            temp_player = s_players[0]
+                            for player in s_players:
+                                if self.get_join_time(player) > lowest_time:
+                                    temp_player = player
+                            self._players = [temp_player]
+                        else:
+                            self._players = [s_players[0]]
+                    else:
+                        if len(t_players) > 1:
+                            lowest_score = 999
+                            temp_player = t_players[0]
+                            for player in t_players:
+                                if player.stats.score < lowest_score:
+                                    temp_player = player
+                            self._players = [temp_player]
+                        else:
+                            self._players = [t_players[0]]
+                elif self._specPlayer[1]:
+                    self._players = [s_players[randrange(len(s_players))]]
+                else:
+                    self._players = [t_players[randrange(len(t_players))]]
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get player for spec Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    # Function meant to return the player that would be sent to spectate because
+    #  the get_player_for_spec function does not return anything
+    # Does not start its own thread
+    def return_spec_player(self, team):
+        try:
+            self.get_player_for_spec(team)
+            return [self._players[0]]
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue return spec player Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_spec(self, player, msg, channel):
+        @minqlxtended.thread
+        def get_player():
+            teams = self.teams().copy()
+            if self.game.state == "in_progress":
+                difference = len(teams["red"]) - len(teams["blue"])
+                if difference:
+                    team = teams["red"] if difference > 0 else teams["blue"]
+                else:
+                    team = teams["red"] + teams["blue"]
+                spec_player = self.return_spec_player(team)[0]
+            else:
+                spec_player = self.return_spec_player(teams["red"] + teams["blue"])[0]
+            if ENABLE_LOG:
+                self.queue_log.info("Player to Spectate: ^7{}".format(spec_player))
+
+        get_player()
+
+    @minqlxtended.thread
+    def get_uneven_players(self, team, amount):
+        try:
+            t_players = {}
+            s_players = {}
+            self._players = []
+            for player in team:
+                t_players[str(self.get_join_time(player))] = player
+                s_players[str(player.stats.score)] = player
+
+            if self._specPlayer[0] and self._specPlayer[1]:
+                if self._specPlayer[2]:
+                    sorted_players = sorted(((k, v) for k, v in s_players.items()), reverse=False)
+                else:
+                    sorted_players = sorted(((k, v) for k, v in t_players.items()), reverse=True)
+            elif self._specPlayer[1]:
+                sorted_players = sorted(((k, v) for k, v in s_players.items()), reverse=False)
+            else:
+                sorted_players = sorted(((k, v) for k, v in t_players.items()), reverse=True)
+            count = 0
+            for s, player in sorted_players:
+                self._players.append(player)
+                count += 1
+                if count == amount:
+                    break
+            return
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get uneven players Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def check_spec_time(self):
+        time.sleep(5)
+        try:
+            max_spec_time = self.get_cvar("qlx_queueMaxSpecTime", int)
+            if 0 < max_spec_time < 9998:
+                admin = self.get_cvar("qlx_queueAdmin", int)
+                admin_multiplier = self.get_cvar("qlx_queueAdminSpec", int)
+                spectators = self.teams()["spectator"]
+                if self._spec.count > 0 and len(spectators) > 0:
+                    s = self._spec.times()
+                    for p, t in s.items():
+                        spec = self.player(int(p))
+                        permission = self.db.get_permission(int(p))
+                        if spec in spectators:
+                            time_in_spec = round((time.time() - t)) / 60
+                            if permission >= admin:
+                                if admin_multiplier:
+                                    if time_in_spec >= max_spec_time * admin_multiplier:
+                                        @minqlxtended.next_frame
+                                        def do_kick(s=spec):
+                                            s.kick("was in spectate, not the queue, for too long.")
+                                        do_kick()
+                            elif time_in_spec >= max_spec_time:
+                                @minqlxtended.next_frame
+                                def do_kick(s=spec):
+                                    s.kick("was in spectate, not the queue, for too long.")
+                                do_kick()
+                        else:
+                            self.remove_from_spec(spec)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue check spec time Exception:{} {}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def _start_afk_position_poll(self):
+        while not self._afk_poll_stop.wait(1):
+            self._check_afk_positions()
+
+    def _check_afk_positions(self):
+        try:
+            afk_time = self.get_cvar("qlx_queueAfkMoveTime", int)
+            if afk_time <= 0:
+                return
+            if self._queue.count < 1:
+                return
+            exempt_level = self.get_cvar("qlx_queueAfkExemptLevel", int)
+            now = time.time()
+            free_players = self.teams().get("free", [])
+        except Exception:
+            return
+        for player in free_players:
+            sid = str(player.steam_id)
+            try:
+                if self.db.get_permission(player.steam_id) >= exempt_level:
+                    with self._afk_pos_lock:
+                        self._afk_last_pos.pop(sid, None)
+                        self._afk_last_moved.pop(sid, None)
+                    continue
+                pos = player.position()
+                curr = (pos.x, pos.y, pos.z)
+            except Exception:
+                continue
+            with self._afk_pos_lock:
+                last = self._afk_last_pos.get(sid)
+                if last is None or curr != last:
+                    self._afk_last_pos[sid] = curr
+                    self._afk_last_moved[sid] = now
+                elif now - self._afk_last_moved.get(sid, 0) >= afk_time:
+                    self._afk_last_pos.pop(sid, None)
+                    self._afk_last_moved.pop(sid, None)
+                    name = getattr(player, "clean_name", None) or player.name
+
+                    @minqlxtended.next_frame
+                    def move(p=player, n=name):
+                        try:
+                            p.put("spectator")
+                            self.msg("^1{} was moved to spectator for being AFK.".format(n))
+                        except Exception:
+                            pass
+                    move()
+
+    # Search for a player name match using the supplied string
+    def find_player(self, name):
+        try:
+            found_player = None
+            found_count = 0
+            if name.isdigit():
+                _id = int(name)
+                for player in self.players():
+                    if player.id == _id or player.steam_id == _id:
+                        found_player = player
+                        return found_player, int(str([found_player]).split(":")[0].split("(")[1])
+                return -1, -1
+            else:
+                # Remove color codes from the supplied string
+                player_name = re.sub(r"\^[0-9]", "", name).lower()
+                # search through the list of connected players for a name match
+                for player in self.players():
+                    if player_name in re.sub(r"\^[0-9]", "", player.name).lower():
+                        # if match is found return player, player id
+                        found_player = player
+                        found_count += 1
+                # if only one match was found return player, player id
+                if found_count == 1:
+                    return found_player, int(str([found_player]).split(":")[0].split("(")[1])
+                # if more than one match is found return 0, -1
+                elif found_count > 1:
+                    return 0, -1
+                # if no match is found return -1, -1
+                else:
+                    return -1, -1
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue find_player Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def player_in_queue(self, player):
+        if player in self._queue:
+            return self._queue.get_queue_position(player)
+        else:
+            return None
+
+    # ==============================================
+    #               Minqlx Bot Commands
+    # ==============================================
+    def get_current_settings(self, player, msg, channel):
+        try:
+            message = ["^6SpecQueue current variable states:"]
+            if self._queue:
+                message.append("^3Queue: {} Size: {}".format(str(self._queue.players()), self._queue.count))
+            else:
+                message.append("^3Queue is empty")
+            if self._spec.count > 0:
+                message.append("^3Specs: {} Size: {}".format(str(self._spec.times()), self._spec.count))
+            else:
+                message.append("^3Specs is empty")
+            if self._join.count > 0:
+                message.append("^3Join Times: {} Size: {}".format(str(self._join.times()), self._join.count))
+            else:
+                message.append("^3Join Times is empty")
+            if len(self._player_models) > 0:
+                message.append("^3Player Models^7: {}".format(str(self._player_models)))
+            else:
+                message.append("^3Player Models is empty")
+            message.append("^1Red Locked^7: {}^7, ^4Blue Locked^7: {}^7, ^2Free Locked^7: {}"
+                           .format("^5True" if self.red_locked else "^6False",
+                                   "^5True" if self.blue_locked else "^6False",
+                                   "^5True" if self.free_locked else "^6False"))
+            message.append("^3End Screen status^7: {}".format("^5True" if self.end_screen else "^6False"))
+            message.append("^3Displaying status^7- ^2Queue {}^7, ^4Spec {}"
+                           .format("^5True" if self.displaying_queue else "^6False",
+                                   "^5True" if self.displaying_spec else "^6False"))
+            message.append("^3In Countdown^7: {}".format("^5True" if self.in_countdown else "^6False"))
+            message.append("^3Game Info^7: {}".format(self.q_game_info))
+            message.append("^3Ignore Status^7: {} ^3Latch^7: {}"
+                           .format("^5True" if self._ignore else "^6False",
+                                   "^5True" if self._latch_ignore else "^6False"))
+            if self.get_cvar("qlx_queueUseSkillPlacement", bool):
+                message.append("^3Players are being placed using {} rankings."
+                               .format("BDM" if self.get_cvar("qlx_queueUseRating", bool) else "ELO"))
+            else:
+                message.append("^3Players are not being placed using rankings.")
+            if channel != "console":
+                player.tell("\n".join(message))
+            minqlxtended.console_print(message[0])
+            minqlxtended.console_print(message[1])
+            minqlxtended.console_print(message[2])
+            minqlxtended.console_print(message[3])
+            minqlxtended.console_print(message[4])
+            minqlxtended.console_print(" ".join(message[5:8]))
+            minqlxtended.console_print(" ".join(message[8:11]))
+            minqlxtended.console_print(message[11])
+            return minqlxtended.Return.STOP_ALL
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get_current_settings Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def reset_queue(self, player, msg, channel):
+        try:
+            minqlxtended.console_command("unlock red")
+            minqlxtended.console_command("unlock blue")
+            minqlxtended.console_command("unlock free")
+            if self.red_locked:
+                self.red_locked = False
+            if self.blue_locked:
+                self.blue_locked = False
+            if self.free_locked:
+                self.free_locked = False
+            if self.end_screen:
+                self.end_screen = False
+            if self.in_countdown:
+                self.in_countdown = False
+            if self.displaying_queue:
+                self.displaying_queue = False
+            if self.displaying_spec:
+                self.displaying_spec = False
+            if self._ignore:
+                self._ignore = False
+            if self._latch_ignore:
+                self._latch_ignore = False
+            self.check_for_opening(0.2)
+            specs = self.teams()["spectator"]
+            if len(specs):
+                for player in specs:
+                    player.tell("^1The queue statuses have been reset. Check your position in the queue.")
+            return minqlxtended.Return.STOP_ALL
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue reset_queue Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def reset_players_model(self, msg=None):
+        try:
+            sleep = msg if msg else 0.2
+            time.sleep(sleep)
+            players = self.players().copy()
+            for pid, model in self._player_models.items():
+                try:
+                    player = self.player(pid)
+                except minqlxtended.NonexistentPlayerError:
+                    continue
+                count = len(players)
+                while count > 0:
+                    count -= 1
+                    if players[count].id == pid:
+                        del players[count]
+                        break
+                player.model = model
+            for pl in players:
+                if pl.model:
+                    pl.model = pl.model
+                else:
+                    pl.model = "sarge"
+            return True
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue reset_players_model Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def reset_model(self, player=None, msg=None, channel=None):
+        try:
+            if len(msg) > 1:
+                if msg[1] == "all":
+                    self.reset_players_model()
+                    player.tell("^3Player models have been reset")
+                    return minqlxtended.Return.STOP_ALL
+                else:
+                    try:
+                        pid = int(msg[1])
+                        p = self.player(pid)
+                    except minqlxtended.NonexistentPlayerError:
+                        player.tell("Invalid client ID.")
+                        return
+                    except ValueError:
+                        p, pid = self.find_player(" ".join(msg[1:]))
+                        if pid == -1:
+                            if p == 0:
+                                player.tell("^1Too Many players matched your player name")
+                            else:
+                                player.tell("^1No player matching that name found")
+                            return minqlxtended.Return.STOP_ALL
+                    player = p
+            if player.id in self._player_models:
+                player.model = self._player_models[player.id]
+            elif player.model:
+                player.model = player.model
+            else:
+                player.model = "sarge"
+            return
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue reset_model Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def ignore_imbalance(self, player, msg, channel):
+        try:
+            self.msg("^3The move to ^1spectate ^3action will be ignored this round")
+            self._ignore = True
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue ignore imbalance Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def ignore_imbalance_latch(self, player, msg, channel):
+        try:
+            if len(msg) < 2:
+                player.tell("^3Command must include 'ignore', 'spec', or 'setting'")
+                return minqlxtended.Return.STOP_ALL
+            else:
+                setting = msg[1].lower()
+                if setting == "ignore":
+                    self.msg("^3The move to spectate actions will be ^1ignored ^3until ^4re-enabled")
+                    self._latch_ignore = True
+                elif setting == "spec" or setting == "spectate":
+                    self.msg("^3The move to spectate actions have been ^4re-enabled")
+                    self._latch_ignore = False
+                elif setting == "setting" or setting == "set":
+                    self.msg("^3The move to ^1spectate ^3actions are set to {}"
+                             .format("ignore" if self._latch_ignore else "spectate"))
+                else:
+                    player.tell("^3Command must include 'ignore', 'spec', or 'setting'")
+                    return minqlxtended.Return.STOP_ALL
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue ignore imbalance latch Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_queue_add(self, player, msg, channel):
+        try:
+            if len(msg) < 2:
+                self.add_to_queue(player)
+            elif self.db.has_permission(player.steam_id, self.get_cvar("qlx_queueAdmin", int)):
+                try:
+                    i = int(msg[1])
+                    target_player = self.player(i)
+                    if not (0 <= i < 64) or not target_player:
+                        raise ValueError
+                except ValueError:
+                    player.tell("Invalid ID.")
+                    return
+                except minqlxtended.NonexistentPlayerError:
+                    player.tell("Invalid client ID.")
+                    return
+                except Exception as e:
+                    if ENABLE_LOG:
+                        self.queue_log.info("specqueue Cmd Que Add Exception: {}\n{}"
+                                            .format(type(e).__name__, traceback.format_exc()))
+                    return
+                if len(msg) > 2:
+                    try:
+                        pos = int(msg[2])
+                        self.add_to_queue_pos(target_player, pos)
+                    except ValueError:
+                        self.add_to_queue(target_player)
+                else:
+                    self.add_to_queue(target_player)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue cmd queue add Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        self.update_queue_tags()
+        self.check_for_opening(0.2)
+
+    def cmd_qversion(self, player, msg, channel):
+        channel.reply("^7This server has installed ^2{0} version {1} by BarelyMiSSeD\n"
+                      "https://github.com/BarelyMiSSeD/minqlx-plugins/{0}.py"
+                      .format(self.__class__.__name__, VERSION))
+
+    def cmd_list_queue(self, player=None, msg=None, channel=None):
+        self.exec_list_queue(player, msg, channel)
+
+    @minqlxtended.thread
+    def exec_list_queue(self, player=None, msg=None, channel=None):
+        try:
+            spectators = self.teams()["spectator"]
+            count = 0
+            message = []
+            if self._queue and len(spectators) > 0:
+                for n in range(0, self._queue.count):
+                    sid = self._queue[n]
+                    p = self.player(sid)
+                    if p in spectators:
+                        t = self._queue[str(sid)]
+                        time_in_queue = round((time.time() - t))
+                        if time_in_queue / 60 > 1:
+                            queue_time = "^7{}^4m^7:{}^4s^7".format(int(time_in_queue / 60), time_in_queue % 60)
+                        else:
+                            queue_time = "^7{}^4s^7".format(time_in_queue)
+                        message.append("{} ^7[{}] ^7{}".format(p, count + 1, queue_time))
+                        count += 1
+                    else:
+                        self.remove_from_queue(p)
+            else:
+                self._queue.empty_queue()
+            if count == 0:
+                message = ["^4No one is in the queue."]
+            if channel:
+                channel.reply("^2Queue^7: " + ", ".join(message))
+            elif player or count:
+                self.msg("^2Queue^7: " + ", ".join(message))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue cmd list queue Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_list_specs(self, player=None, msg=None, channel=None):
+        self.exec_list_specs(player, msg, channel)
+
+    @minqlxtended.thread
+    def exec_list_specs(self, player=None, msg=None, channel=None):
+        try:
+            spectators = self.teams()["spectator"]
+            count = 0
+            message = []
+            if self._spec and len(spectators) > 0:
+                s = self._spec.times()
+                for p, t in s.items():
+                    spec = self.player(int(p))
+                    if spec in spectators:
+                        time_in_spec = round((time.time() - t))
+                        if time_in_spec / 60 > 1:
+                            spec_time = "^7{}^4m^7:{}^4s^7".format(int(time_in_spec / 60), time_in_spec % 60)
+                        else:
+                            spec_time = "^7{}^4s^7".format(time_in_spec)
+                        message.append("{} ^7{}".format(spec, spec_time))
+                        count += 1
+                    else:
+                        self.remove_from_spec(spec)
+            if count == 0:
+                message = ["^4No one is set to spectate only."]
+            if channel:
+                channel.reply("^4Spectators^7: " + ", ".join(message))
+            elif player or count:
+                self.msg("^4Spectators^7: " + ", ".join(message))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue exec list specs Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def specqueue_version(self):
+        return VERSION
+
+    def cmd_go_afk(self, player=None, msg=None, channel=None):
+        if len(msg) > 1:
+            if self.db.get_permission(player.steam_id) >= self.get_cvar("qlx_queueAdmin", int):
+                match = self.find_player(msg[1])
+                if match and match[0] not in (-1, 0):
+                    self.exec_go_afk(match[0], msg[0][1:])
+                else:
+                    player.tell("^1Could not find unique player matching: {}".format(msg[1]))
+        else:
+            self.exec_go_afk(player, msg[0][1:])
+
+    @minqlxtended.thread
+    def exec_go_afk(self, player, afk_tag):
+        try:
+            if player.team != "spectator":
+                self.team_placement(player, "spectator")
+                if not self.end_screen:
+                    self.check_for_opening(0.2)
+                    if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES and \
+                            not (self.red_locked or self.blue_locked or self.free_locked):
+                        self.look_at_teams(1.0)
+            self.remove_from_queue(player)
+            self.add_to_spec(player)
+            self.remove_from_join(player)
+            self.add_to_afk(player, afk_tag)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue exec_go_afk Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_here(self, player=None, msg=None, channel=None):
+        self.exec_here(player)
+
+    @minqlxtended.thread
+    def exec_here(self, player):
+        try:
+            if player.team == "spectator":
+                if not self.end_screen:
+                    self.check_for_opening(0.2)
+                    if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES and \
+                            not (self.red_locked or self.blue_locked or self.free_locked):
+                        self.look_at_teams(1.0)
+                self.add_to_spec(player)
+                self.remove_from_join(player)
+            self.remove_from_afk(player)
+            self.remove_from_queue(player)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue exec_here Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_afk(self, player, afk_tag):
+        try:
+            self._afk.add_to_times(player.steam_id)
+            self._afk_tag[str(player.steam_id)] = afk_tag
+
+            @minqlxtended.next_frame
+            def notify(p=player):
+                p.center_print("^6AFK Mode\n^7Type ^4!here ^7when back.")
+                p.clan = p.clan
+            notify()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add_to_afk Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def remove_from_afk(self, player, msg=True):
+        try:
+            sid = player.steam_id
+            if str(sid) in self._afk:
+                self._afk.remove_from_times(sid)
+                if msg:
+                    @minqlxtended.next_frame
+                    def notify(p=player):
+                        p.center_print("^3Not marked AFK\n^7Join to play or enter the queue.")
+                        p.clan = p.clan
+                    notify()
+            if str(sid) in self._afk_tag:
+                del self._afk_tag[str(sid)]
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue remove_from_afk Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_tags(self, player=None, msg=None, channel=None):
+        if self._queue_tags:
+            player.tell("^3Allowed spectator tags are: ^6{}".format("^7, ^6".join(SPEC_TAGS)))
+        else:
+            player.tell("^3Spectator tags are not being monitored")

--- a/ql-assets/data/minqlxtended-plugins/README.md
+++ b/ql-assets/data/minqlxtended-plugins/README.md
@@ -7,10 +7,32 @@ These files are synced to every minqlxtended host by `setup_host.yml` and
 backfilled into each instance's plugin directory by `add_qlds_instance.yml`.
 Anything here is available to an instance whether or not a preset ships it.
 
-`serverchecker.py` is **not** upstream. It is QLSM's own plugin, ported to the
-minqlxtended API, and it is a hard dependency of live status: it writes
-`minqlx:server_status:<port>`, which `ui/task_logic/service_runtime.py` reads.
-`manifest.json` marks it `"origin": "qlsm"` so a diff against upstream skips it.
+## QLSM's own plugins
+
+Seven files here are **not** upstream. They are QLSM's own plugins, ported to the
+minqlxtended API, and `manifest.json` marks each `"origin": "qlsm"` so a diff against
+upstream skips them. Their minqlx originals live in `ql-assets/data/minqlx-plugins/`.
+
+| File | Notes |
+|---|---|
+| `serverchecker.py` | Hard dependency of live status: writes `minqlx:server_status:<port>`, which `ui/task_logic/service_runtime.py` reads. Never pickable — a `SYSTEM_PLUGIN`, backfilled into every instance. |
+| `myFun.py` | Sound-trigger plugin. Keeps its `minqlx:myFun:*` Redis keys and its Steam Workshop item titles verbatim; both are matched by exact string. |
+| `specqueue.py` | Spectator queue. Ported from the `minqlx-plugins/` copy, **not** the default preset's copy — see the warning below. |
+| `player_info.py` | Does **not** carry the iouonegirl abstract base across. That base installs itself at import by downloading from a minqlx plugin repository; the one helper this plugin used from it is inlined. |
+| `commands.py` | `!plugins` / `!lc`. Unrelated to upstream's `votecommands.py`, which adds `/pass` and `/veto`. |
+| `reset_acc.py` | Needs no engine patch here — `gclient_t` is writable memory. The per-weapon WEAP arrays are `WEAPONS` fields with no setter (`python_objects.c:1156`), so they survive a reset and the plugin no longer claims otherwise. |
+| `suppress_join_msg.py` | Suppresses the "joined the battle" centre-print. |
+
+`serverchecker.py`, `reset_acc.py` and `suppress_join_msg.py` are baseline-only: present
+in every instance's plugin directory, but not in `default-minqlxtended`'s `scripts/`, so
+the picker does not offer them. The other four mirror the minqlx default preset, which
+ships exactly those four.
+
+> ⚠️ **Port from `ql-assets/data/minqlx-plugins/`, never from a preset's `scripts/`.**
+> The two copies of `specqueue.py` on the minqlx side have diverged, and the preset copy
+> is the broken one: its AFK sweep is dedented out of its `elif`, so it moves every
+> player to spectator on every pass. `tests/test_default_minqlxtended_preset.py` pins
+> the minqlxtended preset copies to the baseline so this cannot recur here.
 
 ## Re-vendoring against a newer upstream
 

--- a/ql-assets/data/minqlxtended-plugins/commands.py
+++ b/ql-assets/data/minqlxtended-plugins/commands.py
@@ -1,0 +1,86 @@
+# This is an extension plugin for minqlxtended.
+# Copyright (C) 2018 BarelyMiSSeD (github)
+
+# You can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+
+# You should have received a copy of the GNU General Public License
+# along with minqlxtended. If not, see <http://www.gnu.org/licenses/>.
+
+# This is a plugin and command listing script for the minqlxtended admin bot.
+# This plugin will list all the in game commands loaded on the server.
+"""
+//Server Config cvars
+//Set the permission level needed to list the commands
+set qlx_commandsAdmin "3"
+//Enable to show only the commands the calling player can use, disable to show all commands (0=disable, 1=enable)
+set qlx_commandsOnlyEligible "1"
+"""
+
+import minqlxtended
+
+VERSION = "1.0"
+
+# Hard cap on output lines per invocation to avoid flooding the client
+# command buffer. Use !lc <plugin_name> to narrow results past the cap.
+MAX_TELL_LINES = 20
+
+# Number of plugin names listed per line in !plugins output.
+PLUGINS_PER_LINE = 7
+
+
+class commands(minqlxtended.Plugin):
+    def __init__(self):
+        # queue cvars
+        self.set_cvar_once("qlx_commandsAdmin", "3")
+        self.set_cvar_once("qlx_commandsOnlyEligible", "1")
+
+        # Minqlx bot commands
+        self.add_command("plugins", self.list_plugins, self.get_cvar("qlx_commandsAdmin", int))
+        self.add_command(("lc", "listcmds", "listcommands"), self.cmd_list, self.get_cvar("qlx_commandsAdmin", int),
+                         usage="<plugin_name>")
+
+    def list_plugins(self, player, msg, channel):
+        names = sorted(self.plugins)
+        count = len(names)
+        if not count:
+            return
+        lines = []
+        for i in range(0, count, PLUGINS_PER_LINE):
+            lines.append("^7, ^6".join(names[i:i + PLUGINS_PER_LINE]))
+        player.tell("^1{} ^3Plugins found:".format(count))
+        player.tell("^6{}".format("^7\n^6".join(lines)))
+
+    def cmd_list(self, player, msg, channel):
+        plugins = sorted(self.plugins)
+        only_eligible = self.get_cvar("qlx_commandsOnlyEligible", bool)
+        caller_perm = self.db.get_permission(player)
+        search = msg[1].lower() if len(msg) > 1 else None
+        lines = ["^1Plugin^7: ^2Number of Commands"]
+        count = 0
+        for name in plugins:
+            if search and search not in name.lower():
+                continue
+            try:
+                cmds = self.plugins[name].commands
+            except Exception:
+                minqlxtended.log_exception()
+                continue
+            entries = []
+            for cmd in cmds:
+                if only_eligible and caller_perm < cmd.permission:
+                    continue
+                entries.append("^7(^2{}^7) ^6{}".format(cmd.permission, "^7|^6".join(cmd.name)))
+            if entries:
+                m = len(entries)
+                lines.append("^1{}^7: {} ^3Command{}".format(name, m, "s" if m > 1 else ""))
+                lines.append("^7, ".join(entries))
+                count += 1
+        if not count:
+            player.tell("^3No Plugin matches ^4{}".format(search))
+            return
+        for line in lines[:MAX_TELL_LINES]:
+            player.tell(line)
+        if len(lines) > MAX_TELL_LINES:
+            player.tell("^3Output truncated. Use ^7!lc <plugin_name> ^3to narrow results.")

--- a/ql-assets/data/minqlxtended-plugins/manifest.json
+++ b/ql-assets/data/minqlxtended-plugins/manifest.json
@@ -86,7 +86,7 @@
     },
     "player_info.py": {
       "origin": "qlsm",
-      "sha256": "92e4f69a2c78acee4d254892362c69282c7778152071df32524575e2f680b3c1"
+      "sha256": "92fb51e6568a1bc0191c1faa182f88c5ce6697842c2e00c093429958123bb193"
     },
     "plugin_manager.py": {
       "origin": "upstream",

--- a/ql-assets/data/minqlxtended-plugins/manifest.json
+++ b/ql-assets/data/minqlxtended-plugins/manifest.json
@@ -20,6 +20,10 @@
       "origin": "upstream",
       "sha256": "63d4b858b4c38b19b3fcc7e9094ce4a5dcdbb6745ec3b990b5ba37ec837b9b9c"
     },
+    "commands.py": {
+      "origin": "qlsm",
+      "sha256": "46440173c28b60747e7ad5150d9ecea4c7253a365fe924f565f6c99179e6d9ea"
+    },
     "custom_votes.py": {
       "origin": "upstream",
       "sha256": "399ae4dab636b007defc4012f282574ff125fabda2e9af00bdfb85872347062c"
@@ -68,6 +72,10 @@
       "origin": "upstream",
       "sha256": "7c1741718eab59fcea47d0d6798f35c6b0bcb24e102d9edf7df53bd524e1d8b3"
     },
+    "myFun.py": {
+      "origin": "qlsm",
+      "sha256": "3bbd5bef33136cbed1db7e7b8cfd0c62e81e4f16e1246440bb05acf4ac8ce048"
+    },
     "names.py": {
       "origin": "upstream",
       "sha256": "ed7713340354e6886872baa27419c7ae333d1e0749f8ad4904db90d6520a10ad"
@@ -75,6 +83,10 @@
     "permission.py": {
       "origin": "upstream",
       "sha256": "102a3ba975a3f18f05cab68bade5c744a8ff95d3259b4d7a6904ba6bf71b16c6"
+    },
+    "player_info.py": {
+      "origin": "qlsm",
+      "sha256": "92e4f69a2c78acee4d254892362c69282c7778152071df32524575e2f680b3c1"
     },
     "plugin_manager.py": {
       "origin": "upstream",
@@ -92,6 +104,10 @@
       "origin": "upstream",
       "sha256": "177e2c1649d392fcd645ac949a409614e78412a26549a09891e21e991e029eaa"
     },
+    "reset_acc.py": {
+      "origin": "qlsm",
+      "sha256": "f5e62422b1bf60079cbf281ed2663a1d4bd7d3ffb857b53a49c07b845f2c298d"
+    },
     "scores.py": {
       "origin": "upstream",
       "sha256": "f8835916d5d1fbc8abd058198a286a374afee6fb395ec55583e819b885f45c0d"
@@ -108,9 +124,17 @@
       "origin": "upstream",
       "sha256": "96dad15fe70d367dcf7ffa9fe91920ba6731aa5b197455a62c2bb1a9ebf55abb"
     },
+    "specqueue.py": {
+      "origin": "qlsm",
+      "sha256": "04f5fad3c086d9472e4942f2fe2b93d652ce3d097197223a39ee306138a0ddfa"
+    },
     "stats.py": {
       "origin": "upstream",
       "sha256": "7ee7f44ca30749a9598fc6a38e1af47512b1336d127e5cf89822d3be857010a1"
+    },
+    "suppress_join_msg.py": {
+      "origin": "qlsm",
+      "sha256": "ab0220ab1db527a2479f56c3e5e87f5566a94e3df089ffe3fa19d7e9977b12ed"
     },
     "sv_fps.py": {
       "origin": "upstream",

--- a/ql-assets/data/minqlxtended-plugins/myFun.py
+++ b/ql-assets/data/minqlxtended-plugins/myFun.py
@@ -1,0 +1,2561 @@
+# This is an extension plugin  for minqlxtended.
+# Copyright (C) 2018 BarelyMiSSeD (github)
+
+# You can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+
+# You should have received a copy of the GNU General Public License
+# along with minqlxtended. If not, see <http://www.gnu.org/licenses/>.
+
+# This plugin is a replacement for minqlx's fun.py
+# https://github.com/MinoMino/minqlx
+
+# Created by BarelyMiSSeD
+# https://github.com/BarelyMiSSeD
+
+# You are free to modify this plugin.
+# This plugin comes with no warranty or guarantee.
+
+"""
+*** This is my replacement for the minqlxtended fun.py so if you use this file make sure not to load fun.py ***
+
+This plugin plays sounds for players on the Quake Live server
+It plays the sounds included in fun.py and some from other workshop item sound packs.
+
+This can limit sound spamming to the server.
+It only allows one sound to be played at a time and each user is limited in the frequency they can play sounds.
+If you desire no restriction then set both of the 2 following cvars to "0".
+The default qlx_funSoundDelay setting will require 5 seconds from the start of any sound
+before another sound can be played by anyone.
+The default qlx_funPlayerSoundRepeat setting will require 30 seconds from the start of a player called sound before
+that player can call another sound.
+
+To set the time required between any sound add this line to your server.cfg and edit the "5":
+set qlx_funSoundDelay "5"
+
+To set the time a player has to wait after playing a sound add this like to your server.cfg and edit the "30":
+set qlx_funPlayerSoundRepeat "30"
+
+ The amount of seconds an admin has to wait before using the !playsound command again (0 will effectively disable)
+ This is to keep admins from being able to totally bypass the sound call restrictions by using !playsound
+set qlx_funAdminSoundCall "5"
+
+#Play Join Sound when players connect (set to "path/file" like below example to play sound)
+#  *** Disable the MOTD sound to use this with set qlx_motdSound "0" ****
+set qlx_funJoinSound "sound/feedback/welcome_02.wav"
+
+#Play Join Sound even if players have sounds disabled
+set qlx_funJoinSoundForEveryone "0"
+
+#Play Join Sound on every map change (set to "1" to play join sound every map change)
+set qlx_funJoinSoundEveryMap "0"
+
+#Join sound path/file
+set qlx_funJoinSound "sound/feedback/welcome_02.wav"
+
+# Play Sound when last 2 players alive (should set to "3" to play sounds always)
+# 0 = don't play sound for anyone when the last 2 (or  1 on either team of a team based game) remains
+# 1 = play sound for all except those alive when the last 2 (or  1 on either team of a team based game) remains
+# 2 = only play sounds for people who are dead/spectating when game is active
+# 3 = play sound for everyone with sounds enabled
+set qlx_funLast2Sound "3"
+
+# Enable to use a dictionary to store sounds, faster responses to trigger text (0=disable, 1=enable)
+#  Enabling will cause the server to use more memory, only enable if memory is available.
+#  Must be enabled on server startup or it will not work.
+set qlx_funFastSoundLookup "1"
+
+These extra workshop items need to be loaded on the server for it to work correctly if all sound packs are enabled:
+(put the workshop item numbers in your workshop.txt file)
+#Prestige Worldwide Soundhonks
+585892371
+#Funny Sounds Pack for Minqlx
+620087103
+#Duke Nukem Voice Sound Pack for minqlx
+572453229
+#Warp Sounds for Quake Live
+1250689005
+#West Coast Crew Sound
+1733859113
+
+The minqlxtended 'workshop' plugin needs to be loaded and the required workshop
+items added to the set qlx_workshopReferences line
+(This example shows only these required workshop items):
+set qlx_workshopReferences "585892371, 620087103, 572453229, 1250689005, 1733859113"
+(Only include the sound pack workshop item numbers that you decide to enable on the server)
+(The Default sounds use sounds already available as part of the Quake Live install)
+
+Soundpacks:
+1) The Default soundpack uses sounds that are already included in the Quake Live install.
+2) The Prestige Worldwide Soundhonks soundpack can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=585892371
+3) The Funny Sounds Pack for Minqlx can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=620087103
+4) The Duke Nukem Voice Sound Pack for minqlx soundpack can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=572453229
+5) The Warp Sounds for Quake Live soundpack can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=1250689005
+6) The West Coast Crew Sound soundpack can be seen Here: http://steamcommunity.com/sharedfiles/filedetails/?id=1733859113
+
+The soundpacks are all enabled by default. Which soundpacks are enabled can be set.
+set qlx_funEnableSoundPacks "63" : Enables all sound packs.
+****** How to set which sound packs are enabled ******
+Add the values for each sound pack listed below and set that value to the
+ qlx_funEnableSoundPacks in the same location as the rest of your minqlxtended cvar's.
+
+ ****Sound Pack Values****
+                               Default:  1
+         Prestige Worldwide Soundhonks:  2
+          Funny Sounds Pack for Minqlx:  4
+Duke Nukem Voice Sound Pack for minqlx:  8
+            Warp Sounds for Quake Live:  16
+                 West Coast Crew Sound:  32
+
+   Duke Nukem Soundpack Disabled Example: set qlx_funEnableSoundPacks "55"
+
+When a player issues the !listsounds command it wil list all of the sounds available on the server with
+ the sounds displayed in a tabbed format to help enable the redability of the sounds without requiring
+  the use of pages or exessie scrolling. Only the soundpacks that are enabled will be shown. Any disabled
+   soundpacks will not be displayed and will not be searchable.
+
+If !listsounds is issued with a search term it will search for sounds that contain that term and display
+ each enabled soundpack and the sounds found in them.
+
+Example: !listsounds yeah would list all the sound phrases containing 'yeah'
+and would print this to the player's console (assuming all sound packs are enabled):
+
+SOUNDS: Type these words/phrases in normal chat to play a sound on the server.
+Default
+haha yeah haha hahaha yeah yeah hahaha yeahhh
+Prestige Worldwide Soundhonks
+No Matches
+Funny Sounds Pack for Minqlx
+No Matches
+Duke Nukem Voice Sound Pack for minqlx
+No Matches
+Warp Sounds for Quake Live
+No Matches
+West Coast Crew Sound
+No Matches
+4 SOUNDS: Type these words/phrases in normal chat to play a sound on the server.
+
+If !listsounds is issued with a sound pack limiting value it will only search that soundpack for sounds.
+!listsounds #Default would only list the sounds in the Default soundpack, if it is enabled.
+
+Example: '!listsounds #Default yeah' would list all the sounds containing 'yeah' but limit that search to
+just the Default sounds and produce the following output:
+
+SOUNDS: Type these words/phrases in normal chat to play a sound on the server.
+Default
+haha yeah haha hahaha yeah yeah hahaha yeahhh
+4 SOUNDS: Type these words/phrases in normal chat to play a sound on the server.
+
+// Copy after this line into your server config
+// Let players with at least perm level 'qlx_funAdminlevel' play sounds unrestricted (change applies at load time)
+// 0-Restricted like all players; 1-Unrestricted for player time limits only; 2-Unrestricted from any time limit
+set qlx_funUnrestrictAdmin "0"
+// Set the permission level for a myFun admin (change applies at load time)
+set qlx_funAdminlevel "5"
+// Delay between sounds being played
+set qlx_funSoundDelay "5"
+// **** Used for limiting players spamming sounds. ****
+//  Amount of seconds player has to wait before allowed to play another sound
+set qlx_funPlayerSoundRepeat "30"
+// Amount of seconds an admin has to wait before using the !playsound command again (0 will effectively disable)
+set qlx_funAdminSoundCall "5"
+// Keep muted players from playing sounds
+set qlx_funDisableMutedPlayers "1"
+// Enable/Disable sound pack files
+set qlx_funEnableSoundPacks "63"
+// Join sound path/file ("0" disables sound)
+set qlx_funJoinSound "0"
+// Play Join Sound even if players have sounds disabled
+set qlx_funJoinSoundForEveryone "0"
+// Play Join Sound on every map change
+set qlx_funJoinSoundEveryMap "0"
+// Play Sound when last 2 players alive (should set to "3" to play sounds always)
+// 0 = don't play sound for anyone when the last 2 (or  1 on either team of a team based game) remains
+// 1 = play sound for all except those alive when the last 2 (or  1 on either team of a team based game) remains
+// 2 = only play sounds for people who are dead/spectating when game is active
+// 3 = play sound for everyone with sounds enabled
+set qlx_funLast2Sound "1"
+// Enable fast sound lookup
+set qlx_funFastSoundLookup "1"
+
+#############
+# NOTE
+#############
+Any sound triggers that want to be called using characters outside of A thru Z (case insensitive) need to be added as
+a custom trigger. I.E.: getting 'smiley face' to play when a user types :) would be done with
+!addtrigger smiley face = :)
+
+################################################################################################################
+#    Adding Additional Sound Packs
+################################################################################################################
+*** If making changes to the ADDITIONAL_SOUNDPACKS perform !erasedb first, then reload/restart  *****
+***** To add new sound packs without editing this file "much" *****
+Sound Pack File Requirements:
+The sound file names will use a sound trigger based on the file name. The sound file name will replace
+ underscores (_) with spaces or insert spaces after words starting with a capital letter.
+ The path inside the sound_pack.pk3 is not used to generate the sound trigger, only the sound file name.
+ I.E. The sound 'sound/warp/bend_me_over.ogg' will create the sound trigger 'bend me over'.
+      The sound 'sound/warp/BendMeOver.ogg' will also create the sound trigger 'bend me over'.
+ *** Note: These are the only 2 formats that will be correctly interpreted. I.E. 'sound/warp/bendMeOver.ogg' will not
+     generate the full sound trigger correctly.
+ *** NOTE: The name of the sound pack file stored in the baseq3 directory of the server does not have to match the
+     name of the sound pack file in the steam workshop. As long as the contents of the file are exactly the same.
+     You can rename the file stored in the baseq3 to whatever you want the sound pack called, ending it with
+     the .pk3 file extension. Use underscores for spaces in the sound pack name. (i.e. My_Enjoyable_Sounds.pk3 will be
+     shown as the sound pack 'My Enjoyable Sounds'.
+
+1) put the <sound_pack.pk3> file into the baseq3 directory of the server.
+    The baseq3 sub-directory stored in the cvar fs_basepath.
+2) add the <sound_pack.pk3> file name to the ADDITIONAL_SOUNDPACKS below with the format
+    ADDITIONAL_SOUNDPACKS = ['sound_pack.pk3', 'sound_pack_2.pk3', 'sound_pack_3.pk3']
+3) add the steam workshop item number to the qlx_workshopReferences cvar in the server.cfg
+    set qlx_workshopReferences "585892371, 620087103, 572453229, 1250689005, 1733859113, <new workshop item number>"
+
+The sound pack will be added starting at the end of the list, as sound pack 6 if nothing else was edited in the file.
+Any sound pack added here will automatically be enabled.
+"""
+
+import minqlxtended
+import random
+import time
+import re
+from os import path
+from zipfile import ZipFile
+import traceback
+import threading
+
+VERSION = "8.0"
+SOUND_TRIGGERS = "minqlx:myFun:triggers:{}:{}"
+TRIGGERS_LOCATION = "minqlx:myFun:addedTriggers:{}"
+DISABLED_SOUNDS = "minqlx:myFun:disabled:{}"
+PLAYERS_SOUNDS = "minqlx:players:{}:flags:myFun:{}"
+TEAM_BASED_GAMETYPES = ("ca", "ctf", "ft", "ictf", "tdm")
+CATEGORIES = ["#Default", "#Prestige", "#Funny", "#Duke", "#Warp", "#West"]
+SOUND_PACKS = ["Default Quake Live Sounds", "Prestige Worldwide Soundhonks", "Funny Sounds Pack for Minqlx",
+               "Duke Nukem Voice Sound Pack for minqlx", "Warp Sounds for Quake Live", "West Coast Crew Sound"]
+""" NOTE: If this is changed, you may want to perform a !erasedb before unloading/reloading myFun """
+ADDITIONAL_SOUNDPACKS = ['doompack.pk3', 'doompack2.pk3']
+
+
+class myFun(minqlxtended.Plugin):
+    Enabled_SoundPacks = []
+    soundPacks = []
+    categories = []
+    soundLists = []
+    _enable_dictionary = False
+    _sound_dictionary = {}
+    _custom_triggers = {}
+    sound_list_count = 0
+    help_msg = []
+
+    def __init__(self):
+        # Let players with perm level qlx_funAdminlevel play sounds
+        self.set_cvar_once("qlx_funUnrestrictAdmin", "0")
+        # sets the admin level for playing unrestricted sounds (level 5 recommended)
+        self.set_cvar_once("qlx_funAdminlevel", "5")
+        # Delay between sounds being played
+        self.set_cvar_once("qlx_funSoundDelay", "5")
+        # **** Used for limiting players spamming sounds. ****
+        #  Amount of seconds player has to wait before allowed to play another sound
+        self.set_cvar_once("qlx_funPlayerSoundRepeat", "30")
+        # Amount of seconds an admin has to wait before using the !playsound command again (0 will effectively disable)
+        self.set_cvar_once("qlx_funAdminSoundCall", "5")
+        # Keep muted players from playing sounds
+        self.set_cvar_once("qlx_funDisableMutedPlayers", "1")
+        # Enable/Disable sound pack files
+        self.set_cvar_once("qlx_funEnableSoundPacks", "63")
+        # Join sound path/file ("0" disables sound)
+        self.set_cvar_once("qlx_funJoinSound", "0")
+        # Play Join Sound even if players have sounds disabled
+        self.set_cvar_once("qlx_funJoinSoundForEveryone", "0")
+        # Play Join Sound on every map change
+        self.set_cvar_once("qlx_funJoinSoundEveryMap", "0")
+        # Play Sound when last 2 players alive (should set to "3" to play sounds always)
+        # 0 = don't play sound for anyone when the last 2 (or  1 on either team of a team based game) remains
+        # 1 = play sound for all except those alive when the last 2 (or  1 on either team of a team based game) remains
+        # 2 = only play sounds for people who are dead/spectating when game is active
+        # 3 = play sound for everyone with sounds enabled
+        self.set_cvar_once("qlx_funLast2Sound", "3")
+        # Enable to use a dictionary to store sounds, faster responses to trigger text (0=disable, 1=enable)
+        #  Enabling will cause the server to use more memory, only enable if memory is available.
+        #  Must be enabled on server startup, or it will not work.
+        self.set_cvar_once("qlx_funFastSoundLookup", "1")
+
+        self.add_hook("chat", self.handle_chat)
+        self.add_hook("console_print", self.handle_console_print)
+        self.add_hook("server_command", self.handle_server_command)
+        self.add_hook("player_disconnect", self.handle_player_disconnect)
+        self.add_hook("player_loaded", self.handle_player_loaded, priority=minqlxtended.Priority.LOWEST)
+        self.add_command("cookies", self.cmd_cookies)
+        self.add_command(("ls", "listsounds"), self.list_sounds)
+        self.add_command(("myfun", "fun"), self.cmd_help)
+        self.add_command(("off", "soundoff"), self.sound_off, client_cmd_perm=0)
+        self.add_command(("on", "soundon"), self.sound_on, client_cmd_perm=0)
+        self.add_command(("ol", "offlist", "soundofflist"), self.cmd_sound_off_list, client_cmd_perm=0)
+        self.add_command(("ps", "playsound", "sound"), self.cmd_sound, 3)
+        self.add_command(("pt", "playtrigger"), self.cmd_play_trigger, 3)
+        self.add_command(("ds", "disablesound"), self.cmd_disable_sound, client_cmd_perm=5, usage="<sound trigger>")
+        self.add_command(("es", "enablesound"), self.cmd_enable_sound, client_cmd_perm=5, usage="<sound trigger>")
+        self.add_command(("ld", "listdisabled"), self.cmd_list_disabled, client_cmd_perm=5)
+        self.add_command(("at", "addtrigger"), self.add_trigger, 5)
+        self.add_command(("dt", "deltrigger"), self.del_trigger, 5)
+        self.add_command(("lt", "listtriggers"), self.request_triggers, 3)
+        self.add_command(("ed", "erasedisabled"), self.erase_disabled, 5)
+        self.add_command("sounds", self.cmd_enable_sounds, usage="<0/1>")
+        self.add_command(("erase_sounds", "erasedb"), self.start_erase_db, 5)
+        self.add_command(("fill_sounds", "filldb"), self.start_fill_db, 5)
+        self.add_command("restrictadmin", self.get_set_restrict_admin, 5)
+        self.add_command("adminlevel", self.get_set_admin_level, 5)
+
+        # lambda function to insert spaces in a string (replaces _ or inserts between CamelCase). Returns lowercase.
+        self.convert = lambda x: x.replace('_', ' ') if x.islower() else ' '.join(re.findall('[A-Z][^A-Z]*', x)).lower()
+        # Class Variables
+        self.populating = False
+        # variable to show when a sound has been played
+        self.played = False
+        # variable to store the sound to be called
+        self.soundFile = None
+        # variable to store the sound trigger
+        self.trigger = ""
+        # lock serialising concurrent scan_chat threads accessing soundFile/trigger/played
+        self._sound_lock = threading.Lock()
+        # stores time of last sound play
+        self.last_sound = None
+        # variables used when checking for the presence of a sound file
+        self.checking_file = False
+        self.file_status = False
+        # sounds count
+        self._total_sounds = 0
+        # Dictionary used to store player sound call times.
+        self.sound_limiting = {}
+        # Dictionary used to store admin play sound times.
+        self.admin_limiting = {}
+        # List to store steam ids of muted players
+        self.muted_players = []
+        # populate the database and sound lists with the sound packs
+        self.start_fill_db()
+        # Welcome sound played list
+        self.playedWelcome = []
+        # command prefix
+        self._command_prefix = self.get_cvar("qlx_commandPrefix")
+        # admin settings
+        self.admin_allowed = self.get_cvar("qlx_funUnrestrictAdmin", int)
+        self.admin_level = self.get_cvar("qlx_funAdminlevel", int)
+        # Execute function to remove loaded !sound commands in other scripts
+        self.remove_conflicting_sound_commands()
+
+    def get_set_admin_level(self, player, msg, channel):
+        if len(msg) > 1:
+            try:
+                level = int(msg[1])
+                if level < 0 or level > 5:
+                    raise ValueError
+                self.admin_level = level
+                player.tell("^2myFun admin level set to ^3{}".format(self.admin_level))
+            except Exception as e:
+                player.tell("Level must be an integer. Valid levels are 0-5. Exception: {}".format(type(e).__name__))
+        else:
+            player.tell("^2myFun admin level is ^3{}\n^2{}adminlevel <perms_level> ^3to set admin level."
+                        .format(self.admin_level, self._command_prefix))
+
+    def get_set_restrict_admin(self, player, msg, channel):
+        if len(msg) > 1:
+            try:
+                level = int(msg[1])
+                if level < 0 or level > 5:
+                    raise ValueError
+                elif level == 0:
+                    self.admin_allowed = 0
+                    player.tell("^1myFun admin sound play is restricted.")
+                elif level == 1:
+                    self.admin_allowed = 1
+                    player.tell("^2myFun admin sound play is unrestricted to player time limits.")
+                else:
+                    self.admin_allowed = 2
+                    player.tell("^2myFun admin sound play is fully un-restricted.")
+            except Exception as e:
+                player.tell("Admin restriction valid values are 0/1/2. Exception: {}".format(type(e).__name__))
+        else:
+            r = ['', 'partially un-', 'fully un-']
+            player.tell("^2myFun admin is ^3{}restricted\n"
+                        "^2{}restrictadmin <0/1/2> ^3to restrict/partially un-restrict/fully un-restrict."
+                        .format(r[self.admin_allowed], self._command_prefix))
+
+    @minqlxtended.delay(3)
+    def remove_conflicting_sound_commands(self):
+        loaded_scripts = self.plugins
+        loaded_scripts.pop(self.__class__.__name__)
+        for script, handler in loaded_scripts.items():
+            try:
+                for cmd in handler.commands:
+                    if {"sound"}.intersection(cmd.name):
+                        handler.remove_command(cmd.name, cmd.handler)
+                        minqlxtended.console_print("^1myFun: Removing command ^7{} ^1used in ^7{} ^1plugin"
+                                             .format(cmd.name, script))
+            except:
+                continue
+
+    def start_erase_db(self, player, msg=None, channel=None):
+        self.erase_db(player)
+
+    @minqlxtended.thread
+    def erase_db(self, player, msg=None, channel=None):
+        length = len(self.Enabled_SoundPacks)
+        done = self.erase_triggers(player, length)
+        self.soundPacks = []
+        self.categories = []
+        self.soundLists = []
+        self.help_msg = []
+        self._total_sounds = 0
+        player.tell("^1Completed Database Sound Trigger Erase.")
+
+    def erase_triggers(self, player, index, all_triggers=True):
+        def del_db(num):
+            y = self.db.keys(SOUND_TRIGGERS.format(num, "*"))
+            for key in y:
+                del self.db[key]
+            try:
+                player.tell("^1Database Table {} delete commands issued".format(self.categories[num]))
+            except:
+                pass
+
+        if all_triggers:
+            for x in range(index):
+                del_db(x)
+        else:
+            del_db(index)
+        return True
+
+    def start_fill_db(self, player=None, msg=None, channel=None):
+        self.fill_db(player)
+
+    @minqlxtended.thread
+    def fill_db(self, player, msg=None, channel=None):
+        try:
+            if player:
+                player.tell("^1Filling myFun Sounds Database")
+            # List to store the enable/disabled status of the sound packs (they should all be 0 here)
+            self.Enabled_SoundPacks = [0] * len(CATEGORIES)
+            # set the desired sound packs to enabled
+            self.enable_packs()
+            self.soundPacks = SOUND_PACKS
+            self.categories = CATEGORIES
+            self.soundLists = []
+            # Using sound dictionary or database list return
+            self._enable_dictionary = self.get_cvar("qlx_funFastSoundLookup", bool)
+            if self._enable_dictionary:
+                # Sound dictionary, used if enabled
+                self._sound_dictionary = {}
+                self._custom_triggers = {}
+                for num in range(len(self.Enabled_SoundPacks)):
+                    self._sound_dictionary[num] = {}
+            self.populate_database(player)
+        except Exception as e:
+            minqlxtended.console_print("^3myFun fill_db Exception: {}\n{}".format(type(e).__name__, traceback.format_exc()))
+
+    def enable_packs(self):
+        packs = self.get_cvar("qlx_funEnableSoundPacks", int)
+        maximum = 2 ** len(CATEGORIES)
+        if packs > maximum:
+            packs = maximum
+        binary = bin(packs)[2:]
+        length = len(binary)
+        count = 0
+        # Set all values to disabled, initially
+        for x in range(len(self.Enabled_SoundPacks)):
+            self.Enabled_SoundPacks[x] = 0
+
+        # save the packs value's binary representation to the slots in self.Enabled_SoundPacks
+        # to identify the enabled sound packs
+        while length > 0:
+            self.Enabled_SoundPacks[count] = int(binary[length - 1])
+            count += 1
+            length -= 1
+
+    @minqlxtended.delay(2)
+    def handle_player_loaded(self, player):
+        if self.get_cvar("qlx_motdSound") != "0" or self.get_cvar("qlx_funJoinSound") == "0":
+            return
+        # plays the join sound for a connecting player if qlx_funJoinSound is set and qlx_motdSound is not set
+        # join sound can be played for everyone even if sounds are disabled if qlx_funJoinSoundForEveryone is enabled
+        # join sound will play every map load for already connected players if qlx_funJoinSoundEveryMap is enabled
+        welcome_sound = self.get_cvar("qlx_funJoinSound")
+        if welcome_sound and player.steam_id not in self.playedWelcome and\
+                (self.get_cvar("qlx_funJoinSoundForEveryone", bool) or
+                 self.db.get_flag(player, "essentials:sounds_enabled", default=True)):
+            super().play_sound(welcome_sound, player)
+            if not self.get_cvar("qlx_funJoinSoundEveryMap", bool):
+                self.playedWelcome.append(player.steam_id)
+
+    # Remove stored information for disconnecting players
+    def handle_player_disconnect(self, player, reason):
+        self.process_player_disconnect(player)
+        return
+
+    def process_player_disconnect(self, player):
+        try:
+            del self.sound_limiting[player.steam_id]
+        except:
+            pass
+        try:
+            self.muted_players.remove(player.steam_id)
+        except:
+            pass
+        try:
+            self.playedWelcome.remove(player.steam_id)
+        except:
+            pass
+
+    # stores the mute status of a player when muted or un-muted
+    def handle_server_command(self, player, cmd):
+        self.process_server_command(cmd)
+        return
+
+    def process_server_command(self, cmd):
+        if "has been muted" in cmd:
+            cmd_string = cmd.split()
+            cmd_len = len(cmd_string)
+            name_length = cmd_len - 4
+            name = " ".join(cmd_string[1:name_length]).strip('"')
+            muted = self.find_player(name)
+            steam_id = muted[0].steam_id
+            if steam_id not in self.muted_players:
+                self.muted_players.append(steam_id)
+        elif "has been unmuted" in cmd:
+            cmd_string = cmd.split()
+            cmd_len = len(cmd_string)
+            name_length = cmd_len - 4
+            name = " ".join(cmd_string[1:name_length]).strip('"')
+            muted = self.find_player(name)
+            steam_id = muted[0].steam_id
+            try:
+                self.muted_players.remove(steam_id)
+            except:
+                pass
+
+    # Monitors the chat messages of players to process the sound triggers
+    def handle_chat(self, player, msg, channel):
+        self.scan_chat(player, msg, channel)
+        return
+
+    @minqlxtended.thread
+    def scan_chat(self, player, msg, channel):
+        # don't process the chat if it was in the wrong channel or the player is muted or has sounds turned off
+        if msg.startswith("{}".format(self._command_prefix)) or channel != "chat" or\
+                player.steam_id in self.muted_players or\
+                not self.db.get_flag(player, "essentials:sounds_enabled", default=True):
+            return
+
+        # find the sound trigger for this sound (sets self.trigger, self.soundFile)
+        # lock ensures concurrent chat messages from two players don't race on shared fields
+        with self._sound_lock:
+            if self.find_sound_trigger(self.clean_text(msg)):
+                # stop sound processing if the player has this sound trigger turned off
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, self.soundFile)):
+                    return minqlxtended.Return.NONE
+                # check sound delay time
+                delay_time = self.check_time(player)
+                # see if admin is trying to play sound
+                admin_sound = self.db.get_permission(player.steam_id) >= self.admin_level
+                if delay_time:
+                    # if admins have no delay time restriction then PASS
+                    if self.admin_allowed and admin_sound:
+                        pass
+                    # otherwise, impose the delay time wait and stop sound trigger processing
+                    else:
+                        player.tell("^3You played a sound recently. {} seconds timeout remaining."
+                                    .format(delay_time))
+                        return minqlxtended.Return.NONE
+                # check to see if a sound has been played
+                if not self.last_sound or self.admin_allowed > 1 and admin_sound:
+                    pass
+                # Make sure the last sound played was not within the sound delay limit
+                elif time.time() - self.last_sound < self.get_cvar("qlx_funSoundDelay", int):
+                    player.tell("^3A sound has been played in last {} seconds. Try again after the timeout."
+                                .format(self.get_cvar("qlx_funSoundDelay")))
+                    return minqlxtended.Return.NONE
+                # call the play sound function
+                self.play_sound(self.soundFile)
+
+            # If the sound played record the time with the player's steam id (for delay_time processing)
+            if self.played:
+                self.sound_limiting[player.steam_id] = time.time()
+            # unset self.played so it can be checked again the next time a sound trigger is typed
+            self.played = False
+        return minqlxtended.Return.NONE
+
+    def handle_console_print(self, text):
+        self.process_console_print(text)
+        return
+
+    def process_console_print(self, text):
+        try:
+            if self.checking_file and 'files listed' in text:
+                self.file_status = True if text.split(" ")[0] == "1" else False
+        except:
+            minqlxtended.log_exception()
+    
+    @staticmethod
+    def match_string(pattern, string, flags=0):
+        return re.fullmatch(pattern, string, flags)
+
+    # Compares the msg with the sound triggers to determine if there is a match
+    # --This function is only called from other functions running as their own threads.--
+    def find_sound_trigger(self, msg):
+        self.trigger = None
+        self.soundFile = None
+        msg_lower = msg.lower()
+        match_msg = msg_lower.replace(':()?', '')
+        sound_dict = 0
+        while sound_dict < len(self.Enabled_SoundPacks):
+            if self.Enabled_SoundPacks[sound_dict]:
+                if self._enable_dictionary:
+                    if msg_lower[0] in self._sound_dictionary[sound_dict]:
+                        for sound, item in self._sound_dictionary[sound_dict][msg_lower[0]].items():
+                            match = item.split(";")
+                            try:
+                                # if sound trigger matches set self.trigger to the trigger,
+                                #  self.soundFile to the location of the sound
+                                if self.match_string(match[0], match_msg):
+                                    if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                        return False
+                                    self.trigger = sound
+                                    if match[1]:
+                                        self.soundFile = match[1]
+                                    return True
+                            except Exception as e:
+                                minqlxtended.console_print("^3myFun find sound trigger dictionary Exception: {}\n{}"
+                                                     .format(type(e).__name__, traceback.format_exc()))
+                else:
+                    keys = self.db.keys(SOUND_TRIGGERS.format(sound_dict, "*"))
+                    for key in keys:
+                        match = self.db.get(key).split(";")
+                        # if sound trigger matches set self.trigger to the trigger,
+                        #  self.soundFile to the location of the sound
+                        try:
+                            if self.match_string(match[0], match_msg):
+                                if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                    return False
+                                self.trigger = key.split(":")[4]
+                                if match[1]:
+                                    self.soundFile = match[1]
+                                return True
+                            # if custom sound triggers have been added for the sound being examined
+                            #  it searches through the stored triggers for a match
+                            if self.db.exists(TRIGGERS_LOCATION.format(match[1])):
+                                for trigger in self.db.lrange(TRIGGERS_LOCATION.format(match[1]), 0, -1):
+                                    if trigger == match_msg:
+                                        if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                            return False
+                                        self.trigger = key.split(":")[-1]
+                                        if match[1]:
+                                            self.soundFile = match[1]
+                                        return True
+                        except Exception as e:
+                            minqlxtended.console_print("^3myFun find sound trigger database Exception: {}\n{}"
+                                                 .format(type(e).__name__, traceback.format_exc()))
+                # if custom sound triggers have been added for the sound being examined
+                #  it searches through the stored triggers for a match
+                try:
+                    for file, triggers in self._custom_triggers.items():
+                        if msg_lower in triggers:
+                            if self.db.exists(DISABLED_SOUNDS.format(file)):
+                                return False
+                            self.trigger = msg_lower
+                            self.soundFile = file
+                            return True
+                except Exception as e:
+                    minqlxtended.console_print("^3myFun find Custom sound trigger Exception: {}\n{}"
+                                         .format(type(e).__name__, traceback.format_exc()))
+            sound_dict += 1
+        return False
+
+    def add_trigger(self, player, msg, channel):
+        self.add_custom_trigger(player, msg)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    def add_custom_trigger(self, player, msg):
+        if len(msg) < 3:
+            player.tell("^3usage^7: ^1{}addtrigger ^7<^2default trigger^7> ^1= ^7<^4added trigger^7>"
+                        .format(self._command_prefix))
+            return minqlxtended.Return.STOP_ALL
+        msg_lower = [x.lower() for x in msg]
+        split = 0
+        count = 0
+        for item in msg_lower[1:]:
+            count += 1
+            if item == "=":
+                split = count
+                break
+        if split == 0:
+            player.tell("^7You MUST include a ^1= ^7sign in to separate the default trigger from the desired trigger.")
+            player.tell("^3usage^7: ^1{}addtrigger ^7<^2default trigger^7> ^1= ^7<^4added trigger^7>"
+                        .format(self._command_prefix))
+        else:
+            trigger = " ".join(msg_lower[1:split])
+            add_trigger = " ".join(msg_lower[split + 1:])
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(TRIGGERS_LOCATION.format(found_path)):
+                    for existing_trigger in self.db.lrange(TRIGGERS_LOCATION.format(found_path), 0, -1):
+                        if existing_trigger == add_trigger:
+                            player.tell("^3This trigger already exists")
+                            return minqlxtended.Return.STOP_ALL
+                self.db.rpush(TRIGGERS_LOCATION.format(found_path), add_trigger)
+                if self._enable_dictionary:
+                    try:
+                        if add_trigger not in self._custom_triggers[found_path]:
+                            self._custom_triggers[found_path].append(add_trigger)
+                    except KeyError:
+                        self._custom_triggers[found_path] = []
+                        self._custom_triggers[found_path].append(add_trigger)
+                    except Exception as e:
+                        minqlxtended.console_print("^3myFun add custom trigger Exception: {}\n{}"
+                                             .format(type(e).__name__, traceback.format_exc()))
+                player.tell("^3The sound trigger ^4{0} ^3has been added to the trigger list for ^2{1}."
+                            .format(add_trigger, trigger))
+                return minqlxtended.Return.STOP_ALL
+            else:
+                player.tell("^3usage^7: ^1{}addtrigger ^7<^2default trigger^7> ^1= ^7<^4added trigger^7>"
+                            .format(self._command_prefix))
+        return minqlxtended.Return.STOP_ALL
+
+    def del_trigger(self, player, msg, channel):
+        self.del_custom_trigger(player, msg)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    def del_custom_trigger(self, player, msg):
+        if len(msg) < 3:
+            player.tell("^3usage^7: ^1!deltrigger ^7<^2default trigger^7> ^1= ^7<^4delete trigger^7>")
+            return minqlxtended.Return.STOP_ALL
+        msg_lower = [x.lower() for x in msg]
+        split = 0
+        count = 0
+        for item in msg_lower[1:]:
+            count += 1
+            if item == "=":
+                split = count
+                break
+        if split == 0:
+            player.tell("^7You MUST include a ^1= ^7sign in to separate the default trigger from the desired trigger.")
+            player.tell("^3usage^7: ^1{}deltrigger ^7<^2default trigger^7> ^1= ^7<^4del trigger^7>"
+                        .format(self._command_prefix))
+        else:
+            trigger = " ".join(msg_lower[1:split])
+            del_trigger = " ".join(msg_lower[split + 1:])
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(TRIGGERS_LOCATION.format(found_path)):
+                    self.db.lrem(TRIGGERS_LOCATION.format(found_path), 0, del_trigger)
+                    if self._enable_dictionary:
+                        try:
+                            if del_trigger in self._custom_triggers[found_path]:
+                                self._custom_triggers[found_path].remove(del_trigger)
+                        except ValueError:
+                            pass
+                        except Exception as e:
+                            minqlxtended.console_print("^3myFun del custom trigger Exception: {}\n{}"
+                                                 .format(type(e).__name__, traceback.format_exc()))
+                    player.tell("^3The sound trigger ^4{0} ^3has been deleted from the trigger list for ^2{1}."
+                                .format(del_trigger, trigger))
+                else:
+                    player.tell("^3There are no custom triggers saved for ^4{}".format(trigger))
+            else:
+                player.tell("^3usage^7: ^1{}deltrigger ^7<^2default trigger^7> ^1= ^7<^4del trigger^7>"
+                            .format(self._command_prefix))
+        return minqlxtended.Return.STOP_ALL
+
+    def request_triggers(self, player, msg, channel):
+        self.list_triggers(player, msg)
+
+    @minqlxtended.thread
+    def list_triggers(self, player, msg):
+        if len(msg) > 1:
+            msg_lower = [x.lower() for x in msg]
+            trigger = " ".join(msg_lower[1:])
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(TRIGGERS_LOCATION.format(found_path)):
+                    if self.db.llen(TRIGGERS_LOCATION.format(found_path)) == 0:
+                        player.tell("^3There are no custom triggers saved for ^4{}".format(trigger))
+                        return minqlxtended.Return.STOP_ALL
+                    else:
+                        triggers = self.db.lrange(TRIGGERS_LOCATION.format(found_path), 0, -1)
+                        self.msg("^3The custom sound triggers for ^4{0}^7: ^2{1}".format(trigger, ", ".join(triggers)))
+                        return
+                else:
+                    player.tell("^3There are no custom triggers saved for ^4{}".format(trigger))
+            else:
+                player.tell("^3There are no custom sound triggers for ^2{}^7.".format(trigger))
+            return minqlxtended.Return.STOP_ALL
+        else:
+            message = ["^3Custom Triggers:"]
+            triggers = self.db.keys(TRIGGERS_LOCATION.format("*"))
+            for item in triggers:
+                trigger = self.sound_trigger(item.split(":")[3])
+                custom_triggers = self.db.lrange(item, 0, 100)
+                message.append("^1{}:\n^2   {}".format(trigger, "^7, ^2".join(custom_triggers)))
+            player.tell("\n".join(message))
+            return minqlxtended.Return.STOP_ALL
+
+    # players can turn off individual sounds for only themselves
+    def sound_off(self, player, msg, channel):
+        self.cmd_sound_off(player, msg)
+
+    @minqlxtended.thread
+    def cmd_sound_off(self, player, msg):
+        if len(msg) < 2:
+            if self.soundFile:
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, self.soundFile)):
+                    player.tell("^3The sound ^4{0} ^3is already disabled. Use ^1{1}on ^4{0} ^3to enable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(self.trigger, self._command_prefix))
+                else:
+                    self.db.set(PLAYERS_SOUNDS.format(player.steam_id, self.soundFile), 1)
+                    if not self.trigger:
+                        self.find_sound_trigger(self.soundFile)
+                    player.tell("^3The sound ^4{0} ^3has been disabled. Use ^1{1}on ^4{0} ^3to enable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(self.trigger, self._command_prefix))
+            else:
+                player.tell("^1{0}off <sound call> ^7use ^6{0}listsounds #help ^7to find triggers"
+                            .format(self._command_prefix))
+
+        else:
+            trigger = " ".join(msg[1:]).lower()
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, found_path)):
+                    player.tell("^3The sound ^4{0} ^3is already disabled. Use ^1{1}on ^4{0} ^3to enable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(trigger, self._command_prefix))
+                else:
+                    self.db.set(PLAYERS_SOUNDS.format(player.steam_id, found_path), 1)
+                    player.tell("^3The sound ^4{0} ^3has been disabled. Use ^1{1}on ^4{0} ^3to enable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(trigger, self._command_prefix))
+            else:
+                player.tell("^3usage: ^1{0}off <sound call> ^7use ^1{0}listsounds #help ^7to find triggers"
+                            .format(self._command_prefix))
+        return
+
+    # players can re-enable sounds that they previously disabled for themselves
+    def sound_on(self, player, msg, channel):
+        self.cmd_sound_on(player, msg)
+
+    @minqlxtended.thread
+    def cmd_sound_on(self, player, msg):
+        if len(msg) < 2:
+            if self.soundFile:
+                if not self.trigger:
+                    self.find_sound_trigger(self.soundFile)
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, self.soundFile)):
+                    del self.db[PLAYERS_SOUNDS.format(player.steam_id, self.soundFile)]
+                    player.tell("^3The sound ^4{0} ^3has been enabled. Use ^1{1}off ^4{0} ^3to disable."
+                                .format(self.trigger, self._command_prefix))
+                else:
+                    player.tell("^3The sound ^4{0} ^3is not disabled. Use ^1{1}off ^4{0} ^3to disable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(self.trigger, self._command_prefix))
+            else:
+                player.tell("^1{0}on <sound call> ^7use ^1{0}listsounds #help ^7to find triggers"
+                            .format(self._command_prefix))
+
+        else:
+            trigger = " ".join(msg[1:]).lower()
+            found_path = self.find_sound_path(trigger)
+            if found_path:
+                if self.db.exists(PLAYERS_SOUNDS.format(player.steam_id, found_path)):
+                    del self.db[PLAYERS_SOUNDS.format(player.steam_id, found_path)]
+                    player.tell("^3The sound ^4{0} ^3has been enabled. Use ^1{1}off ^4{0} ^3to disable."
+                                .format(trigger, self._command_prefix))
+                else:
+                    player.tell("^3The sound ^4{0} ^3is not disabled. Use ^1{1}off ^4{0} ^3to disable."
+                                " ^1{1}offlist ^3to see sounds you have disabled."
+                                .format(trigger, self._command_prefix))
+            else:
+                player.tell("^3usage: ^1{0}on <sound call> ^7use ^1{0}listsounds #help ^7to find triggers"
+                            .format(self._command_prefix))
+        return
+
+    # return the path to the supplied sound trigger
+    def find_sound_path(self, trigger):
+        sound_dict = 0
+        while sound_dict < len(self.Enabled_SoundPacks):
+            if self.Enabled_SoundPacks[sound_dict]:
+                keys = self.db.keys(SOUND_TRIGGERS.format(sound_dict, "*"))
+                for key in keys:
+                    if key.split(":")[4] == trigger:
+                        return self.db.get(key).split(";")[1]
+            sound_dict += 1
+
+        return False
+
+    # return the sound trigger for the sound at the supplied path
+    def sound_trigger(self, _path, disabled_lookup=False):
+        sound_dict = 0
+        while sound_dict < len(self.Enabled_SoundPacks):
+            if self.Enabled_SoundPacks[sound_dict]:
+                if not self._enable_dictionary or disabled_lookup:
+                    keys = self.db.keys(SOUND_TRIGGERS.format(sound_dict, "*"))
+                    for key in keys:
+                        if self.db.get(key).split(";")[1] == _path:
+                            return key.split(":")[4]
+                else:
+                    for sub, triggers in self._sound_dictionary[sound_dict].items():
+                        for sound, item in self._sound_dictionary[sound_dict][sub].items():
+                            if item.split(";")[1] == _path:
+                                return sound
+            sound_dict += 1
+
+        return None
+
+    def cmd_sound_off_list(self, player, msg, channel):
+        self.sound_off_list(player)
+
+    @minqlxtended.thread
+    # list the disabled sound to the requesting player
+    def sound_off_list(self, player):
+        try:
+            disabled_key = "minqlx:players:{0}:flags:myFun".format(player.steam_id)
+            sound_list = []
+            count = 0
+            _list = self.db.keys(disabled_key + ":*")
+            for key in _list:
+                trigger = self.sound_trigger(key.split(":")[-1])
+                if trigger:
+                    trigger = trigger.replace('?', '')
+                    sound_list.append(trigger)
+                    count += 1
+            player.tell("^3You have ^4{0} ^3sounds disabled: ^1{1}".format(count, "^7, ^1".join(sound_list)))
+            return
+        except Exception as e:
+            player.tell("^1Sound off list exception. See minqlxtended log for details")
+            minqlxtended.console_print("^1myFun sound_off_list exception: {}\n{}"
+                                 .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_disable_sound(self, player, msg, channel):
+        self.disable_sound(player, msg, channel)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    # disable the specified sound on the server
+    def disable_sound(self, player, msg, channel):
+        try:
+            if len(msg) < 2:
+                return
+            trigger = " ".join(msg[1:]).lower()
+            sound_path = self.find_sound_path(trigger)
+            if sound_path:
+                self.db.set(DISABLED_SOUNDS.format(sound_path), 1)
+                player.tell("^3The sound ^4{} ^3is now disabled.".format(trigger))
+                self.populate_sound_lists()
+            else:
+                player.tell("^3Invalid sound trigger. Use ^1{}ls ^7<^1search string^7>"
+                            " ^3to find the correct sound trigger.".format(self._command_prefix))
+            return
+        except Exception as e:
+            player.tell("^1Disable sound exception. See minqlxtended log for details")
+            minqlxtended.console_print("^1myFun disable_sound exception: {}\n{}"
+                                 .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_enable_sound(self, player, msg, channel):
+        self.enable_sound(player, msg)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    # enable the specified sound on the server
+    def enable_sound(self, player, msg):
+        if len(msg) < 2:
+            return
+        trigger = " ".join(msg[1:]).lower()
+        sound_path = self.find_sound_path(trigger)
+        if sound_path:
+            try:
+                if self.db.exists(DISABLED_SOUNDS.format(sound_path)):
+                    del self.db[DISABLED_SOUNDS.format(sound_path)]
+                    self.populate_sound_lists()
+                    player.tell("^3The sound ^1{} ^3is now enabled".format(trigger))
+                else:
+                    player.tell("^3The sound ^1{} ^3is not disabled. ^1{}ld ^3to see the disabled sounds."
+                                .format(trigger, self._command_prefix))
+            except Exception as e:
+                player.tell("^1Enable sound exception when finding trigger {}. See minqlxtended log for details"
+                            .format(trigger))
+                minqlxtended.console_print("^1myFun enable_sound exception: {}\n{}"
+                                     .format(type(e).__name__, traceback.format_exc()))
+        else:
+            player.tell("^3The sound trigger ^4{} ^3was not found. Ensure the trigger supplied is correct."
+                        " ^1{}ld ^3to see the disabled sounds."
+                        .format(trigger, self._command_prefix))
+        return minqlxtended.Return.STOP_ALL
+
+    def cmd_list_disabled(self, player, msg, channel):
+        player.tell("^2Retrieving Disabled Sounds from the database.")
+        self.list_disabled(player)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    # list the sounds disabled on the server for the requesting player
+    def list_disabled(self, player):
+        try:
+            sound_list = []
+            count = 0
+            for key in self.db.keys("minqlx:myFun:disabled:*"):
+                sound_path = key.split(":")[-1]
+                trigger = self.sound_trigger(sound_path, True)
+                if not trigger:
+                    continue
+                sound_list.append(trigger)
+                count += 1
+            if count:
+                player.tell("^3There {} ^4{} ^3sound{} disabled on the server:\n^1{}"
+                            .format('is' if count == 1 else 'are', count, '' if count == 1 else 's',
+                                    "\n^1".join(sound_list)))
+            else:
+                player.tell("^3There are ^4No ^3disabled sounds on this server.")
+            return
+        except Exception as e:
+            player.tell("^1myFun exception listing disabled sounds.\n"
+                        "^7You may want to erase stored disabled sounds with {}ed"
+                        .format(self._command_prefix))
+            minqlxtended.console_print("^1myFun list_disabled exception (? erase stored disabled sounds with {}ed ?): {}\n{}"
+                                 .format(self._command_prefix, type(e).__name__, traceback.format_exc()))
+
+    def erase_disabled(self, player, msg, channel):
+        player.tell("^3Erasing all Disabled sounds from the database.")
+        self.fix_disabled(player, True)
+        return minqlxtended.Return.STOP_ALL
+
+    # function to change the way the disabled sounds are stored in the database
+    @minqlxtended.thread
+    def fix_disabled(self, player=None, erase_all=False):
+        try:
+            if erase_all:
+                for key in self.db.keys("minqlx:myFun:disabled:*"):
+                    del self.db[key]
+                self.populate_sound_lists()
+                if player:
+                    player.tell("^2All Disabled sounds have been removed from the database.")
+                minqlxtended.console_print("^3All Disabled sounds have been removed from the database.")
+            else:
+                for key in self.db.keys("minqlx:myFun:disabled:*"):
+                    try:
+                        trigger = key.split(":")[-1]
+                        sound_path = self.find_sound_path(trigger)
+                        if sound_path:
+                            self.db.set(DISABLED_SOUNDS.format(sound_path), 1)
+                        del self.db[DISABLED_SOUNDS.format(trigger)]
+                    except:
+                        continue
+        except Exception as e:
+            minqlxtended.console_print("^1myFun fix_disabled exception: {}\n{}"
+                                 .format(type(e).__name__, traceback.format_exc()))
+
+    # play the sound at the supplied path
+    def cmd_sound(self, player, msg, channel):
+        self.exec_sound(player, msg, channel)
+        return minqlxtended.Return.STOP_ALL
+
+    @minqlxtended.thread
+    def exec_sound(self, player, msg, channel):
+        if len(msg) < 2:
+            player.tell("^3Include a path/sound to play.")
+            return
+
+        if "console" != channel and not self.db.get_flag(player, "essentials:sounds_enabled", default=True):
+            player.tell("^1Your sounds are disabled. Use ^6{}sounds ^1to enable them again."
+                        .format(self._command_prefix))
+            minqlxtended.console_print("^3Admin {} tried calling sound {} but player's sounds are disabled."
+                                 .format(player, msg[1]))
+            return
+
+        try:
+            play_time = time.time() - self.admin_limiting[player.steam_id]
+            if play_time >= self.get_cvar("qlx_funAdminSoundCall", int):
+                stop = False
+            else:
+                stop = self.get_cvar("qlx_funAdminSoundCall", int) - play_time
+        except KeyError:
+            stop = False
+
+        if stop is not False:
+            minqlxtended.console_print("^3Admin {} tried calling sound {} before timeout expired.".format(player, msg[1]))
+            player.tell("^3You have {} seconds before you can call another sound.".format(int(stop)))
+        else:
+            # check for a valid sound file
+            self.checking_file = True
+            self.file_status = False
+            minqlxtended.console_command("fdir {}".format(msg[1]))
+            count = 0
+            while count < 10 and not self.file_status:
+                count += 1
+                time.sleep(0.1)
+            self.checking_file = False
+            if not self.file_status:
+                player.tell("^1Sound ^4{} ^1is not valid.".format(msg[1]))
+                return
+
+            if "console" == channel:
+                minqlxtended.console_print("^1Playing sound^7: ^4{}".format(msg[1]))
+                self.play_sound(msg[1])
+                return
+            minqlxtended.console_print("^3Admin {} called sound {}".format(player, msg[1]))
+            self.admin_limiting[player.steam_id] = time.time()
+            self.play_sound(msg[1])
+        return
+
+    def cmd_play_trigger(self, player, msg, channel):
+        self.play_trigger(player, msg, channel)
+        return minqlxtended.Return.STOP_ALL
+
+    # play the sound associated with the trigger
+    @minqlxtended.thread
+    def play_trigger(self, player, msg, channel):
+        if len(msg) < 2:
+            player.tell("Include a sound trigger.")
+            return
+
+        msg_lower = " ".join(msg[1:]).lower()
+
+        if "console" != channel and not self.db.get_flag(player, "essentials:sounds_enabled", default=True):
+            player.tell("Your sounds are disabled. Use ^6{}sounds^7 to enable them again."
+                        .format(self._command_prefix))
+            return
+
+        sound = self.get_sound_trigger(msg_lower)
+
+        # Play locally to validate.
+        if not sound or "console" != channel and not super().play_sound(sound, player):
+            player.tell("^1Invalid sound.")
+            return
+
+        if "console" == channel:
+            minqlxtended.console_print("^1Playing sound^7: ^4{}".format(msg_lower))
+
+        self.play_sound(sound)
+
+        return
+
+    # Compares the msg with the sound triggers to determine if there is a match
+    def get_sound_trigger(self, msg_lower):
+        sound_dict = 0
+        while sound_dict < len(self.Enabled_SoundPacks):
+            if self.Enabled_SoundPacks[sound_dict]:
+                keys = self.db.keys(SOUND_TRIGGERS.format(sound_dict, "*"))
+                for key in keys:
+                    match = self.db.get(key).split(";")
+                    # if sound trigger matches set self.trigger to the trigger,
+                    #  self.soundFile to the location of the sound
+                    try:
+                        if self.match_string(match[0], msg_lower):
+                            if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                return None
+                            return match[1]
+                        # if custom sound triggers have been added for the sound being examined
+                        #  it searches through the stored triggers for a match
+                        if self.db.exists(TRIGGERS_LOCATION.format(match[1])):
+                            for trigger in self.db.lrange(TRIGGERS_LOCATION.format(match[1]), 0, -1):
+                                if trigger == msg_lower:
+                                    if self.db.exists(DISABLED_SOUNDS.format(match[1])):
+                                        return None
+                                    return match[1]
+                    except Exception as e:
+                        minqlxtended.console_print("^3myFun get_sound_trigger Exception: {}\n{}"
+                                             .format(type(e).__name__, traceback.format_exc()))
+            sound_dict += 1
+        return None
+
+    # plays the supplied sound for the players on the server (if the player has the sound(s) enabled)
+    def play_sound(self, _path, player=None):
+        play = self.last_2_sound()
+        active = self.game.state in ["in_progress", "countdown"]
+        if play == 3 or not active:
+            self.played = True
+            self.last_sound = time.time()
+            targets = [p for p in self.players()
+                       if self.db.get_flag(p, "essentials:sounds_enabled", default=True)
+                       and not self.db.exists(PLAYERS_SOUNDS.format(p.steam_id, _path))]
+        elif play == 1 or (play == 2 and active):
+            self.played = True
+            self.last_sound = time.time()
+            teams = self.teams()
+            targets = [p for p in teams["red"] + teams["blue"] + teams["free"]
+                       if not p.is_alive
+                       and self.db.get_flag(p, "essentials:sounds_enabled", default=True)
+                       and not self.db.exists(PLAYERS_SOUNDS.format(p.steam_id, _path))]
+            targets += [p for p in teams["spectator"]
+                        if self.db.get_flag(p, "essentials:sounds_enabled", default=True)
+                        and not self.db.exists(PLAYERS_SOUNDS.format(p.steam_id, _path))]
+        else:
+            return
+
+        # dispatch send_server_command to the game frame — must not be called from a background thread
+        @minqlxtended.next_frame
+        def _send(pts=targets, path=_path):
+            for p in pts:
+                super(myFun, self).play_sound(path, p)
+        _send()
+
+    def last_2_sound(self):
+        # 0 = don't play sound for anyone when the last 2 (or  1 on either team of a team based game) remains
+        # 1 = play sound for all except those alive when the last 2 (or  1 on either team of a team based game) remains
+        # 2 = only play sounds for people who are dead/spectating when game is active
+        # 3 = play sound for everyone with sounds enabled
+        play_last2 = self.get_cvar("qlx_funLast2Sound", int)
+        if play_last2 in [2, 3]:
+            return play_last2
+        teams = self.teams()
+        remaining = 0
+        if self.game.type_short in TEAM_BASED_GAMETYPES:
+            r_remaining = 0
+            b_remaining = 0
+            for r in teams["red"]:
+                if r.is_alive:
+                    r_remaining += 1
+            for b in teams["blue"]:
+                if b.is_alive:
+                    b_remaining += 1
+            if r_remaining == 1 or b_remaining == 1:
+                remaining = 2
+        else:
+            for p in teams["free"]:
+                if p.is_alive:
+                    remaining += 1
+        if remaining == 2:
+            return play_last2
+        else:
+            return 3
+
+    # populates the sound list that is used to list the available sounds on the server
+    # All calls to this function are called in sub-threads
+    def populate_sound_lists(self, player=None):
+        try:
+            if not self.populating:
+                self.populating = True
+                self.soundLists = [[] if x else None for x in self.Enabled_SoundPacks]
+                self.sound_list_count = 0
+                self._total_sounds = 0
+                self.help_msg = []
+                custom_triggers = {}
+                for slot, value in enumerate(self.Enabled_SoundPacks):
+                    if self.Enabled_SoundPacks[slot]:
+                        self.sound_list_count += 1
+                        self.help_msg.append(self.categories[slot])
+                        keys = self.db.keys(SOUND_TRIGGERS.format(slot, "*"))
+                        for key in keys:
+                            db_value = self.db.get(key)
+                            self._total_sounds += 1
+                            entry = db_value.split(';')
+                            if len(entry) < 2:
+                                del self.db[key]
+                                continue
+                            if self.db.exists(DISABLED_SOUNDS.format(entry[1])):
+                                continue
+                            trigger = key.split(":")[4]
+                            self.soundLists[slot].append(trigger)
+                            if self._enable_dictionary:
+                                matches = entry[0].split('|')
+                                for match in matches:
+                                    if not match:
+                                        continue
+                                    _m = match[0].lower()
+                                    if not _m.isalpha():
+                                        custom_triggers[match] = entry[1]
+                                        continue
+                                    if _m not in self._sound_dictionary[slot]:
+                                        self._sound_dictionary[slot][_m] = {}
+                                    self._sound_dictionary[slot][_m][match] = "{};{}".format(match, entry[1])
+                                if self.db.exists(TRIGGERS_LOCATION.format(entry[1])):
+                                    self._custom_triggers[entry[1]] = self.db.lrange(TRIGGERS_LOCATION.format(entry[1]), 0, -1)
+                        self.soundLists[slot].sort()
+                        self.category_loaded(slot, 'Quick Lookup Dictionary', player)
+                if custom_triggers:
+                    for match, entry in custom_triggers.items():
+                        if entry not in self._custom_triggers:
+                            self._custom_triggers[entry] = []
+                        self._custom_triggers[entry].append(match)
+            sound_packs = []
+            count = 0
+            while count < len(self.Enabled_SoundPacks):
+                if self.Enabled_SoundPacks[count]:
+                    sound_packs.append(self.soundPacks[count])
+                count += 1
+            if player:
+                player.tell("Enabled Sound Packs are: ^3{}".format(", ".join(sound_packs)))
+                player.tell("Completed Sound Pack reload.")
+            else:
+                minqlxtended.console_print("Enabled Sound Packs are: ^3{}".format(", ".join(sound_packs)))
+                minqlxtended.console_print("Completed Sound Pack reload.")
+        except Exception as e:
+            minqlxtended.console_print("myFun populate_sound_lists Exception: {}\n{}"
+                                 .format(type(e).__name__, traceback.format_exc()))
+        finally:
+            self.populating = False
+
+    def cmd_cookies(self, player, msg, channel):
+        x = random.randint(0, 100)
+        if not x:
+            channel.reply("^6♥ ^7Here you go, {}. I baked these just for you! ^6♥".format(player))
+        elif x == 1:
+            channel.reply("What, you thought ^6you^7 would get cookies from me, {}? Hah, think again.".format(player))
+        elif x < 50:
+            channel.reply("For me? Thank you, {}!".format(player))
+        else:
+            channel.reply("I'm out of cookies right now, {}. Sorry!".format(player))
+
+    ''' Here in case the essentials plugin is not loaded '''
+    def cmd_enable_sounds(self, player, msg, channel):
+        if "essentials" not in self._loaded_plugins:
+            flag = self.db.get_flag(player, "essentials:sounds_enabled", default=True)
+            self.db.set_flag(player, "essentials:sounds_enabled", not flag)
+
+            if flag:
+                player.tell("Sounds have been disabled. Use ^6{}sounds^7 to enable them again."
+                            .format(self._command_prefix))
+            else:
+                player.tell("Sounds have been enabled. Use ^6{}sounds^7 to disable them again."
+                            .format(self._command_prefix))
+
+            return minqlxtended.Return.STOP_ALL
+
+    def check_time(self, player):
+        if self.get_cvar("qlx_funUnrestrictAdmin", bool) and self.db.get_permission(player.steam_id) == 5:
+            return False
+        try:
+            saved_time = self.sound_limiting[player.steam_id]
+            play_time = time.time() - saved_time
+            if play_time > self.get_cvar("qlx_funPlayerSoundRepeat", int):
+                return False
+            else:
+                return int(self.get_cvar("qlx_funPlayerSoundRepeat", int) - play_time)
+        except KeyError:
+            return False
+
+    # list the command usage for !listsounds
+    def cmd_help(self, player, msg=None, channel=None):
+        count = 0
+        help_msg = ''
+        for msg in self.help_msg:
+            if not help_msg:
+                help_msg = msg
+            elif not count % 6:
+                help_msg = help_msg + "^7,\n^2" + msg
+            else:
+                help_msg = help_msg + "^7, ^2" + msg
+            count += 1
+        player.tell("^1myFun Version {0}\n"
+                    "^6{1}myFun ^3to quickly pull up this help menu.\n"
+                    "^6{1}listsounds ^3shows all sounds\n^6{1}listsounds #sound-pack ^3 to see just one sound"
+                    " pack\n^6{1}listsounds #sound-pack search-term ^3to see sounds in that sound pack that"
+                    " have the search term\n^6{1}listsounds search-term ^3to search all sound packs for sounds"
+                    " with that search term\n^2EXAMPLES^7:\n^6{1}listsounds #Default ^3 will display all"
+                    " ^4Default Quake Live Sounds\n^6{1}lsitsounds #Default yeah ^3 will search ^4#Default"
+                    " ^3for sounds containing ^4yeah\n^6{1}listsounds yeah ^3 will search all the sound packs"
+                    " for sounds containing ^4yeah\n^3Search terms can be multiple words\n"
+                    "^3Valid sound-pack(s) are^7:\n^2{2}\n^6{1}sounds ^3to disable^7/^3enable"
+                    " all sound playing for yourself."
+                    "\n^6{1}off^7/^6{1}on trigger ^3to disable^7/^3enable a specific sound\n^6{1}offlist ^3to see a"
+                    " list of sounds you have disabled."
+                    .format(VERSION, self._command_prefix, help_msg))
+        return
+
+    # list the command usage for !listsounds
+    def listsounds_usage(self, player):
+        if self._total_sounds:
+            count = 0
+            help_msg = ''
+            for msg in self.help_msg:
+                if not help_msg:
+                    help_msg = msg
+                elif not count % 6:
+                    help_msg = help_msg + "^7,\n^2" + msg
+                else:
+                    help_msg = help_msg + "^7, ^2" + msg
+                count += 1
+            player.tell("^1There are {2} sounds available to play.\n"
+                        "^4Include a category and/or search value for {0}listsounds\n"
+                        "^5Ex: ^4{0}listsounds #default pain\n"
+                        "^3Valid sound-pack(s) are^7:\n^2{1}\n"
+                        .format(self._command_prefix, help_msg, self._total_sounds))
+        else:
+            player.tell("^1There are no sounds loaded")
+        return
+
+    # list the available sounds to the requesting player
+    def list_sounds(self, player, msg, channel):
+        self.cmd_list_sounds(player, msg, channel)
+
+    @minqlxtended.thread
+    def cmd_list_sounds(self, player, msg, channel):
+        sounds = ["^4SOUNDS^7: ^3Type these words/phrases in normal chat to play a sound on the server.\n"]
+        length = len(msg)
+        count = 0
+        category = None
+        search = None
+        if length == 2 and msg[1]:
+            if msg[1].startswith("#"):
+                category = msg[1]
+            else:
+                search = msg[1]
+        elif length > 2 and msg[1]:
+            if msg[1].startswith("#"):
+                category = msg[1]
+                search = " ".join(msg[2:])
+            else:
+                search = " ".join(msg[1:])
+        else:
+            self.listsounds_usage(player)
+            return
+
+        if category:
+            category = category.lower()
+            if category == "#help":
+                self.cmd_help(player)
+                return
+            elif any(s.lower() == category for s in self.help_msg):
+                category_num = -1
+                cat_num = 0
+                while cat_num < len(self.categories):
+                    if self.match_string(self.categories[cat_num].lower(), category):
+                        category_num = cat_num
+                    cat_num += 1
+
+                if -1 < category_num < len(self.Enabled_SoundPacks):
+                    sounds_line = ""
+                    sounds.append("^4" + self.soundPacks[category_num] + "\n")
+                    for item in self.soundLists[category_num]:
+                        if search and search not in item:
+                            continue
+                        add_sound, status = self.line_up(sounds_line, item)
+                        if status == 1:
+                            sounds.append("^1" + sounds_line + "\n")
+                            sounds_line = add_sound
+                        elif status == 2:
+                            sounds_line += add_sound
+                            sounds.append("^1" + sounds_line + "\n")
+                            sounds_line = ""
+                        else:
+                            sounds_line += add_sound
+                        count += 1
+                    if len(sounds_line):
+                        sounds.append("^1" + sounds_line + "\n")
+
+                if count == 0:
+                    sounds.append("^3No Matches\n")
+            else:
+                if self.sound_list_count == 1:
+                    player.tell("^3INVALID ^2Category ^7given. Valid category is ^2" + "^7, ^2".join(self.help_msg))
+                else:
+                    player.tell("^3INVALID ^2Category ^7given. Valid categories are ^2" + "^7, ^2".join(self.help_msg))
+                return
+
+        else:
+            slot = 0
+            while slot < len(self.Enabled_SoundPacks):
+                sounds_line = ""
+                if self.Enabled_SoundPacks[slot]:
+                    found = 0
+                    if self.soundLists[slot]:
+                        sounds.append("^4" + self.soundPacks[slot] + "\n")
+                        for item in self.soundLists[slot]:
+                            if search and search not in item:
+                                continue
+                            add_sound, status = self.line_up(sounds_line, item)
+                            if status == 1:
+                                sounds.append("^1" + sounds_line + "\n")
+                                sounds_line = add_sound
+                            elif status == 2:
+                                sounds_line += add_sound
+                                sounds.append("^1" + sounds_line + "\n")
+                                sounds_line = ""
+                            else:
+                                sounds_line += add_sound
+                            count += 1
+                            found += 1
+                    if len(sounds_line):
+                        sounds.append("^1" + sounds_line + "\n")
+                    if found == 0:
+                        sounds.append("^3No Matches\n")
+                slot += 1
+
+            if count == 0 and search:
+                player.tell("^4Server^7: No sounds contain the search string ^1{}^7.".format(search))
+                return
+            if count == 0:
+                player.tell("^4Server^7: No sounds were found")
+                return
+
+            if self.sound_list_count > 1 and not category and not search:
+                sounds.append("^3Type ^4{}listsounds #help ^3 to get instructions on narrowing your search results.\n"
+                              .format(self._command_prefix))
+            elif not search:
+                sounds.append("^3Add a search string to further narrow results:\n^2{0}listsounds ^7<^2category^7>"
+                              " <^2search string^7>".format(self._command_prefix))
+
+        sounds.append("^2{} ^4SOUND{}^7: ^3Type these words/phrases in normal chat to trigger a sound on the server.\n"
+                      .format(count, 'S' if count > 1 else ''))
+
+        if "console" == channel:
+            for line in sounds:
+                minqlxtended.console_print(line.strip())
+        else:
+            player.tell("".join(sounds))
+        return
+
+    # puts the list of sounds in a column style format for easier reading
+    def line_up(self, sound_line, add_sound):
+        length = len(sound_line)
+        # 0 = add to line, 1 = add to new line, 2 = add current sound and start new line
+        status = 0
+        if length + len(add_sound) > 78:
+            append = add_sound
+            status = 1
+        elif length == 0:
+            append = add_sound
+        elif length < 16:
+            append = " " * (18 - length) + add_sound
+        elif length < 36:
+            append = " " * (38 - length) + add_sound
+        elif length < 56:
+            append = " " * (58 - length) + add_sound
+        elif length < 76:
+            append = " " * (78 - length) + add_sound
+            status = 2
+        else:
+            append = add_sound
+            status = 1
+        return append, status
+
+    def category_loaded(self, cat_index, target, player=None):
+        if len(self.categories) > cat_index:
+            if player:
+                player.tell("^2Category {} loaded to {}".format(self.categories[cat_index], target))
+            else:
+                minqlxtended.console_print("^2Category {} loaded to {}".format(self.categories[cat_index], target))
+
+    # These are the sounds available on the server put into the dictionaries used to search for a sound trigger match
+    #  when processing normal chat messages
+    def populate_database(self, player=None):
+        old_version = 0.0
+        if self.db.exists("minqlx:myFun:version"):
+            old_version = self.db.get("minqlx:myFun:version")
+        self.db.set("minqlx:myFun:version", VERSION)
+        self.db.set("minqlx:myFun:enabled", self.get_cvar("qlx_funEnableSoundPacks"))
+        if float(old_version) < 4.2:
+            self.fix_disabled()
+        if self.Enabled_SoundPacks[0]:
+            self.db.set(SOUND_TRIGGERS.format(0, "battlesuit"), "battlesuit;sound/vo/battlesuit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(0, "bite"), "bite;sound/vo/bite.ogg")
+            self.db.set(SOUND_TRIGGERS.format(0, "combo kill"), "combo kill;sound/vo/combokill2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(0, "haha"), "haha;sound/player/lucy/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "haha yeah haha"), "haha,? yeah?,? haha;sound/player/biker/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "yeah hahaha"), "yeah?,? haha(ha)?;sound/player/razor/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death"), "death;sound/player/biker/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death2"), "death2;sound/player/bitterman/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death3"), "death3;sound/player/bones/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death4"), "death4;sound/player/doom/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death5"), "death5;sound/player/grunt/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death6"), "death6;sound/player/hunter/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death7"), "death7;sound/player/james/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death8"), "death8;sound/player/janet/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death9"), "death9;sound/player/keel/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death10"), "death10;sound/player/klesk/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death11"), "death11;sound/player/major/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death12"), "death12;sound/player/orbb/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death13"), "death13;sound/player/santa/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death14"), "death14;sound/player/sarge/death2.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death15"), "death15;sound/player/slash/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death16"), "death16;sound/player/sorlag/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death17"), "death17;sound/player/tankjr/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death18"), "death18;sound/player/uriel/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death19"), "death19;sound/player/visor/death3.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "death20"), "death20;sound/player/xaero/death1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "duahahaha"), "duahaha(?:ha)?;sound/player/keel/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "denied"), "denied;sound/vo/denied")
+            self.db.set(SOUND_TRIGGERS.format(0, "headshot"), "headshot;sound/vo/headshot")
+            self.db.set(SOUND_TRIGGERS.format(0, "hahaha"), "hahaha;sound/player/santa/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "glhf"), "gl ?hf|hf;sound/vo/crash_new/39_01.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "fall2"), "fall2;sound/player/santa/falling1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "f3"), "f3|press f3|ready( up)?;sound/vo/crash_new/36_04.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "holy shit"), "holy shit;sound/vo_female/holy_shit")
+            self.db.set(SOUND_TRIGGERS.format(0, "welcome to quake live"), "welcome to q(uake )?l(ive)?;sound/vo_evil/welcome")
+            self.db.set(SOUND_TRIGGERS.format(0, "gasp"), "gasp;sound/player/anarki/gasp.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "go"), "go;sound/vo/go")
+            self.db.set(SOUND_TRIGGERS.format(0, "beep boop"), "beep boop;sound/player/tankjr/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "you win"), "you win;sound/vo_female/you_win.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "you lose"), "you lose;sound/vo/you_lose.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "impressive"), "impressive;sound/vo_female/impressive1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "excellent"), "excellent;sound/vo_evil/excellent1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "balls out"), "ball'?s out;sound/vo_female/balls_out")
+            self.db.set(SOUND_TRIGGERS.format(0, "one frag left"), "one frag left;sound/vo/1_frag.ogg")
+            self.db.set(SOUND_TRIGGERS.format(0, "one"), "one;sound/vo_female/one")
+            self.db.set(SOUND_TRIGGERS.format(0, "two"), "two;sound/vo_female/two")
+            self.db.set(SOUND_TRIGGERS.format(0, "three"), "three;sound/vo_female/three")
+            self.db.set(SOUND_TRIGGERS.format(0, "fight"), "fight;sound/vo_evil/fight")
+            self.db.set(SOUND_TRIGGERS.format(0, "gauntlet"), "gauntlet;sound/vo_evil/gauntlet")
+            self.db.set(SOUND_TRIGGERS.format(0, "humiliation"), "humiliation;sound/vo_evil/humiliation1")
+            self.db.set(SOUND_TRIGGERS.format(0, "perfect"), "perfect;sound/vo_evil/perfect")
+            self.db.set(SOUND_TRIGGERS.format(0, "wah wah wah wah"), "wah wah wah( wah)?;sound/misc/yousuck")
+            self.db.set(SOUND_TRIGGERS.format(0, "ah ah ah ah"), "ah ah ah( ah)?;sound/player/slash/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "oink"), "oink;sound/player/sorlag/pain50_1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "argh"), "a+rgh;sound/player/doom/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "hah haha"), "hah haha;sound/player/hunter/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "woohoo"), "woohoo;sound/player/janet/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "quake live"), "ql|quake live;sound/vo_female/quake_live")
+            self.db.set(SOUND_TRIGGERS.format(0, "chaching"), "€|£|$|chaching;sound/misc/chaching")
+            self.db.set(SOUND_TRIGGERS.format(0, "uh ah"), "uh ah;sound/player/mynx/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "oohwee"), "ooh+wee;sound/player/anarki/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "erah"), "erah;sound/player/bitterman/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "yeahhh"), "yeahhh;sound/player/major/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "scream"), "scream;sound/player/bones/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "salute"), "salute;sound/player/sarge/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "squish"), "squish;sound/player/orbb/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "oh god"), "oh god;sound/player/ranger/taunt.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "pain"), "pain;sound/player/anarki/pain25_1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "pain2"), "pain2;sound/player/orbb/pain25_1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "pain3"), "pain3;sound/player/keel/pain50_1.wav")
+            self.db.set(SOUND_TRIGGERS.format(0, "snarl"), "snarl;sound/player/sorlag/taunt.wav")
+            self.category_loaded(0, 'database', player)
+        if self.Enabled_SoundPacks[1]:
+            self.db.set(SOUND_TRIGGERS.format(1, "assholes"), "assholes;soundbank/assholes.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "assshafter"), "assshafter|asshafter|ass shafter;soundbank/assshafterloud.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "babydoll"), "babydoll;soundbank/babydoll.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "barelymissed"), "barelymissed|barely;soundbank/barelymissed.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "belly"), "belly;soundbank/belly.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "bitch"), "bitch;soundbank/bitch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "blud"), "dtblud|blud;soundbank/dtblud.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "boats"), "boats;soundbank/boats.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "bobg"), "bobg|bob;soundbank/bobg.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "bogdog"), "bogdog;soundbank/bogdog.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "boom"), "boom;soundbank/boom.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "boom2"), "boom2;soundbank/boom2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "buk"), "buk|ibbukn;soundbank/buk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "bullshit"), "bull ?shit|bs;soundbank/bullshit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "butthole"), "butthole;soundbank/butthole.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "buttsex"), "buttsex;soundbank/buttsex.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cheeks"), "cheeks;soundbank/cheeks.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cocksucker"), "cocksucker|cs;soundbank/cocksucker.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "conquer"), "conquer;soundbank/conquer.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "countdown"), "countdown;soundbank/countdown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cum"), "cum;soundbank/cum.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cumming"), "cumming;soundbank/cumming.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "cunt"), "cunt;soundbank/cunt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "dirkfunk"), "dirkfunk|dirk;soundbank/dirkfunk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "disappointment"), "disappointment;soundbank/disappointment.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "drumset"), "drumset;soundbank/drumset.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "eat"), "eat;soundbank/eat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "eat me"), "eatme|eat me|byte me;soundbank/eatme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "fag"), "fag|homo(sexual)?;soundbank/fag.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "fingerass"), "fingerass;soundbank/fingerass.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "flash"), "flash(soul)?;soundbank/flash.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "fuckface"), "fuckface;soundbank/fuckface.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "fuckyou"), "fuckyou;soundbank/fuckyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "get emm"), "get ?emm?;soundbank/getemm.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "gonads"), "gonads|nads;soundbank/gonads.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "gtfo"), "gtfo;soundbank/gtfo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "hug it out"), "hug it out;soundbank/hugitout.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "idiot"), "idiot|andycreep|d3phx|gladiat0r;soundbank/idiot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "idiot2"), "idiot2;soundbank/idiot2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "it's time"), "it'?s time;soundbank/itstime.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "jeopardy"), "jeopardy;soundbank/jeopardy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "jerk off"), "jerk( ?off)?;soundbank/jerkoff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "killo"), "killo;soundbank/killo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "knocked"), "knocked;soundbank/knocked.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "ld3"), "die|ld3;soundbank/ld3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "liquidswords"), "liquid(swords)?;soundbank/liquid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "massacre"), "massacre;soundbank/massacre.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "mixer"), "mixer;soundbank/mixer.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "mjman"), "mjman|marijuanaman;soundbank/mjman.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "mmmm"), "mmmm;soundbank/mmmm.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "monty"), "monty;soundbank/monty.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "n8"), "n8;soundbank/n8.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "nikon"), "nikon?(guru)?;soundbank/nikon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "nina"), "nina;soundbank/nina.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "nthreem"), "nthreem;sound/vo_female/impressive1.wav")
+            self.db.set(SOUND_TRIGGERS.format(1, "olhip"), "olhip|hip;soundbank/hip.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "organic"), "org(anic)?;soundbank/organic.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "paintball"), "paintball;soundbank/paintball.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "pigfucker"), "pig ?fucker|pig fucker;soundbank/pigfer.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "popeye"), "popeye;soundbank/popeye.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "rosie"), "rosie;soundbank/rosie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "seaweed"), "seaweed;soundbank/seaweed.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "shit"), "shit;soundbank/shit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "sit"), "sit;soundbank/sit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "soulianis"), "soul(ianis)?;soundbank/soulianis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "spam"), "spam;soundbank/spam3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "stalin"), "stalin;soundbank/ussr.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "stfu"), "stfu;soundbank/stfu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "suck a dick"), "suck a dick;soundbank/suckadick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "suckit"), "suckit;soundbank/suckit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "suck my dick"), "suck my dick;soundbank/suckmydick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "teapot"), "teapot;soundbank/teapot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "thank god"), "thank ?god;soundbank/thankgod.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "traxion"), "traxion;soundbank/traxion.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "trixy"), "trixy;soundbank/trixy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "twoon"), "twoon|2pows;soundbank/twoon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "ty"), "ty|thanks|thank you;soundbank/thankyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "venny"), "venny;soundbank/venny.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "viewaskewer"), "view(askewer)?;soundbank/view.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "what's that"), "what'?s that;soundbank/whatsthat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(1, "who are you"), "who are you;soundbank/whoareyou.ogg")
+            self.category_loaded(1, 'database', player)
+        if self.Enabled_SoundPacks[2]:
+            self.db.set(SOUND_TRIGGERS.format(2, "007"), "007;sound/funnysounds/007.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "A Scratch"), "scratch|a scratch|just a scratch;sound/funnysounds/AScratch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "adams family"), "adams family;sound/funnysounds/adamsfamily.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "All The Things"), "all the things;sound/funnysounds/AllTheThings.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "allahuakbar"), "allahuakbar;sound/funnysounds/allahuakbar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "allstar"), "allstar;sound/funnysounds/allstar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Amazing"), "amazing;sound/funnysounds/Amazing.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Ameno"), "ameno;sound/funnysounds/Ameno.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "America"), "america;sound/funnysounds/America.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Amerika"), "amerika;sound/funnysounds/Amerika.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "And Nothing Else"), "and nothing else;sound/funnysounds/AndNothingElse.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Animals"), "animals;sound/funnysounds/Animals.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "asskicking"), "asskicking;sound/funnysounds/asskicking.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ave"), "ave;sound/funnysounds/ave.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "baby baby"), "baby baby;sound/funnysounds/babybaby.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "baby evil"), "baby evil;sound/funnysounds/babyevillaugh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "baby laughing"), "baby( laughing)?;sound/funnysounds/babylaughing.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "bad boys"), "bad boys;sound/funnysounds/badboys.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Banana Boat"), "banana boat;sound/funnysounds/BananaBoatSong.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "benny hill"), "benny hill;sound/funnysounds/bennyhill.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "benzin"), "benzin;sound/funnysounds/benzin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "blue wins"), "blue ?wins;sound/funnysounds/bluewins.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "bonkers"), "bonkers;sound/funnysounds/bonkers.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "boom headshot"), "boom headshot;sound/funnysounds/boomheadshot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "booo"), "booo?;sound/funnysounds/booo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "boring"), "boring;sound/funnysounds/boring.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "boze"), "boze;sound/funnysounds/boze.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "bright side of life"), "bright ?side ?of ?life;sound/funnysounds/brightsideoflife.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "buckdich"), "buckdich;sound/funnysounds/buckdich.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "bullshitter"), "bullshitter;sound/funnysounds/bullshitter.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "burns burns"), "burns burns;sound/funnysounds/burnsburns.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "camel toe"), "camel toe;sound/funnysounds/cameltoe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "can't touch this"), "can'?t touch this;sound/funnysounds/canttouchthis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "cccp"), "cccp|ussr;sound/funnysounds/cccp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "champions"), "champions;sound/funnysounds/champions.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "chicken"), "chicken;sound/funnysounds/chicken.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "chocolate rain"), "chocolate rain;sound/funnysounds/chocolaterain.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "coin"), "coin;sound/funnysounds/coin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "come"), "come;sound/funnysounds/come.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Come With Me Now"), "come with me now;sound/funnysounds/ComeWithMeNow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Count down"), "count down;sound/funnysounds/Countdown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "cowards"), "cowards;sound/funnysounds/cowards.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "crazy"), "crazy;sound/funnysounds/crazy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "damnit"), "damnit;sound/funnysounds/damnit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Danger Zone"), "danger zone;sound/funnysounds/DangerZone.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "dead soon"), "dead ?soon;sound/funnysounds/deadsoon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "defeated"), "defeated;sound/funnysounds/defeated.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "devil"), "devil;sound/funnysounds/devil.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "doesn't love you"), "doesn'?t love you;sound/funnysounds/doesntloveyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "du bist"), "du bist;sound/funnysounds/dubist.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "du hast"), "du hast;sound/funnysounds/duhast.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "dumb ways"), "dumb ways;sound/funnysounds/dumbways.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Eat Pussy"), "eat pussy;sound/funnysounds/EatPussy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "education"), "education;sound/funnysounds/education.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "einschrei"), "einschrei;sound/funnysounds/einschrei.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Eins Zwei"), "eins zwei;sound/funnysounds/EinsZwei.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "electro"), "electro;sound/funnysounds/electro.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "elementary"), "elementary;sound/funnysounds/elementary.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "engel"), "engel;sound/funnysounds/engel.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "erstwenn"), "erstwenn;sound/funnysounds/erstwenn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "exit light"), "exit ?light;sound/funnysounds/exitlight.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "faint"), "faint;sound/funnysounds/faint.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "fatality"), "fatality;sound/funnysounds/fatality.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Feel Good"), "feel good;sound/funnysounds/FeelGood.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "flesh wound"), "flesh wound;sound/funnysounds/fleshwound.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "for you"), "for you;sound/funnysounds/foryou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "freestyler"), "freestyler;sound/funnysounds/freestyler.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "fuckfuck"), "fuckfuck;sound/funnysounds/fuckfuck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "fucking burger"), "fucking burger;sound/funnysounds/fuckingburger.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "fucking kids"), "fucking kids;sound/funnysounds/fuckingkids.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "gangnam"), "gangnam;sound/funnysounds/gangnam.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ganjaman"), "ganjaman;sound/funnysounds/ganjaman.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "gay"), "gay;sound/funnysounds/gay.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "get crowbar"), "get crowbar;sound/funnysounds/getcrowbar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "get out the way"), "get out the way;sound/funnysounds/getouttheway.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ghostbusters"), "ghostbusters;sound/funnysounds/ghostbusters.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "girl look"), "girl look;sound/funnysounds/girllook.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "girly"), "girly;sound/funnysounds/girly.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "gnr guitar"), "gnr guitar;sound/funnysounds/gnrguitar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "goddamn right"), "goddamn right;sound/funnysounds/goddamnright.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "goodbye andrea"), "goodbye andrea;sound/funnysounds/goodbyeandrea.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "goodbye sarah"), "goodbye sarah;sound/funnysounds/goodbyesarah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "gotcha"), "gotcha;sound/funnysounds/gotcha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hakunamatata"), "hakunamatata;sound/funnysounds/hakunamatata.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hammertime"), "hammertime;sound/funnysounds/hammertime.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hello"), "hello;sound/funnysounds/hello.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hellstestern"), "hellstestern;sound/funnysounds/hellstestern.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "holy"), "holy;sound/funnysounds/holy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hoppereiter"), "hoppereiter;sound/funnysounds/hoppereiter.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "how are you"), "how are you;sound/funnysounds/howareyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "hush"), "hush;sound/funnysounds/hush.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i bet"), "i ?bet;sound/funnysounds/ibet.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i can't believe"), "i can'?t believe;sound/funnysounds/icantbelieve.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ichtuedieweh"), "ichtuedieweh;sound/funnysounds/ichtuedieweh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i do parkour"), "i do parkour;sound/funnysounds/idoparkour.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i hate all"), "i hate all;sound/funnysounds/ihateall.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ill be back"), "i'?ll be back;sound/funnysounds/beback.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "imperial"), "imperial;sound/funnysounds/imperial.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i'm sexy"), "i'?m sexy;sound/funnysounds/imsexy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i'm your father"), "i'?m your father;sound/funnysounds/imyourfather.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "incoming"), "incoming;sound/funnysounds/incoming.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "indiana jones"), "indiana jones;sound/funnysounds/indianajones.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "in your head zombie"), "in your head zombie;sound/funnysounds/inyourheadzombie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i see assholes"), "i see assholes;sound/funnysounds/iseeassholes.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "i see dead people"), "i see dead people;sound/funnysounds/iseedeadpeople.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "it's my life"), "it'?s my life;sound/funnysounds/itsmylife.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "it's not"), "it'?s not;sound/funnysounds/itsnot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "jackpot"), "jackpot;sound/funnysounds/jackpot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "jesus"), "jesus;sound/funnysounds/jesus.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Jesus Oh"), "jesus oh;sound/funnysounds/JesusOh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "john cena"), "john ?cena;sound/funnysounds/johncena.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "jump motherfucker"), "jump motherfucker;sound/funnysounds/jumpmotherfucker.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "just do it"), "just do it;sound/funnysounds/justdoit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "kamehameha"), "kamehameha;sound/funnysounds/kamehameha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "keep on fighting"), "keep on fighting;sound/funnysounds/keeponfighting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "keep your shirt on"), "keep your shirt on;sound/funnysounds/keepyourshirton.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Knocked Down"), "knocked down;sound/funnysounds/KnockedDown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "kommtdiesonne"), "kommtdiesonne;sound/funnysounds/kommtdiesonne.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "kung fu"), "kung ?fu;sound/funnysounds/kungfu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "lately"), "lately;sound/funnysounds/lately.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Legitness"), "legitness;sound/funnysounds/Legitness.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "let's get ready"), "let'?s get ready;sound/funnysounds/letsgetready.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "let's put a smile"), "let'?s put a smile;sound/funnysounds/letsputasmile.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "lights out"), "lights out;sound/funnysounds/lightsout.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "lion king"), "lion king;sound/funnysounds/lionking.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "live to win"), "live to win;sound/funnysounds/livetowin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "losing my religion"), "losing my religion;sound/funnysounds/losingmyreligion.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "love me"), "love ?me;sound/funnysounds/loveme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "low"), "low;sound/funnysounds/low.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "luck"), "luck;sound/funnysounds/luck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "lust"), "lust;sound/funnysounds/lust.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mahnamahna"), "mahnamahna;sound/funnysounds/mahnamahna.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mario"), "mario;sound/funnysounds/mario.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Me"), "me;sound/funnysounds/Me.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "meinland"), "meinland;sound/funnysounds/meinland.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "message"), "message;sound/funnysounds/message.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mimimi"), "mimimi;sound/funnysounds/mimimi.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mission"), "mission;sound/funnysounds/mission.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "moan"), "moan;sound/funnysounds/moan.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "mortal kombat"), "mortal kombat;sound/funnysounds/mortalkombat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "move ass"), "move ass;sound/funnysounds/moveass.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "muppet opening"), "muppet opening;sound/funnysounds/muppetopening.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "my little pony"), "my little pony;sound/funnysounds/mylittlepony.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "my name"), "my name;sound/funnysounds/myname.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "never seen"), "never seen;sound/funnysounds/neverseen.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nightmare"), "nightmare;sound/funnysounds/nightmare.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nobody likes you"), "nobody likes you;sound/funnysounds/nobodylikesyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nonie"), "nonie;sound/funnysounds/nonie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nooo"), "nooo+;sound/funnysounds/nooo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "no time for loosers"), "no time for loosers;sound/funnysounds/notimeforloosers.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "numanuma"), "numanuma;sound/funnysounds/numanuma.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "nyancat"), "nyancat;sound/funnysounds/nyancat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "o fuck"), "o fuck;sound/funnysounds/ofuck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "oh my god"), "oh my god;sound/funnysounds/ohmygod.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Oh My Gosh"), "oh my gosh;sound/funnysounds/OhMyGosh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ohnedich"), "ohnedich;sound/funnysounds/ohnedich.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "oh no"), "oh no;sound/funnysounds/ohno.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "oh noe"), "oh noe;sound/funnysounds/ohnoe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pacman"), "pacman;sound/funnysounds/pacman.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pick me up"), "pick me up;sound/funnysounds/pickmeup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pikachu"), "pikachu;sound/funnysounds/pikachu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pinkiepie"), "pinkiepie;sound/funnysounds/pinkiepie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Pink Panther"), "pink panther;sound/funnysounds/PinkPanther.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pipe"), "pipe;sound/funnysounds/pipe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "piss me off"), "piss me off;sound/funnysounds/pissmeoff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "play a game"), "play a game;sound/funnysounds/playagame.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "pooping"), "pooping;sound/funnysounds/pooping.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "powerpuff"), "powerpuff;sound/funnysounds/powerpuff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "radioactive"), "radioactive;sound/funnysounds/radioactive.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "rammsteinriff"), "rammsteinriff;sound/funnysounds/rammsteinriff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "red wins"), "red ?wins;sound/funnysounds/redwins.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "renegade"), "renegade;sound/funnysounds/renegade.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "retard"), "retard;sound/funnysounds/Retard.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "rocky"), "rocky;sound/funnysounds/rocky")
+            self.db.set(SOUND_TRIGGERS.format(2, "rock you guitar"), "rock ?you ?guitar;sound/funnysounds/rockyouguitar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sail"), "sail;sound/funnysounds/sail.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Salil"), "salil;sound/funnysounds/Salil.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "samba"), "samba;sound/funnysounds/samba.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sandstorm"), "sandstorm;sound/funnysounds/sandstorm.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "saymyname"), "saymyname;sound/funnysounds/saymyname.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "scatman"), "scatman;sound/funnysounds/scatman.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sell you all"), "sell you all;sound/funnysounds/sellyouall.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sense of humor"), "sense of humor;sound/funnysounds/senseofhumor.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "shakesenora"), "shakesenora;sound/funnysounds/shakesenora.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "shut the fuck up"), "shut the fuck up;sound/funnysounds/shutthefuckup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "shut your fucking mouth"), "shut your fucking mouth;sound/funnysounds/shutyourfuckingmouth.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "silence"), "silence;sound/funnysounds/silence.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Skeet Skeet"), "skeet skeet;sound/funnysounds/AllSkeetSkeet.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "smooth criminal"), "smooth criminal;sound/funnysounds/smoothcriminal.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "socobatevira"), "socobatevira;sound/funnysounds/socobatevira.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "socobatevira end"), "socobatevira end;sound/funnysounds/socobateviraend.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "socobatevira fast"), "socobatevira fast;sound/funnysounds/socobatevirafast.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "socobatevira slow"), "socobatevira slow;sound/funnysounds/socobateviraslow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sogivemereason"), "sogivemereason;sound/funnysounds/sogivemereason.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "so stupid"), "so stupid;sound/funnysounds/sostupid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Space Jam"), "space jam;sound/funnysounds/SpaceJam.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "space unicorn"), "space unicorn;sound/funnysounds/spaceunicorn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "spierdalaj"), "spierdalaj;sound/funnysounds/spierdalaj.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "stamp on"), "stamp on;sound/funnysounds/stampon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "star wars"), "star wars;sound/funnysounds/starwars.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "stayin alive"), "stayin alive;sound/funnysounds/stayinalive.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "stoning"), "stoning;sound/funnysounds/stoning.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "stop"), "stop;sound/funnysounds/Stop.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "story"), "story;sound/funnysounds/story.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "surprise"), "surprise;sound/funnysounds/surprise.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "swedish chef"), "swedish chef;sound/funnysounds/swedishchef.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "sweet dreams"), "sweet dreams;sound/funnysounds/sweetdreams.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "take me down"), "take me down;sound/funnysounds/takemedown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "talk scotish"), "talk scotish;sound/funnysounds/talkscotish.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "teamwork"), "teamwork;sound/funnysounds/teamwork.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "technology"), "technology;sound/funnysounds/technology.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "this is sparta"), "this is sparta;sound/funnysounds/thisissparta.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "thunderstruck"), "thunderstruck;sound/funnysounds/thunderstruck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "to church"), "to church;sound/funnysounds/tochurch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "tsunami"), "tsunami;sound/funnysounds/tsunami.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "tuturu"), "tuturu;sound/funnysounds/tuturu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "tututu"), "tututu;sound/funnysounds/tututu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "unbelievable"), "unbelievable;sound/funnysounds/unbelievable.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "undderhaifisch"), "undderhaifisch;sound/funnysounds/undderhaifisch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "up town girl"), "up town girl;sound/funnysounds/uptowngirl.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "valkyries"), "valkyries;sound/funnysounds/valkyries.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wahwahwah"), "wahwahwah|dcmattic|mattic;sound/funnysounds/wahwahwah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "want you"), "want you;sound/funnysounds/wantyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wazzup"), "wazzup;sound/funnysounds/wazzup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wehmirohweh"), "wehmirohweh;sound/funnysounds/wehmirohweh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "what is love"), "what is love;sound/funnysounds/whatislove.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "when angels"), "when angels;sound/funnysounds/whenangels.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "where are you"), "where are you;sound/funnysounds/whereareyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "whistle"), "whistle;sound/funnysounds/whistle.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "Will Be Singing"), "will be singing;sound/funnysounds/WillBeSinging.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wimbaway"), "wimbaway;sound/funnysounds/wimbaway.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "windows"), "windows;sound/funnysounds/windows.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "would you like"), "would you like;sound/funnysounds/wouldyoulike.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "wtf"), "wtf;sound/funnysounds/wtf.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "yeee"), "yeee;sound/funnysounds/yeee.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "yes master"), "yes master;sound/funnysounds/yesmaster.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "yhehehe"), "yhehehe;sound/funnysounds/yhehehe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "ymca"), "ymca;sound/funnysounds/ymca.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "you"), "you;sound/funnysounds/You.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "you are a cunt"), "you are a cunt;sound/funnysounds/cunt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "you fucked my wife"), "wife|my wife|you fucked my wife;sound/funnysounds/youfuckedmywife.ogg")
+            self.db.set(SOUND_TRIGGERS.format(2, "You Realise"), "you realise;sound/funnysounds/YouRealise.ogg")
+            self.category_loaded(2, 'database', player)
+        if self.Enabled_SoundPacks[3]:
+            self.db.set(SOUND_TRIGGERS.format(3, "my ride"), "my ride;sound/duke/2ride06.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "abort"), "abort;sound/duke/abort01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "ahhh"), "ahhh;sound/duke/ahh04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "much better"), "much better;sound/duke/ahmuch03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "aisle 4"), "aisle ?4;sound/duke/aisle402.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "a mess"), "a mess;sound/duke/amess06.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "annoying"), "annoying;sound/duke/annoy03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "bitchin"), "bitchin;sound/duke/bitchn04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "blow it out"), "blow it out;sound/duke/blowit01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "booby trap"), "booby trap;sound/duke/booby04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "bookem"), "bookem;sound/duke/bookem03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "born to be wild"), "born to be wild;sound/duke/born01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "chew gum"), "chew gum;sound/duke/chew05.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "come on"), "come on;sound/duke/comeon02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "the con"), "the con;sound/duke/con03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "cool"), "cool;sound/duke/cool01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "not crying"), "not crying;sound/duke/cry01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "daamn"), "daa?mn;sound/duke/damn03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "damit"), "damit;sound/duke/damnit04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "dance"), "dance;sound/duke/dance01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "diesob"), "diesob;sound/duke/diesob03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "doomed"), "doomed;sound/duke/doomed16.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "eyye"), "eyye;sound/duke/dscrem38.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "duke nukem"), "duke nukem;sound/duke/duknuk14.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "no way"), "no way;sound/duke/eat08.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "eat shit"), "eat shit;sound/duke/eatsht01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "escape"), "escape;sound/duke/escape01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "face ass"), "face ass;sound/duke/face01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "a force"), "a force;sound/duke/force01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "get that crap"), "get that crap;sound/duke/getcrap1.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "get some"), "get some;sound/duke/getsom1a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "game over"), "game over;sound/duke/gmeovr05.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "gotta hurt"), "gotta hurt;sound/duke/gothrt01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "groovy"), "groovy;sound/duke/groovy02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "you guys suck"), "you guys suck;sound/duke/guysuk01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "hail king"), "hail king;sound/duke/hail01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "shit happens"), "shit happens;sound/duke/happen01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "holy cow"), "holy cow;sound/duke/holycw01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "duke holy shit"), "duke holy ?shit;sound/duke/holysh02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "im good"), "im good;sound/duke/imgood12.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "independence"), "independence;sound/duke/indpnc01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "in hell"), "in ?hell;sound/duke/inhell01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "going in"), "going ?in;sound/duke/introc.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "dr jones"), "dr jones;sound/duke/jones04.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "kick your ass"), "your ass|kick your ass;sound/duke/kick01-i.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "ktit"), "ktit;sound/duke/ktitx.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "let god"), "let god;sound/duke/letgod01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "let's rock"), "let'?s rock;sound/duke/letsrk03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "lookin' good"), "lookin'? good;sound/duke/lookin01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "make my day"), "make my day;sound/duke/makeday1.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "midevil"), "midevil;sound/duke/mdevl01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "my meat"), "my meat;sound/duke/meat04-n.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "no time"), "no time;sound/duke/myself3a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "i needed that"), "i needed that;sound/duke/needed03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "nobody"), "nobody;sound/duke/nobody01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "only one"), "only one;sound/duke/onlyon03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "my kinda party"), "my kinda party;sound/duke/party03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "gonna pay"), "gonna pay;sound/duke/pay02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "pisses me off"), "pisses me off;sound/duke/pisses01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "pissin me off"), "pissin me off;sound/duke/pissin01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "postal"), "postal;sound/duke/postal01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "aint afraid"), "aint ?afraid;sound/duke/quake06.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "r and r"), "r and r;sound/duke/r&r01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "ready for action"), "ready for action;sound/duke/ready2a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "rip your head off"), "rip your head off;sound/duke/rip01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "rip em"), "rip em;sound/duke/ripem08.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "rockin"), "rockin;sound/duke/rockin02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "shake it"), "shake ?it;sound/duke/shake2a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "slacker"), "slacker;sound/duke/slacker1.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "smack dab"), "smack dab;sound/duke/smack02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "so help me"), "so help me;sound/duke/sohelp02.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "suck it down"), "suck it down;sound/duke/sukit01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "terminated"), "terminated;sound/duke/termin01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "this sucks"), "this sucks;sound/duke/thsuk13a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "vacation"), "vacation;sound/duke/vacatn01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "christmas"), "christmas;sound/duke/waitin03.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "wants some"), "wants some;sound/duke/wansom4a.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "you and me"), "you and me;sound/duke/whipyu01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "where"), "where;sound/duke/whrsit05.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "yippie kai yay"), "yippie kai yay;sound/duke/yippie01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "bottle of jack"), "bottle of jack;sound/duke/yohoho01.wav")
+            self.db.set(SOUND_TRIGGERS.format(3, "long walk"), "long walk;sound/duke/yohoho09.wav")
+            self.category_loaded(3, 'database', player)
+        if self.Enabled_SoundPacks[4]:
+            self.db.set(SOUND_TRIGGERS.format(4, "aiming"), "aiming;sound/warp/aiming.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "always open"), "always open;sound/warp/always_open.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "thanks for the advice"), "thanks for the advice;sound/warp/ash_advice.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "angry cat"), "angry cat;sound/warp/angry_cat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "appreciate"), "appreciate;sound/warp/ash_appreciate.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "looking forward to it"), "looking forward to it;sound/warp/ash_lookingforwardtoit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "make me"), "make me;sound/warp/ash_makeme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pessimist"), "pessimist;sound/warp/ash_pessimist.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "shoot me now"), "shoot me now;sound/warp/ash_shootmenow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "shoot on sight"), "shoot on sight;sound/warp/ash_shootonsight.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "won't happen again"), "won'?t happen again;sound/warp/ash_wonthappenagain.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "attractive"), "attractive;sound/warp/attractive.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "awesome"), "awesome;sound/warp/awesome.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "awkward"), "awkward;sound/warp/awkward.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bad feeling"), "bad feeling;sound/warp/badfeeling.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bad idea"), "bad idea;sound/warp/badidea.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ballbag"), "ballbag;sound/warp/ballbag.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bburp"), "bburp;sound/warp/bburp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bburpp"), "bburpp;sound/warp/bburpp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "believe"), "believe;sound/warp/believe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bend me over"), "bend me over;sound/warp/bend_me_over.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "big leagues"), "big leagues;sound/warp/bigleagues.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bike horn"), "bike horn;sound/warp/bike_horn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bj"), "bj;sound/warp/bj.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "kill you with my brain"), "kill you with my brain;sound/warp/brain.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bravery"), "bravery;sound/warp/bravery.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "broke"), "broke;sound/warp/broke.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "space bugs"), "space bugs;sound/warp/bugs.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "bunk"), "bunk;sound/warp/bunk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "burp"), "burp;sound/warp/burp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "burpp"), "burpp;sound/warp/burpp.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cover your butt"), "cover your butt;sound/warp/butt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "came out"), "came out;sound/warp/cameout.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "anybody care"), "anybody care;sound/warp/care.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "catch"), "catch;sound/warp/catch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "castrate"), "castrate;sound/warp/castrate.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cat scream"), "cat scream;sound/warp/cat_scream.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "hello2"), "hello2;sound/warp/coach_hello.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "corny"), "corny;sound/warp/corny.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cock push ups"), "cock push ups;sound/warp/cockpushups.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "code"), "code;sound/warp/code.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cold"), "cold;sound/warp/cold.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "college student"), "college student;sound/warp/college.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "conanapalooza"), "conana(palooza)?;sound/warp/conanana.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "confident"), "confident;sound/warp/confident.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cooperation"), "cooperation;sound/warp/cooperation.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cow dick"), "cow dick;sound/warp/cowdick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "crush your enemies"), "crush( your enemies)?;sound/warp/crushyourenemies.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "crusher"), "crusher;sound/warp/crusher.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "cucumber"), "cucumber;sound/warp/cucumber.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "go crazy"), "go crazy;sound/warp/crazy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "crowded"), "crowded;sound/warp/crowded.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dance off"), "dance off;sound/warp/danceoff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dead"), "dead;sound/warp/dead.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dead guy"), "dead guy;sound/warp/deadguy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dick message"), "dick message;sound/warp/dickmessage.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dick slip"), "dick slip;sound/warp/dick_slip.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dink bag"), "dink bag;sound/warp/dinkbag.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "dirty"), "dirty;sound/warp/dirty.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "do as you're told"), "do as you'?re told;sound/warp/doasyouretold.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what have we done"), "what have we done;sound/warp/done.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "done for the day"), "done( for the)?( day)?;sound/warp/done_for_the_day.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "done it"), "done it;sound/warp/doneit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "do now"), "do now;sound/warp/donow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "don't like vaginas"), "don'?t like vaginas;sound/warp/dontlikevaginas.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "do you feel special"), "(do you feel )?special;sound/warp/doyoufeelspecial.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "drawing"), "drawing;sound/warp/drawing.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "eat it"), "eat it;sound/warp/eat_it.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "eat my grenade"), "grenade|eat my grenade;sound/warp/eatmygrenade.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "eat my"), "eat my;sound/warp/eatmytits.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "electricity"), "electricity;sound/warp/electricity.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "enima"), "enima;sound/warp/enima.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "face"), "face;sound/warp/face.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "face2"), "face2;sound/warp/face2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fart"), "fart;sound/warp/fart.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fartt"), "fartt;sound/warp/fartt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "farttt"), "farttt;sound/warp/farttt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ffart"), "ffart;sound/warp/ffart.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ffartt"), "ffartt;sound/warp/ffartt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ffarttt"), "ffarttt;sound/warp/ffarttt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fffartt"), "fffartt;sound/warp/fffartt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fffarttt"), "fffarttt;sound/warp/fffarttt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "not fair"), "not fair;sound/warp/fair.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "falcon pawnch"), "falcon pawnch;sound/warp/falcon_pawnch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fall"), "fall;sound/warp/fall.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "favor"), "favor;sound/warp/favor.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "feel"), "feel;sound/warp/feel.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "feels"), "feels;sound/warp/feels.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fragile"), "fragile;sound/warp/fragile.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "something wrong"), "something wrong\\??;sound/warp/femaleshepherd_somethingwrong.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "suspense"), "suspense;sound/warp/femaleshepherd_suspense.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fog horn"), "fog horn;sound/warp/fog_horn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "found them"), "found them;sound/warp/found_them.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fuku"), "fuku;sound/warp/fuku.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fuck me"), "fuck me;sound/warp/fuck_me.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "fuck ugly"), "fuck ugly;sound/warp/fuck_ugly.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "awaiting orders"), "awaiting orders;sound/warp/garrus_awaitingorders.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "got your back"), "got your back;sound/warp/garrus_gotyourback.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "keep moving"), "keep moving;sound/warp/garrus_keepmoving.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nice work"), "nice work;sound/warp/garrus_nicework.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "get away cat"), "cat|get away cat;sound/warp/getawaycat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "get off"), "get off;sound/warp/getoff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "wasting my time"), "wasting my time;sound/warp/glados_wasting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "just go crazy"), "just go crazy;sound/warp/go_crazy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "grows"), "grows;sound/warp/grows.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ha ha"), "ha ha;sound/warp/haha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "heroics"), "heroics;sound/warp/heroics.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "hit or miss"), "hit or miss;sound/warp/hitormiss.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ho bags"), "ho ?bags;sound/warp/hobags.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "hop"), "hop;sound/warp/hop.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "horrible"), "horrible;sound/warp/horrible.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "huge vagina"), "huge vagina;sound/warp/hugevagina.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "hunting"), "hunting;sound/warp/hunting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i am the law"), "i am the law;sound/warp/iamthelaw.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "implied"), "implied;sound/warp/implied.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i died"), "i died;sound/warp/i_died.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i farted"), "i farted;sound/warp/i_farted.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i don't trust you"), "i don'?t trust you|leaf(green)?;sound/warp/idonttrustyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i have a plan"), "i have a plan;sound/warp/ihaveaplan.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i like you"), "i like you;sound/warp/ilikeyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "intensify"), "intensify;sound/warp/intensify.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "in the ass"), "in ?the ?ass;sound/warp/intheass.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i will eat"), "i will eat( your)?;sound/warp/iwilleatyour.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "jail"), "jail;sound/warp/jail.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "jump pad"), "jump pad;sound/warp/jump_pad.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "just the tip"), "just the tip|tippy(touch)?;sound/warp/just_the_tip.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "kevin bacon"), "kevin bacon;sound/warp/kevinbacon.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "kill"), "kill;sound/warp/kill.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "kizuna"), "kizuna;sound/warp/kizuna.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "need to kill"), "need to kill;sound/warp/krogan_kill.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ladybug"), "ladybug;sound/warp/ladybug.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "legend"), "legend|ere( ?bux)?;sound/warp/legend.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "lego maniac"), "lego maniac|zach|stukey;sound/warp/lego_maniac.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "human relationships"), "human relationships?;sound/warp/liara_humanrelationships.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "incredible"), "incredible;sound/warp/liara_incredible.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "never happened"), "never happened;sound/warp/liara_neverhappened.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "lick me"), "lick me;sound/warp/lick_me.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "like this thing"), "like this thing;sound/warp/like.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "wasn't listening"), "wasn'?t listening;sound/warp/listening.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "listen up"), "listen( up)?;sound/warp/listenup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "look fine"), "look fine;sound/warp/lookfine.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "lovely"), "lovely;sound/warp/lovely.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "your luck"), "your luck;sound/warp/luck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "maggot"), "maggot;sound/warp/maggot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "like an idiot"), "like an idiot;sound/warp/makes_you_look_like_idiot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "this beat"), "this beat;sound/warp/marg_tongue.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "killed with math"), "(killed )?(with )?math;sound/warp/math.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "me me me"), "me me( ?me)?;sound/warp/mememe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "metaphor"), "metaphor;sound/warp/metaphor.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "misdirection"), "misdirection;sound/warp/misdirection.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nobody move"), "nobody move;sound/warp/move.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "muuddy"), "muuddy(creek)?;sound/warp/muuddy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "mwahaha"), "mwahaha;sound/warp/mwahaha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "my friends"), "my friends;sound/warp/my_friends.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "my gun's bigger"), "my gun'?s bigger;sound/warp/mygunsbigger.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nades"), "nades;sound/warp/nades.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "never look back"), "never look back|muddy(creek)?;sound/warp/neverlookback.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nonono"), "no ?no ?no;sound/warp/nonono.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "nutsack"), "nutsack;sound/warp/nutsack.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "my god"), "my god;sound/warp/oh_my_god.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "oh fudge"), "fudge|oh fudge;sound/warp/ohfudge.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "on me"), "on me;sound/warp/onme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "on my mom"), "on my mom;sound/warp/onmymom.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ow what the"), "what the|ow what the;sound/warp/owwhatthe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pain in the ass"), "pain in the ass;sound/warp/pain.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pan out"), "pan out;sound/warp/panout.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pee bad"), "pee bad;sound/warp/pee_bad.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pee myself"), "pee myself;sound/warp/pee_myself.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "petty"), "petty;sound/warp/petty.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pie intro"), "pie intro;sound/warp/pie_intro4.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pile of shit"), "pile( of shit)?;sound/warp/pile.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "pizza time"), "pizza time;sound/warp/pizza_time.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "plasma"), "plasma|respect the plasma;sound/warp/plasma.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "plus back"), "plus back;sound/warp/plus_back.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "poop myself"), "poop myself;sound/warp/poop_myself.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "good point"), "good point;sound/warp/point.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "quarter"), "quarter;sound/warp/quarter.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "question"), "question;sound/warp/question.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "rage"), "rage;sound/warp/rage.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "real me"), "real me;sound/warp/realme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "roll with"), "roll with;sound/warp/roll_with.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "no longer require"), "no longer require;sound/warp/require.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ready for this"), "ready for this;sound/warp/rochelle_ready.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "rock this"), "rock this;sound/warp/rockthis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "santa"), "santa;sound/warp/santa.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "say my name"), "say my name;sound/warp/saymyname.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "you can scream"), "you can scream;sound/warp/scream.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "shart"), "shart;sound/warp/shart.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "shartt"), "shartt;sound/warp/shartt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "smiley face"), "smiley face;sound/warp/smileyface.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "oh snap"), "snap|oh snap;sound/warp/snap.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sneezed"), "sneezed;sound/warp/sneezed.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "solitude"), "solitude;sound/warp/solitude.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sorry"), "sorry;sound/warp/sorry.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "spaghetti"), "spagh?etti;sound/warp/spagetti.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "human speech"), "speech|human speech;sound/warp/speech.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sprechen sie dick"), "sprechen sie dick;sound/warp/sprechensiedick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "start over"), "start over;sound/warp/startover.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "stfu cunt"), "stfu cunt;sound/warp/stfu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "study harder"), "study harder;sound/warp/study_harder.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "stunned our ride"), "stunned our ride;sound/warp/stunned.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sure"), "sure;sound/warp/sure.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "swallow"), "swallow;sound/warp/swallow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "take a break"), "take a break|wally;sound/warp/takeabreaknow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "take down"), "take down;sound/warp/takedown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "the creeps"), "the creeps;sound/warp/tali_creeps.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "used to living"), "used to living;sound/warp/tali_usedtoliving.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "talk to me"), "talk to me;sound/warp/talk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "tnt"), "tnt;sound/warp/tnt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "asshole"), "asshole;sound/warp/tastless_asshole.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "tears"), "tears;sound/warp/tears.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "that's right"), "that'?s right;sound/warp/thatsright.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "the talk"), "the talk;sound/warp/the_talk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "think"), "think;sound/warp/think.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "tricked"), "tricked;sound/warp/tricked.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "trusted"), "trusted;sound/warp/trusted.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "trust me"), "trust me;sound/warp/trustme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "target"), "target;sound/warp/turret_target.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "ugly stick"), "ugly stick;sound/warp/ugly.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "unfair"), "unfair;sound/warp/unfair.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "unicorn"), "unicorn;sound/warp/unicorn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "v3"), "v3|vestek;sound/warp/v3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "valid"), "valid;sound/warp/valid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "very nice"), "very nice;sound/warp/very_nice.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "vewy angwy"), "vewy angwy;sound/warp/vewy_angwy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "volunteer"), "volunteer;sound/warp/volunteer.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "waiting"), "waiting;sound/warp/waiting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "walk"), "walk;sound/warp/walk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what i want"), "what i want;sound/warp/want.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "at war"), "at war;sound/warp/war.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "warp server intro"), "(warp server intro)|(quality);sound/warp/warpserverintro.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "wednesday"), "wednesday;sound/warp/wednesday.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "wee lamb"), "wee lamb;sound/warp/weelamb.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "well"), "well;sound/warp/well.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "we're grownups"), "we'?re grownups;sound/warp/weregrownups.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what happened"), "what happened;sound/warp/whathappened.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what is this"), "what is this;sound/warp/whatisthis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what now"), "what now;sound/warp/whatnow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what the"), "what the;sound/warp/whatthe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "where the fuck"), "where the( fuck)?;sound/warp/where_the_fuck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "winnie the pew"), "winnie( the pew)?;sound/warp/winnie_the_pew.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "with my fist"), "my fist|with my fist;sound/warp/withmyfist.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "busy"), "busy;sound/warp/wrex_busy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "sometimes crazy"), "sometimes crazy;sound/warp/wrex_crazy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "i like"), "i like;sound/warp/wrex_like.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "orders"), "orders;sound/warp/wrex_orders.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "right behind you"), "right behind you;sound/warp/wrex_rightbehindyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "what can i do"), "what can i do;sound/warp/wrex_whatcanido.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "your mom"), "your mom|pug(ster)?;sound/warp/yourmom.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "yarg"), "yarg;sound/warp/yarg.ogg")
+            self.db.set(SOUND_TRIGGERS.format(4, "zooma"), "zooma?|xuma;sound/warp/zooma.ogg")
+            self.category_loaded(4, 'database', player)
+        if self.Enabled_SoundPacks[5]:
+            self.db.set(SOUND_TRIGGERS.format(5, "2ez"), "2ez|too easy;sound/westcoastcrew/2ez.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ability"), "ability;sound/westcoastcrew/ability.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ahsi"), "ahsi;sound/westcoastcrew/ahsi.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "all dead"), "all ?dead;sound/westcoastcrew/alldead.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "kinrazed"), "kinrazed;sound/westcoastcrew/alright.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "another one bites the dustt"), "bites the dustt|another one bites the dustt;sound/westcoastcrew/anotherbitesdust.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "another one bites the dust"), "bites the dust|another one bites the dust;sound/westcoastcrew/anotheronebitesthedust.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "and another one gone"), "and another one gone;sound/westcoastcrew/anotheronegone.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "atustamena"), "atustamena;sound/westcoastcrew/atustamena.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ay caramba"), "ay caramba;sound/westcoastcrew/aycaramba.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "baby back"), "baby ?back;sound/westcoastcrew/babyback.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "badabababa"), "badababa(ba)?;sound/westcoastcrew/badabababa.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "baiting"), "baitin'?g?;sound/westcoastcrew/baiting.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ballin"), "ballin'?g?;sound/westcoastcrew/ballin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bender"), "bender;sound/westcoastcrew/bender.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "biff"), "biff;sound/westcoastcrew/biff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "outro"), "outro;sound/westcoastcrew/biggerlove.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bigpippin"), "bigpippin'?g?;sound/westcoastcrew/bigpippin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "big whoop"), "big wh?oop;sound/westcoastcrew/bigwhoop.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bite my shiny metal ass"), "bite my shiny metal ass;sound/westcoastcrew/bitemyshinymetalass.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bofumballs"), "bofumb(alls)?;sound/westcoastcrew/bofumballs.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "boomshakalaka"), "boomshakalaka;sound/westcoastcrew/boomshakalaka.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "borracho"), "borracho;sound/westcoastcrew/borracho.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bumblebee tuna"), "your balls are showing|bumblebee tuna;sound/westcoastcrew/bumblebeetuna.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bum bum"), "bum ?bum;sound/westcoastcrew/bumbum.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "bweenabwaana"), "bweena(bwaana)?;sound/westcoastcrew/bweenabwaana.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "c3"), "c3;sound/westcoastcrew/c3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "campingtroll"), "campingtroll|baby got back;sound/westcoastcrew/campingtroll.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cann"), "cann;sound/westcoastcrew/cann.ogg")
+            # repeat of FunnySounds
+            #self.db.set(SOUND_TRIGGERS.format(5, "can't touch this"), "can'?t touch this;sound/westcoastcrew/CantTouchThis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "captains draft"), "captains ?draft;sound/westcoastcrew/captainsdraft.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cheers"), "cheers;sound/westcoastcrew/cheers.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cheers2"), "cheers2;sound/westcoastcrew/cheers2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "chocosaurus"), "chocosaurus;sound/westcoastcrew/chocosaurus.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "clear"), "clear;sound/westcoastcrew/clear.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "clever girl"), "clever girl;sound/westcoastcrew/clevergirl.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "clr"), "clr;sound/westcoastcrew/clr.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "clr2"), "clr2;sound/westcoastcrew/clr2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "counting on you"), "counting on you;sound/westcoastcrew/countingonyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "g1bbles"), "g1bbles;sound/westcoastcrew/crymeariver.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cry me a river"), "cry me a river;sound/westcoastcrew/crymeariver1.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cry me a riverr"), "cry me a riverr;sound/westcoastcrew/crymeariver2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "cthree"), "cthree;sound/westcoastcrew/cuttingedge.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "damn im good"), "damn i'?m good;sound/westcoastcrew/damnimgood.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dead last"), "yeah,? how'?d he finish again|dead ?last;sound/westcoastcrew/deadlast.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "did i do that"), "did i do that;sound/westcoastcrew/dididothat.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dddid i do that"), "ddd?id i do that;sound/westcoastcrew/dididothat2.ogg")
+            # repeat of Prestige Sounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "die"), "die;sound/westcoastcrew/die.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "die already"), "die already;sound/westcoastcrew/diealready.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "die mothafuckas"), "die mothafuckas;sound/westcoastcrew/diemothafuckas.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "die motherfucker"), "die motherfucker;sound/westcoastcrew/diemotherfucker.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "it's a disastah"), "disastah|it'?s a disastah;sound/westcoastcrew/disastah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dominating"), "dominating;sound/westcoastcrew/dominating.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "you're doomed"), "you'?re doome?d;sound/westcoastcrew/doomed.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dr1nya"), "dr1nya;sound/westcoastcrew/dr1nya.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "drunk"), "drunk|always smokin'? blunts|gettin'? drunk;sound/westcoastcrew/drunk.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dundun"), "dun ?dun;sound/westcoastcrew/dundun.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dundundun"), "dun dun dun|dundundun;sound/westcoastcrew/dundundun.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "dundundundun"), "dun dun dun dun|dundundundun;sound/westcoastcrew/dundundundun.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "easy as"), "easy as;sound/westcoastcrew/easyas.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "easy come easy go"), "easy come easy go;sound/westcoastcrew/easycomeeasygo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ehtogg"), "ehtogg;sound/westcoastcrew/ehtogg.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "elo"), "elo;sound/westcoastcrew/elo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "enemy pick"), "enemy ?pick;sound/westcoastcrew/enemypick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ez"), "ez|easy$|so easy|that was easy|that was ez;sound/westcoastcrew/ez.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "f33"), "f33;sound/westcoastcrew/f3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "facial"), "facial;sound/westcoastcrew/facial.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "feroz"), "feroz;sound/westcoastcrew/feroz.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "filthy zealot"), "keep the change|filthy zealot;sound/westcoastcrew/filthyzealot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "flush"), "flush;sound/westcoastcrew/flush.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "fox"), "fox;sound/westcoastcrew/fox.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "fuckin bitch"), "fuckin bitch;sound/westcoastcrew/fuckinbitch.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "Gay"), "Gay;sound/westcoastcrew/Gay.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "get outta here"), "get outta here;sound/westcoastcrew/getouttahere.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gibbles"), "gibbles;sound/westcoastcrew/gibbles.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "giggs"), "giggs;sound/westcoastcrew/giggs.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gimme a break"), "gimme a break;sound/westcoastcrew/gimmeabreak.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "give up and die"), "give up and die;sound/westcoastcrew/giveupanddie.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "godlike"), "godlike;sound/westcoastcrew/godlike.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gojira"), "gojira;sound/westcoastcrew/gojira.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "great shot"), "g(reat)? ?(shot)?;sound/westcoastcrew/greatshot.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gs"), "gs;sound/westcoastcrew/gs.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "h2o"), "h2o;sound/westcoastcrew/h2o.ogg")
+            # repeat of Warp Sounds for Quake Live
+            # self.db.set(SOUND_TRIGGERS.format(5, "haha"), "haha;sound/westcoastcrew/haha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hahaha2"), "hahaha2;sound/westcoastcrew/hahaha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hahahaha"), "hahahaha;sound/westcoastcrew/hahahaha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "happy hour"), "happy hour|it'?s happy hour;sound/westcoastcrew/happyhour.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "he's heating up"), "he'?s heating up;sound/westcoastcrew/heatingup.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hehe"), "hehe;sound/westcoastcrew/hehe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hehehe"), "hehehe;sound/westcoastcrew/hehehe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hehe yeah"), "hehe yeah;sound/westcoastcrew/heheyeah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "hot steppah"), "hot ?steppah;sound/westcoastcrew/hotsteppah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "i'm lovin it"), "i'?m loving? ?it;sound/westcoastcrew/imlovinit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "im on fire"), "i'?m on fire;sound/westcoastcrew/imonfire.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "im stephan"), "i'?m stephan;sound/westcoastcrew/imstephan.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "inspector gadget"), "inspector( gadget)?;sound/westcoastcrew/inspectornorse.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "it's in the bag"), "it'?s in the bag;sound/westcoastcrew/inthebag1.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the bag"), "in the bag;sound/westcoastcrew/inthebag2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the bagg"), "in the bagg;sound/westcoastcrew/inthebag3.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the baggg"), "in the baggg;sound/westcoastcrew/inthebag4.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the face"), "in the face;sound/westcoastcrew/intheface.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "in the zone"), "in the zone|i'?m in the zone;sound/westcoastcrew/inthezone.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "doom2"), "doom2|tell me what you came here for;sound/westcoastcrew/intoyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "introtoo"), "introtoo;sound/westcoastcrew/intro2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "isabadmutha"), "isabadmutha;sound/westcoastcrew/isabadmutha.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "jdub"), "jdub;sound/westcoastcrew/jdub.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "jsss"), "jsss;sound/westcoastcrew/jsss.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "killswitch"), "killswitch;sound/westcoastcrew/killswitch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "kinraze"), "kinraze;sound/westcoastcrew/kinraze.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "lakad"), "lakad;sound/westcoastcrew/lakad.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "lg"), "lg;sound/westcoastcrew/lg.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "lol loser"), "(lol )?loser;sound/westcoastcrew/lolloser.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "look what you did"), "look what you did;sound/westcoastcrew/lookwhatyoudid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "look what you've done"), "look what you'?ve done;sound/westcoastcrew/lookwhatyouvedone.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "los"), "los;sound/westcoastcrew/los.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "lovin' it"), "lovin'? it;sound/westcoastcrew/lovinit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "makaveli"), "makaveli;sound/westcoastcrew/makaveli.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "martin"), "martin;sound/westcoastcrew/martin.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "pizza pizza"), "pizza pizza|meetzah meetzah|heetzah peetzah;sound/westcoastcrew/meetzah.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "mirai"), "mirai;sound/westcoastcrew/mirai.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "did you miss me"), "did you miss me;sound/westcoastcrew/missme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "mobil"), "mobil;sound/westcoastcrew/mobil.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "i'm a motherfuckin monster"), "i'?m a motherfuckin monst(er)?;sound/westcoastcrew/monster.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "monster kill"), "monster kill;sound/westcoastcrew/monsterkill.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "muthafucka"), "muthafucka;sound/westcoastcrew/muthafucka.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "nanana"), "nanana;sound/westcoastcrew/nanana.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "next level"), "next ?level;sound/westcoastcrew/nextlevel.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "no no no no no"), "no no no( no)?( no)?;sound/westcoastcrew/nonononono.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "nonsense"), "nonsense;sound/westcoastcrew/nonsense.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "nooo"), "nooo;sound/westcoastcrew/Nooo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "not tonight"), "not ?tonight;sound/westcoastcrew/nottonight.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "no way"), "no ?way;sound/westcoastcrew/noway.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "oblivion"), "oblivion;sound/westcoastcrew/obliv.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "obliv"), "obliv(ious)?;sound/westcoastcrew/obliv2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "oh boy"), "oh boy;sound/westcoastcrew/ohboy.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "oh no"), "oh no;sound/westcoastcrew/OhNo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "he's on fire"), "he'?s on fire;sound/westcoastcrew/onfire.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ooom"), "ooom;sound/westcoastcrew/oomwhatyousay.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "opinion"), "opinion|well, you know, that'?s;sound/westcoastcrew/opinion.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "oshikia"), "oshikia;sound/westcoastcrew/oshikia.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "oy"), "oy;sound/westcoastcrew/oy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "papabalyo"), "papabalyo;sound/westcoastcrew/papabaylo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "gotta pay the troll"), "gotta pay the troll;sound/westcoastcrew/paytrolltoll.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "pick music"), "pick ?music;sound/westcoastcrew/pickmusic.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "littlemeezers"), "littlemeezers;sound/westcoastcrew/pizzaguy.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "psygib"), "psygib;sound/westcoastcrew/psygib.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "puff"), "puff;sound/westcoastcrew/puff.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "qaaq"), "qaaq;sound/westcoastcrew/qaaq.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "qibuqi"), "qibuqi;sound/westcoastcrew/qibuqi.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "qqaaq"), "qqaaq;sound/westcoastcrew/qqaaq.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "questionable"), "questionable;sound/westcoastcrew/questionable.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rage quit"), "rage quit;sound/westcoastcrew/ragequit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "let's get ready to rumble"), "let'?s get ready to rumble;sound/westcoastcrew/readytorumble.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "really"), "really;sound/westcoastcrew/really.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "reflexes"), "reflexes|it'?s all in the reflexes;sound/westcoastcrew/reflexes.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rekt"), "rekt;sound/westcoastcrew/rekt.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "retard"), "retard;sound/westcoastcrew/Retard.ogg")
+            #self.db.set(SOUND_TRIGGERS.format(5, "rockyouguitar"), "rockyouguitar;sound/westcoastcrew/RockYouGuitar.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rothkoo"), "rothkoo;sound/westcoastcrew/rothko.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rothko"), "rothko;sound/westcoastcrew/rothko_theme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "rugged"), "rugged|like a rock;sound/westcoastcrew/rugged.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "santa town"), "santa ?town;sound/westcoastcrew/santatown.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "saved"), "saved;sound/westcoastcrew/saved.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "scrub"), "scrub;sound/westcoastcrew/scrub.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "senth"), "senth;sound/westcoastcrew/senth.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "shaft"), "shaft;sound/westcoastcrew/shaft.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "shenookies cookies"), "shenookie'?s cookies;sound/westcoastcrew/shenook.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "shenookie"), "shenookie;sound/westcoastcrew/shenookies.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "you show that turd"), "turd|you show that turd|show that turd;sound/westcoastcrew/showthatturd.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "shufflenufiguess"), "shufflenufiguess;sound/westcoastcrew/shufflenufflegus.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "skadoosh"), "skadoosh;sound/westcoastcrew/skadoosh.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "slime"), "slime;sound/westcoastcrew/slime.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "snort"), "snort;sound/westcoastcrew/snort.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "snpete"), "snpete;sound/westcoastcrew/SNpete.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "snpete2"), "snpete2|chick chicky boom;sound/westcoastcrew/SNpete2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "so is your face"), "so is your face;sound/westcoastcrew/soisyourface.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "solis"), "solis;sound/westcoastcrew/solis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "spank you"), "spank you;sound/westcoastcrew/spankyou.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "stfu2"), "stfu2;sound/westcoastcrew/stfu.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "still feel like you're mad"), "still feel like you'?re mad;sound/westcoastcrew/stillmad.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "stitch"), "stitch;sound/westcoastcrew/stitch.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "somebody stop me"), "somebody stop me;sound/westcoastcrew/stopme.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "survey said"), "survey said;sound/westcoastcrew/surveysaid.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "swish"), "swish;sound/westcoastcrew/swish.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "team complete"), "team ?complete;sound/westcoastcrew/teamcomplete2.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "teamwork"), "teamwork;sound/westcoastcrew/Teamwork.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "that's all folks"), "that'?s all folks;sound/westcoastcrew/thatsallfolks.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "thetealduck"), "the ?teal ?duck;sound/westcoastcrew/thetealduck.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "thriller"), "thriller;sound/westcoastcrew/thriller.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "tooold"), "too?o?ld;sound/westcoastcrew/tooold.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "troll toll"), "troll ?toll;sound/westcoastcrew/trolltoll.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "turple"), "turple;sound/westcoastcrew/turpled.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "tustamena"), "tustamena;sound/westcoastcrew/tustamena.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ty2"), "thanks2|ty2;sound/westcoastcrew/ty.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "unstoppable"), "unstoppable;sound/westcoastcrew/unstoppable.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ventt"), "ventt;sound/westcoastcrew/v3ntt.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "vacuum"), "vacuum;sound/westcoastcrew/vacuum.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "vks"), "vks|bow;sound/westcoastcrew/vks.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "w3rd"), "w3rd;sound/westcoastcrew/w3rd.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "wanerbuliao"), "wanerbuliao;sound/westcoastcrew/wanerbuliao.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "waow"), "waow;sound/westcoastcrew/waow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "what did you do"), "what did you do;sound/westcoastcrew/whatdidyoudo.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "what just happened"), "what ?just ?happened;sound/westcoastcrew/whatjusthappened.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "why you little"), "why you little;sound/westcoastcrew/whyyoulittle.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "wolf"), "wolf;sound/westcoastcrew/wolf.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "wow"), "wow;sound/westcoastcrew/wow.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "woww"), "woww;sound/westcoastcrew/wow2.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "wuyoga"), "wuyoga;sound/westcoastcrew/wuyoga.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "xxx"), "xxx;sound/westcoastcrew/xxx.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "ya basic"), "ya ?basic;sound/westcoastcrew/yabasic.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "jdub"), "jdub|y'?all ready for this;sound/westcoastcrew/yallreadyforthis.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "yawn"), "yawn;sound/westcoastcrew/yawn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "yawnn"), "yawnn+;sound/westcoastcrew/yawnn.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "yeah baby"), "yeah baby;sound/westcoastcrew/yeahbaby.ogg")
+            # repeat of FunnySounds
+            # self.db.set(SOUND_TRIGGERS.format(5, "yhehehe"), "yhehehe;sound/westcoastcrew/YHehehe.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "you can do it"), "you can do( it)?;sound/westcoastcrew/youcandoit.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "youlose"), "youlose;sound/westcoastcrew/youlose.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "your pick"), "your ?pick;sound/westcoastcrew/yourpick.ogg")
+            self.db.set(SOUND_TRIGGERS.format(5, "zebby"), "zebby;sound/westcoastcrew/zebby.ogg")
+            self.category_loaded(5, 'database', player)
+
+            if ADDITIONAL_SOUNDPACKS:
+                base_path = self.get_cvar("fs_basepath")
+                next_num = len(self.Enabled_SoundPacks)
+                for item in ADDITIONAL_SOUNDPACKS:
+                    file = "{}/baseq3/{}".format(base_path, item)
+                    if path.isfile(file):
+                        sounds = ZipFile(file).namelist()
+                        pack_name = item.split('.')[0]
+                        self.Enabled_SoundPacks.append(1)
+                        self.soundPacks.append(pack_name.replace('_', ' '))
+                        self.categories.append('#{}'.format(pack_name))
+                        for sound in sounds:
+                            try:
+                                sf = path.split(sound)
+                                if sf[1]:
+                                    name = self.convert(sf[1].split('.')[0])
+                                    append = 1
+                                    exists = True
+                                    while exists:
+                                        exists = False
+                                        for x in range(0, next_num):
+                                            if self.db.exists(SOUND_TRIGGERS.format(x, name)):
+                                                exists = True
+                                        if exists:
+                                            name = '{}{}'.format(name, append) if append == 1 else \
+                                                '{}{}'.format(name[:-1], append)
+                                            append += 1
+                                    self.db.set(SOUND_TRIGGERS.format(next_num, name), "{};{}".format(name, sound))
+                            except:
+                                continue
+                        if self._enable_dictionary:
+                            self._sound_dictionary[next_num] = {}
+                        if player:
+                            count = 0
+                            while not self.db.keys(SOUND_TRIGGERS.format(next_num, "*")):
+                                time.sleep(1)
+                                if count > 10:
+                                    break
+                                count += 1
+                        self.category_loaded(next_num, 'database', player)
+                        next_num += 1
+
+        self.populate_sound_lists(player)
+        return

--- a/ql-assets/data/minqlxtended-plugins/player_info.py
+++ b/ql-assets/data/minqlxtended-plugins/player_info.py
@@ -398,8 +398,11 @@ class player_info(minqlxtended.Plugin):
             ban = {"expires": expires, "reason": "deactivated account", "issued": now, "issued_by": "player_info"}
             db.hmset(base_key + ":{}".format(ban_id), ban)
             db.execute()
-            self.kick(player.id, "banned from this server because of deactivated account.")
+            # Plugin has no kick method on either runtime, so the minqlx original's
+            # call here was an AttributeError waiting to happen. Player.kick takes the
+            # reason directly (_player.py:926).
+            player.kick("banned from this server because of deactivated account.")
         except:
             n = player.name
-            self.kick(player.id, "kicked because of deactivated account.")
+            player.kick("kicked because of deactivated account.")
             self.msg("{} has been kicked, but could not be banned. Contact iouonegirl".format(n))

--- a/ql-assets/data/minqlxtended-plugins/player_info.py
+++ b/ql-assets/data/minqlxtended-plugins/player_info.py
@@ -1,0 +1,405 @@
+﻿# This is a plugin created by iouonegirl(@gmail.com)
+# Copyright (c) 2016 iouonegirl + Minkyn
+# https://github.com/dsverdlo/minqlx-plugins
+#
+# You are free to modify this plugin to your custom,
+# except for the version command related code.
+#
+# Its purpose is to display some information about the players.
+# When players fall off the scoreboard, they are now also able
+# to view their information
+#
+# Players deactivated on qlstats can be banned or just
+# trigger a server warning.
+# Can also use a different elo rating site by changing
+# cvar qlx_balanceUrl
+#
+# Uses:
+# - set qlx_pinfo_display_auto "0"
+# - set qlx_pinfo_show_deactivated "1"
+#          ^ (If this is 1 then a warning will be shown of players who are deactivated on qlstats/other)
+# - set qlx_pinfo_ban_deactivated "0"
+# - set qlx_pinfo_ban_duration_weeks "1"
+#       ^ If ban_deactivated is "1", then this var will specify for how many weeks the ban will last
+#         (please only use integers (no decimals) here)
+
+import minqlxtended
+import requests
+import itertools
+import threading
+import datetime
+import random
+import time
+import os
+import re
+from redis.exceptions import RedisError as _RedisError
+
+# On minqlx this plugin subclasses the iouonegirl abstract base, which installs itself
+# at import time by fetching its module from github.com/dsverdlo/minqlx-plugins.
+# That base is deliberately not carried across:
+#
+#   - it is not in the minqlxtended baseline, and everything it auto-updates is
+#     minqlx-API code, which would not load on this runtime anyway;
+#   - it downloads at import, so every plugin load depends on the game server having
+#     outbound access to GitHub and on that repository still serving the file.
+#
+# player_info used exactly one thing from it — find_by_name_or_id — which is inlined
+# below. Nothing else it inherited was ever called from this file.
+
+VERSION = "v0.36"
+
+PLAYER_KEY = "minqlx:players:{}"
+COMPLETED_KEY = PLAYER_KEY + ":games_completed"
+LEFT_KEY = PLAYER_KEY + ":games_left"
+LENGTH_REGEX = re.compile(r"(?P<number>[0-9]+) (?P<scale>seconds?|minutes?|hours?|days?|weeks?|months?|years?)")
+TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+# Elo retrieval vars
+EXT_SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm", "duel", "ffa")
+RATING_KEY = "minqlx:players:{0}:ratings:{1}" # 0 == steam_id, 1 == short gametype.
+MAX_ATTEMPTS = 3
+CACHE_EXPIRE = 60*30 # 30 minutes TTL.
+DEFAULT_RATING = 1500
+SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm")
+
+
+def zadd_compat(db, key, member, score):
+    """Support both redis-py 2.x (raises RedisError) and 3.x+ (dict mapping) zadd signatures."""
+    try:
+        return db.zadd(key, {member: score})
+    except (TypeError, _RedisError):
+        return db.zadd(key, score, member)
+
+
+class player_info(minqlxtended.Plugin):
+    def __init__(self):
+        super().__init__()
+
+        # set cvars once. EDIT THESE IN SERVER.CFG
+        self.set_cvar_once("qlx_balanceApi", "elo")
+        self.set_cvar_once("qlx_balanceUrl", "qlstats.net")
+        self.set_cvar_once("qlx_pinfo_display_auto", "0")
+        self.set_cvar_once("qlx_pinfo_show_deactivated", "1")
+        self.set_cvar_once("qlx_pinfo_ban_deactivated", "0")
+        self.set_cvar_once("qlx_pinfo_ban_duration_weeks", "1")
+
+        self.add_command("info", self.cmd_player_info,  usage="[<id>|<name>]")
+        self.add_command("scoreboard", self.cmd_scoreboard, usage="[<id>|<name>]")
+        self.add_command(("allelo", "allelos", "aelo", "eloall"), self.cmd_all_elos, usage="[<id>|<name>]")
+
+        self.add_hook("player_connect", self.handle_player_connect, priority=minqlxtended.Priority.LOWEST)
+        
+        self.cache_cvars()
+
+    
+    def cache_cvars(self):
+        self.balanceApiUrl = self.get_cvar("qlx_balanceUrl")
+        self.api_url = "http://{}/{}/".format(self.balanceApiUrl, self.get_cvar("qlx_balanceApi"))
+
+
+    def handle_player_connect(self, player, is_bot):
+        # player_connect gained `is_bot` on this runtime (_events.py:586). It replaces
+        # the steam-id heuristic the minqlx version used to guess the same thing: a
+        # bot has no qlstats history to look up.
+        if is_bot:
+            return
+
+        cond = self.get_cvar("qlx_pinfo_display_auto", int)
+        cond += self.get_cvar("qlx_pinfo_show_deactivated", int)
+        cond += self.get_cvar("qlx_pinfo_ban_deactivated", int)
+
+        if cond:
+            self.fetch(player, self.game.type_short, None)
+
+    def find_by_name_or_id(self, player, target):
+        """Resolve `target` to a single connected player, or tell `player` why not.
+
+        Inlined from iouonegirl.py's abstract base, which this port does not carry
+        (see the note above the class). Behaviour is unchanged from the original.
+        """
+        # Find players returns a list of name-matching players
+        def find_players(query):
+            players = []
+            for p in self.find_player(query):
+                if p not in players:
+                    players.append(p)
+            return players
+
+        # Tell a player which players matched
+        def list_alternatives(players, indent=2):
+            player.tell("A total of ^6{}^7 players matched for {}:".format(len(players), target))
+            out = ""
+            for p in players:
+                out += " " * indent
+                out += "{}^6:^7 {}\n".format(p.id, p.name)
+            player.tell(out[:-1])
+
+        # Get the list of matching players on name
+        target_players = find_players(target)
+
+        # If id:X is given and it amounts to a player, give it precedence.
+        # This is to avoid deadlocks
+        match = re.search("(id[=:][0-9]{1,2})", target)
+        if match and match.group() == target:
+            try:
+                match_id = re.search("([0-9]{1,2})", target)
+                player = self.player(int(match_id.group()))
+                if player.steam_id:
+                    return player
+            except:
+                pass
+
+        # even if we get only 1 person, we need to check if the input was meant as an ID
+        # if we also get an ID we should return with ambiguity
+
+        try:
+            i = int(target)
+            target_player = self.player(i)
+            if not (0 <= i < 64) or not target_player:
+                raise ValueError
+            # Add the found ID if the player was not already found
+            if not target_player in target_players:
+                target_players.append(target_player)
+        except ValueError:
+            pass
+
+        # If there were absolutely no matches
+        if not target_players:
+            player.tell("Sorry, but no players matched your tokens: {}.".format(target))
+            return None
+
+        # If there were more than 1 matches
+        if len(target_players) > 1:
+            list_alternatives(target_players)
+            return None
+
+        # By now there can only be one person left
+        return target_players.pop()
+
+
+
+
+    def cmd_player_info(self, player, msg, channel):
+        if len(msg) > 2:
+            return minqlxtended.Return.USAGE
+
+        if len(msg) < 2:
+            target_player = player
+        else:
+            try:
+                sid = int(msg[1])
+                assert len(msg[1]) == 17
+                target_player = sid
+            except:
+                target_player = self.find_by_name_or_id(player, msg[1])
+                if not target_player: return minqlxtended.Return.STOP_EVENT
+
+        # If there is a duel going on and a spec called the command,
+        # ensure that the playing players don't see it
+        if self.game.type_short == "duel" and self.game.state == "in_progress":
+            if player.team != "free":
+                channel = minqlxtended.SPECTATOR_CHAT_CHANNEL
+
+        # go fetch his elo
+        self.fetch(target_player, self.game.type_short, channel)
+
+
+    def cmd_all_elos(self, player, msg, channel):
+        if len(msg) > 2:
+            return minqlxtended.Return.USAGE
+
+        if len(msg) < 2:
+            target_player = player
+        else:
+            try:
+                sid = int(msg[1])
+                assert len(msg[1]) == 17
+                target_player = sid
+            except:
+                target_player = self.find_by_name_or_id(player, msg[1])
+                if not target_player: return minqlxtended.Return.STOP_EVENT
+
+        # go fetch his elo
+        self.fetch(target_player, None, channel)
+
+    # Show info of people fallen off the scoreboard
+    def cmd_scoreboard(self, player, msg, channel):
+        def show(target):
+            _n = target.name
+            _s = target.stats.score
+            _k = target.stats.kills
+            _d = target.stats.deaths
+            try:
+                _p = target.stats.ping
+            except:
+                _p = "--" # in case of older minqlx version
+
+            _tm = int(target.stats.time / 60000 )
+            _ts = int((target.stats.time % 60000) / 1000)
+            _dd = target.stats.damage_dealt
+            _t = target.team
+            _ad = "{}^2ALIVE" if target.is_alive else "{}^1DEAD"
+            _hc = int(target.cvars.get('handicap', 100))
+            _c = '^7,'
+            if _t == 'blue': _c = '^4,'
+            if _t == 'red': _c = '^1,'
+            _hc = "^3{}％^7-".format(_hc) if (_hc < 100) else ''
+            _ad = _ad.format(_hc)
+
+
+            message = "{}^7({}^7) {k}score ^7{}{c} {k}k/d ^7{}/{}{c} {k}dmg ^7{}{c} {k}time ^7{}m{}s{c} {k}ping ^7{}"
+            message = message.format(_n, _ad, _s, _k, _d, _dd, _tm, _ts, _p, c=_c, k=_c[0:-1])
+            channel.reply("^7" + message)
+
+        teams = self.teams()
+        scoreboard_length = 8
+
+        players = []
+        if len(teams['red']) > scoreboard_length:
+            sorted_red = sorted(teams["red"], key=lambda p: p.score, reverse=True)
+            for p in sorted_red[scoreboard_length:]:
+                players.append(p)
+        if len(teams['blue']) > scoreboard_length:
+            sorted_blue = sorted(teams['blue'], key=lambda p: p.score, reverse=True)
+            for p in sorted_blue[scoreboard_length:]:
+                players.append(p)
+
+        if not players:
+            channel.reply("^7No players falling off the scoreboard...")
+            return
+
+        for p in players:
+            show(p)
+
+
+
+
+
+    @minqlxtended.thread
+    def fetch(self, player, gt, channel):
+        try:
+            sid = player.steam_id
+        except:
+            sid = player
+
+        attempts = 0
+        last_status = 0
+        while attempts < MAX_ATTEMPTS:
+            attempts += 1
+            url = f"{self.api_url}{sid}"
+            res = requests.get(url)
+            last_status = res.status_code
+            if res.status_code != requests.codes.ok:
+                continue
+
+            js = res.json()
+            if "players" not in js:
+                last_status = -1
+                continue
+
+            if "deactivated" in js and js["deactivated"]:
+
+                # If we notice deactivated, ban player (auto or cmd initiated)
+                if self.get_cvar("qlx_pinfo_ban_deactivated", int):
+                    self.ban_deactivated(player)
+                    return
+
+                elif self.get_cvar("qlx_pinfo_show_deactivated", int):
+                    @minqlxtended.next_frame
+                    def warn():
+                        self.msg("^3SERVER WARNING^7! {}^7's account has been ^1DEACTIVATED^7 on {}.".format(player.name, self.balanceApiUrl))
+                    warn()
+
+            # if we came here from a connect trigger, for a server that doesnt want auto info, return
+            if not channel and not self.get_cvar("qlx_pinfo_display_auto", int):
+                return
+
+            if not channel:
+                channel = minqlxtended.CHAT_CHANNEL
+                if self.game.state == "in_progress":
+                    channel = minqlxtended.SPECTATOR_CHAT_CHANNEL
+
+
+            for p in js["players"]:
+                _sid = int(p["steamid"])
+                if _sid == sid: # got our player
+                    # If they want all the elos
+                    if not gt: return self.callback_all(player, p, channel)
+                    # If the request gametype is found
+                    if gt in p: return self.callback(player, p[gt]["elo"], p[gt]["games"], channel)
+                    # If the gametype was not found
+                    else: return self.callback(player, 0,0, channel)
+
+
+
+        return self.callback(player, 0, 0, channel)
+
+
+    def callback_all(self, player, modes, channel):
+        info = []
+        for mode in modes:
+            if mode not in EXT_SUPPORTED_GAMETYPES: continue
+            elo = modes[mode]['elo']
+            games = modes[mode]["games"]
+            info.append(" ^3{}^7: {} ({} games)".format(mode.upper(), elo, games))
+
+        if not info:
+            channel.reply("^6{}^7 has no tracked elos.".format(player.name))
+        else:
+            b = 'b' if self.get_cvar('qlx_balanceApi') == 'elo_b' else ''
+            channel.reply("^6{}^7's {}ELO's: {}".format(player.name, b, ", ".join(info)))
+
+
+    def callback(self, target_player, elo, games, channel):
+
+        try:
+            ident = target_player.steam_id
+            name = target_player.name
+        except:
+            ident = target_player
+            name = target_player
+
+        try:
+            completed = int(self.db[COMPLETED_KEY.format(ident)])
+        except:
+            completed = 0
+        try:
+            left = int(self.db[LEFT_KEY.format(ident)])
+        except:
+            left = 0
+
+
+        if left + completed == 0:
+            games_here_p = 1
+        else:
+            games_here_p = left + completed
+
+
+        info = ["^6{} ^7games here".format(completed + left)]
+        info[0] = info[0] + " ^7(^6{}^7 tracked {})".format(games, self.game.type_short)
+
+        info.append("^7quit ^6{}^7％".format(round(left/(games_here_p)*100)))
+
+        info.append("^3{} ^7{}ELO: ^6{}^7".format(self.game.type_short.upper(),'b' if self.get_cvar('qlx_balanceApi') == 'elo_b' else '', elo, games))
+
+        return channel.reply("^6{}^7: ".format(name) + "^7, ".join(info) + "^7.")
+
+    @minqlxtended.delay(2)
+    def ban_deactivated(self, player):
+        try:
+            duration = self.get_cvar("qlx_pinfo_ban_duration_weeks", int)
+            td = datetime.timedelta(weeks=duration)
+            now = datetime.datetime.now().strftime(TIME_FORMAT)
+            expires = (datetime.datetime.now() + td).strftime(TIME_FORMAT)
+            base_key = PLAYER_KEY.format(player.steam_id) + ":bans"
+            ban_id = self.db.zcard(base_key)
+            db = self.db.pipeline()
+            zadd_compat(db, base_key, ban_id, time.time() + td.total_seconds())
+            ban = {"expires": expires, "reason": "deactivated account", "issued": now, "issued_by": "player_info"}
+            db.hmset(base_key + ":{}".format(ban_id), ban)
+            db.execute()
+            self.kick(player.id, "banned from this server because of deactivated account.")
+        except:
+            n = player.name
+            self.kick(player.id, "kicked because of deactivated account.")
+            self.msg("{} has been kicked, but could not be banned. Contact iouonegirl".format(n))

--- a/ql-assets/data/minqlxtended-plugins/reset_acc.py
+++ b/ql-assets/data/minqlxtended-plugins/reset_acc.py
@@ -1,0 +1,328 @@
+"""
+reset_acc - Reset scoreboard stats mid-game (accuracy, K/D, score).
+
+Designed for FFA warmup/practice servers where players want per-fight
+stats. After a fight, type !resetstats to zero your accuracy, kills,
+deaths, and score so the next Tab press shows only that engagement.
+
+On minqlxtended this needs no engine patch: gclient_t is exposed as writable
+memory (engine_fields.h:536), so the reset is ordinary attribute assignment.
+
+One limit, inherited from the engine rather than chosen here: the per-weapon
+shotsFired/shotsHit arrays behind the end-of-match weapon breakdown are
+WEAPONS fields, and python_objects.c:1156 defines their setter as NULL. They
+are snapshots with no write path. So the aggregate accuracy the scoreboard
+shows resets; the per-weapon breakdown does not.
+
+Commands:
+  !resetstats          - Reset accuracy, K/D, and score to 0
+  !resetstats <name>   - Admin: reset another player's stats
+  !resetacc            - Reset accuracy only (K/D unchanged)
+  !resetacc <name>     - Admin: reset another player's accuracy only
+  !autoresetacc        - Toggle accuracy reset after kills/deaths (2s)
+  !autoresetstats      - Toggle full stats reset after kills/deaths (2s)
+"""
+
+import threading
+import minqlxtended
+
+ADMIN_LEVEL = 2
+AUTO_RESET_DELAY = 2.0
+
+DB_KEY = "minqlx:players:{}:reset_acc:{}"
+
+
+def _zero_accuracy(client_id):
+    """Zero the aggregate accuracy counters for a client.
+
+    Replaces minqlx.reset_player_accuracy() from
+    ql-assets/patches/minqlx-reset-accuracy.patch, which wrote the same two
+    fields in C. That patch does not exist on this runtime and is not needed.
+
+    Returns False when the client id has no gclient_t behind it — the same
+    answer the patch gave for `!g_entities[client_id].client`.
+    """
+    try:
+        client = minqlxtended.GameClient(client_id)
+    except (ValueError, TypeError, AttributeError):
+        return False
+
+    client.accuracy_shots = 0
+    client.accuracy_hits = 0
+    return True
+
+
+def _zero_stats(client_id):
+    """Zero accuracy, round counters, and kills/deaths for a client.
+
+    Replaces minqlx.reset_player_stats(). The C patch also zeroed
+    expandedStats.shotsFired[16] and shotsHit[16]; those are WEAPONS fields
+    with no setter (python_objects.c:1156), so the per-weapon breakdown
+    survives a reset on this runtime.
+    """
+    if not _zero_accuracy(client_id):
+        return False
+
+    client = minqlxtended.GameClient(client_id)
+    client.round_shots = 0
+    client.round_hits = 0
+    client.expanded_stats.num_kills = 0
+    client.expanded_stats.num_deaths = 0
+    return True
+
+
+class reset_acc(minqlxtended.Plugin):
+    def __init__(self):
+        self.add_command("resetstats", self.cmd_resetstats, 0)
+        self.add_command("resetacc", self.cmd_resetacc, 0)
+        self.add_command("autoresetacc", self.cmd_autoresetacc, 0)
+        self.add_command("autoresetstats", self.cmd_autoresetstats, 0)
+
+        self.add_hook("kill", self.handle_kill)
+        self.add_hook("player_loaded", self.handle_loaded)
+        self.add_hook("player_disconnect", self.handle_disconnect)
+
+        # {steam_id: {"mode": "both", "delay": 2.0}}
+        self._auto_acc = {}
+        self._auto_stats = {}
+        # {steam_id: threading.Timer}
+        self._pending_timers = {}
+
+    # -------------------------------------------------------------------------
+    # Redis persistence
+    # -------------------------------------------------------------------------
+
+    def _db_load(self, player, store, key):
+        sid = player.steam_id
+        mode = self.db.get(DB_KEY.format(sid, f"{key}:mode"))
+        if mode not in ("kill", "death", "both"):
+            return False
+        pref = {"mode": "both", "delay": AUTO_RESET_DELAY}
+        store[sid] = pref
+        self._db_save(player, key, pref)
+        return True
+
+    def _db_save(self, player, key, pref):
+        sid = player.steam_id
+        if pref is None:
+            self.db.delete(DB_KEY.format(sid, f"{key}:mode"))
+            self.db.delete(DB_KEY.format(sid, f"{key}:delay"))
+        else:
+            self.db[DB_KEY.format(sid, f"{key}:mode")] = pref["mode"]
+            self.db[DB_KEY.format(sid, f"{key}:delay")] = str(pref["delay"])
+
+    def handle_loaded(self, player):
+        sid = player.steam_id
+        self._auto_acc.pop(sid, None)
+        self._auto_stats.pop(sid, None)
+
+        if self._db_load(player, self._auto_stats, "stats"):
+            self._db_save(player, "acc", None)
+        elif self._db_load(player, self._auto_acc, "acc"):
+            self._db_save(player, "stats", None)
+        else:
+            self._db_save(player, "stats", None)
+            self._db_save(player, "acc", None)
+
+    # -------------------------------------------------------------------------
+    # Manual reset commands
+    # -------------------------------------------------------------------------
+
+    def cmd_resetstats(self, player, msg, channel):
+        if len(msg) == 1:
+            self._reset_all(player, player)
+            return minqlxtended.Return.STOP_ALL
+
+        if player.privileges is None or player.privileges not in ("admin", "mod"):
+            player.tell("^1Only admins can reset another player's stats.")
+            return minqlxtended.Return.STOP_ALL
+
+        target = self._find_player(" ".join(msg[1:]).lower())
+        if target is None:
+            player.tell(f"^1No player found matching ^7{' '.join(msg[1:])}^1.")
+            return minqlxtended.Return.STOP_ALL
+
+        self._reset_all(player, target)
+        return minqlxtended.Return.STOP_ALL
+
+    def cmd_resetacc(self, player, msg, channel):
+        if len(msg) == 1:
+            self._reset_accuracy(player, player)
+            return minqlxtended.Return.STOP_ALL
+
+        if player.privileges is None or player.privileges not in ("admin", "mod"):
+            player.tell("^1Only admins can reset another player's accuracy.")
+            return minqlxtended.Return.STOP_ALL
+
+        target = self._find_player(" ".join(msg[1:]).lower())
+        if target is None:
+            player.tell(f"^1No player found matching ^7{' '.join(msg[1:])}^1.")
+            return minqlxtended.Return.STOP_ALL
+
+        self._reset_accuracy(player, target)
+        return minqlxtended.Return.STOP_ALL
+
+    # -------------------------------------------------------------------------
+    # Auto-reset toggle commands
+    # -------------------------------------------------------------------------
+
+    def cmd_autoresetacc(self, player, msg, channel):
+        self._handle_auto_toggle(
+            player, msg, self._auto_acc, self._auto_stats,
+            "accuracy", "autoresetacc", "acc", "stats"
+        )
+        return minqlxtended.Return.STOP_ALL
+
+    def cmd_autoresetstats(self, player, msg, channel):
+        self._handle_auto_toggle(
+            player, msg, self._auto_stats, self._auto_acc,
+            "stats", "autoresetstats", "stats", "acc"
+        )
+        return minqlxtended.Return.STOP_ALL
+
+    def _handle_auto_toggle(self, player, msg, store, other_store, label,
+                            cmd, db_key, other_db_key):
+        if len(msg) != 1:
+            player.tell(f"^7Usage: ^3!{cmd} ^7(toggle on/off)")
+            return
+
+        sid = player.steam_id
+        self._cancel_pending(sid)
+
+        if sid in store:
+            store.pop(sid, None)
+            self._db_save(player, db_key, None)
+            player.tell(f"^7Auto-reset {label}: ^1disabled^7.")
+            return
+
+        other_store.pop(sid, None)
+        self._db_save(player, other_db_key, None)
+        pref = {"mode": "both", "delay": AUTO_RESET_DELAY}
+        store[sid] = pref
+        self._db_save(player, db_key, pref)
+        player.tell(
+            f"^7Auto-reset {label}: ^2enabled^7 after kills/deaths "
+            f"(^2{AUTO_RESET_DELAY}s^7)."
+        )
+
+    # -------------------------------------------------------------------------
+    # Kill hook
+    # -------------------------------------------------------------------------
+
+    def handle_kill(self, victim, killer, mod):
+        # kill dispatches the means of death here (_events.py:801), where minqlx passed
+        # a stats dict this read as data["TEAMKILL"]. The engine exposes no teamkill
+        # flag, so derive it: same team, on a team the concept applies to.
+        #
+        # The team check has to exclude `free`. This plugin is aimed at FFA practice
+        # servers, where every player is on the free team — treating same-team as a
+        # teamkill there would classify every kill in the plugin's main use case as
+        # one, and stop the auto-reset it exists to perform.
+        self_kill = killer.steam_id == victim.steam_id
+        is_teamkill = (
+            not self_kill
+            and killer.team == victim.team
+            and killer.team in (minqlxtended.Team.RED, minqlxtended.Team.BLUE)
+        )
+
+        if not self_kill and not is_teamkill:
+            self._schedule_auto_reset(killer, "kill")
+        self._schedule_auto_reset(victim, "death")
+
+    def _schedule_auto_reset(self, player, trigger):
+        sid = player.steam_id
+        client_id = player.id
+
+        # Determine which reset applies (stats takes priority over acc)
+        stats_pref = self._auto_stats.get(sid)
+        acc_pref = self._auto_acc.get(sid)
+
+        reset_fn = None
+        delay = AUTO_RESET_DELAY
+
+        if stats_pref and stats_pref["mode"] in (trigger, "both"):
+            reset_fn = self._reset_all
+        elif acc_pref and acc_pref["mode"] in (trigger, "both"):
+            reset_fn = self._reset_accuracy
+
+        if reset_fn is None:
+            return
+
+        if self._pending_timers.get(sid):
+            return
+
+        def _fire(fn=reset_fn, player_sid=sid, player_id=client_id):
+            @minqlxtended.next_frame
+            def _execute():
+                if self._pending_timers.get(player_sid) is not timer:
+                    return
+                self._pending_timers.pop(player_sid, None)
+                try:
+                    current_player = self.player(player_id)
+                except minqlxtended.NonexistentPlayerError:
+                    return
+                if not current_player or current_player.steam_id != player_sid:
+                    return
+                fn(current_player, current_player, silent=True)
+            _execute()
+
+        timer = threading.Timer(delay, _fire)
+        timer.daemon = True
+        self._pending_timers[sid] = timer
+        try:
+            timer.start()
+        except Exception:
+            if self._pending_timers.get(sid) is timer:
+                self._pending_timers.pop(sid, None)
+            raise
+
+    # -------------------------------------------------------------------------
+    # Disconnect cleanup
+    # -------------------------------------------------------------------------
+
+    def _cancel_pending(self, sid):
+        timer = self._pending_timers.pop(sid, None)
+        if timer is not None:
+            timer.cancel()
+
+    def handle_disconnect(self, player, reason):
+        sid = player.steam_id
+        self._cancel_pending(sid)
+        self._auto_acc.pop(sid, None)
+        self._auto_stats.pop(sid, None)
+
+    # -------------------------------------------------------------------------
+    # Reset helpers
+    # -------------------------------------------------------------------------
+
+    def _reset_all(self, requester, target, silent=False):
+        if not _zero_stats(target.id):
+            requester.tell("^1Could not reset stats (player not fully connected?).")
+            return
+
+        target.score = 0
+
+        if not silent:
+            if requester.id == target.id:
+                requester.tell("^2Stats reset. ^7Accuracy, K/D, and score are now 0.")
+            else:
+                requester.tell(f"^2Reset stats for ^7{target.clean_name}^2.")
+                target.tell(f"^2Your stats were reset by ^7{requester.clean_name}^2.")
+
+    def _reset_accuracy(self, requester, target, silent=False):
+        if not _zero_accuracy(target.id):
+            requester.tell("^1Could not reset accuracy (player not fully connected?).")
+            return
+
+        if not silent:
+            if requester.id == target.id:
+                requester.tell("^2Accuracy reset. ^7Your overall accuracy is now 0.")
+            else:
+                requester.tell(f"^2Reset accuracy for ^7{target.clean_name}^2.")
+                target.tell(f"^2Your accuracy was reset by ^7{requester.clean_name}^2.")
+
+    def _find_player(self, name_fragment):
+        for p in self.players():
+            if name_fragment in p.clean_name.lower():
+                return p
+        return None

--- a/ql-assets/data/minqlxtended-plugins/specqueue.py
+++ b/ql-assets/data/minqlxtended-plugins/specqueue.py
@@ -1,0 +1,2441 @@
+# This is an extension plugin  for minqlxtended.
+# Copyright (C) 2018 BarelyMiSSeD (github)
+
+# You can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+
+# You should have received a copy of the GNU General Public License
+# along with minqlxtended. If not, see <http://www.gnu.org/licenses/>.
+
+# This is a queueing plugin for the minqlx admin bot.
+# This plugin can be used alone or with the serverBDM.py plugin.
+# Player placement into teams can be done using skill ratings (BDM 0r ELO) or used as a simple queue.
+#
+# This plugin is intended to help keep the game as enjoyable as possible,
+#  without the hassles of people making teams uneven, or someone joining later than others,
+#  but happening to hit the join button first and cutting in line when a play spot opens.
+#
+# The plugin will also attempt to keep team games even, when adding 2 players at once,
+#  by putting players into the most appropriate team, based on team scores or player BDMs/ELOs.
+#
+# This plugin will spectate people when teams are uneven. It will, by default settings,
+#  first look at player times then player scores to determine who, on the team with more players,
+#  gets put to spectate. When a player gets put to spectate they will automatically get put into the
+#  queue at the beginning of the line.
+#
+# There is also the option to have the players in spectate for too long (set with qlx_queueMaxSpecTime)
+#  to be kicked. This will only kick the player, not do any kind of ban, so the player can reconnect immediately.
+# This feature will not kick people with permission levels at or above the qlx_queueAdmin level,
+#  or people who are in the queue.
+#
+# Use the command '!fix' to fix a player that is shown as sarge and not seen as an enemy or a teammate.
+# This will set each player's model to the model recorded when they joined the server.
+#
+# See the following section for the meaning of the specqueue server cvars. The section can be copied as-is
+# into a server config file and edited as desired.
+
+# *** NOTE ****
+# This plugin will unload any "set_configstring" hooks loaded by other scripts.
+# The remove action is logged by printing the action to the console, check the minqlxtended.log.
+# If this is not desired comment the self.remove_conflicting_hooks() line.
+# Use minqlxtended.configstring(index) to be able to parse information from the config string.
+
+"""
+//set the minqlx permission level needed to admin this script
+set qlx_queueAdmin "3"
+//enable to use BDM/ELO in placement into teams when 2 players are put in together
+//disable to use as generic queue system (0=off, 1=on)
+set qlx_queueUseSkillPlacement "1"
+//if pacing by skill rating (see qlx_queueUseSkillPlacement), use BDM or ELO (0=ELO, 1=BDM)
+set qlx_queueUseRating "1"
+//The script will try to place players in by BDM/ELO ranking, if this is set on (0=off 1=on) it will
+// put the higher BDM/ELO player in the losing team if the score is greater than the qlx_queueTeamScoresDiff setting
+set qlx_queuePlaceByTeamScores "1"
+//Set the score difference used if qlx_queuePlaceByTeamScores is on
+set qlx_queueTeamScoresDiff "3"
+//Display the Queue message at the start of each round (0=off, 1=on, 2=display every 5th round)
+set qlx_queueQueueMsg "1"
+//Display the Spectate message at the start of each round
+set qlx_queueSpecMsg "1"
+//the minimum amount of players before the teams will be kept player number balanced
+set qlx_queueMinPlayers "2"
+//the maximum amount of players after which the teams will not be kept player number balanced
+set qlx_queueMaxPlayers "30"
+//use time played as a choosing factor to decide which player to spectate
+set qlx_queueSpecByTime "1"
+//use score played as a choosing factor to decide which player to spectate
+set qlx_queueSpecByScore "1"
+//set to either "score" or "time" to set which to use as the primary deciding factor in choosing a player to spectate
+set qlx_queueSpecByPrimary "time"
+//set to an amount of minutes a player is allowed to remain in spectate (while not in the queue) before the server will
+// kick the player to make room for people who want to play. (valid values are greater than "0" and less than "9999")
+set qlx_queueMaxSpecTime "9999"
+// Set the maximum admin spectate time: 0=no Limit, Not 0=setting * qlx_queueMaxSpecTime
+set qlx_queueAdminSpec "2"
+// The amount of time in NO_COUNTDOWN_TEAM_GAMES it will give when teams are detected
+//  as uneven before putting a player in spectate
+set qlx_queueCheckTeamsDelay "5"
+// Enable the fix the sarge player bug to execute at the start of a game
+//  This will wait 2 seconds after the start of the game and set everyone's player model to the model being reported by
+//   the server. It will not change what the player has set unless the server did not correctly receive the
+//   player model information on player connect. This is an attempt to fix any occurrence of a player showing up as
+//   the Sarge character of brown color, appearing like they are not on a team. (0=disable, 1=enable)
+set qlx_queueResetPlayerModels "0"
+// Enable to shuffle teams whenever the map changes, even if the same map is loaded again, or when a game is aborted
+// (0=disable, 1=enable) (enabling not recommended if server is set to auto balance teams)
+set qlx_queueShuffleOnMapChange "0"
+// If shuffle on map change is enabled, sets the amount of time to wait before shuffling teams
+// (must have qlx_queueShuffleOnMapChange enabled to work and a min of 10 and max of 30 seconds is required)
+set qlx_queueShuffleTime "10"
+// If shuffle on map change is enabled, displays a message to players counting down to the shuffle
+// (0=disable, 1=center print every second, 2=center print every 5 seconds,
+//    3=chat message every second, 4=chat message every 5 seconds)
+set qlx_queueShuffleMessage "2"
+// This will enable/disable the labeling of spectators with their spec/queue status (0=disable, 1=enable)
+set qlx_queueShowQPosition "1"
+// Chose the style of character surrounding the spec/queue label (default is brackets [] , ex. [1] )
+// Start counting at 0 and chose the character position from the POSITION_LABEL list, so {} would
+// be set qlx_queuePositionLabel "2". Set qlx_queuePositionLabel to one of these numbers or set it to a
+// custom string, custom setting must have only two positions in, contained in quotes.
+// 0="[]", 1="()", 2="{}", 3="<>", 4="--", 5="==", 6="||", 7="!!", 8="''", 9="..", 10="**", 11="〔〕", 12="《》"
+// 13="〚〛", 14="  " (spaces)
+set qlx_queuePositionLabel "0"  // custom ex: set qlx_queuePositionLabel "~~"
+// This setting will perform check the clan tags saved in the database. Set it to the desired action.
+// 0=Do Nothing, 1=Delete clan tags with special characters, 2=Delete all saved clan tags
+set qlx_queueCleanClanTags "0"
+// Will enforce even teams if enabled (0=disabled, 1=enabled)
+set qlx_queueEnforceEvenTeams "1"
+// Saves the retrieved player ELOs to the database. (0=disable, 1=enable)
+// NOTE: Will overwrite any rankings set if blalance.py's !setelo is used. Makes balance.py get rankings faster.
+set qlx_queueSaveEloToDatabase "1"
+// Will request rankings from ELO_URL each map change. (0=disable, 1=enable)
+set qlx_queueGetEloRatingsEachMap "1"
+"""
+
+import minqlxtended
+import time
+import traceback
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from threading import RLock, Event
+from random import randrange
+import re
+import requests
+
+VERSION = "2.13.6"
+
+# Add allowed spectator tags to this list. Tags can only be 5 characters long.
+SPEC_TAGS = ("afk", "food", "away", "phone")
+
+SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm", "ad", "1f", "har", "ffa", "race", "rr")
+TEAM_BASED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm", "ad", "1f", "har")
+NONTEAM_BASED_GAMETYPES = ("ffa", "race", "rr")
+NO_COUNTDOWN_TEAM_GAMES = ("ft", "1f", "ad", "dom", "ctf")
+RANKING_GAMETYPES = ("ft", "ca", "ctf", "ffa", "ictf", "tdm")
+NON_ROUND_BASED_GAMETYPES = ("ffa", "race", "tdm", "ctf", "har", "dom", "rr")
+BDM_KEY = "minqlx:players:{0}:bdm:{1}:{2}"
+ELO_KEY = "minqlx:players:{0}:ratings:{1}"  # 0 == steam_id, 1 == short game type.
+POSITION_LABELS = ("[]", "()", "{}", "<>", "--", "==", "||", "!!", "''", "..", "**", "〔〕", "《》", "〚〛", "  ")
+ELO_URL = "qlstats.net"
+DEFAULT_ELO = 1122
+ELO_REQUEST_TIMEOUT = 5.0
+
+ENABLE_LOG = True  # set to True/False to enable/disable logging
+
+
+
+# This is the class used to manage the player queue. I tried using the Queue that comes with python
+# and tried just using a simple list, but both of those options had problems with the QL server's stability.
+# I found that making my own queueing class eliminated the problems I was seeing as well as being able to make
+# more efficient code to speed up execution time.
+class PlayerQueue:
+    def __init__(self):
+        self._queue = []
+        self._queue_player = []
+        self._queue_times = {}
+        self._q_count = 0
+        self._lock = RLock()
+
+    def __contains__(self, value):
+        if self._q_count > 0:
+            try:
+                if isinstance(value, int):
+                    return value in self._queue
+                elif value.isdecimal():
+                    return value in self._queue_times
+                else:
+                    return value in self._queue_player
+            except:
+                pass
+        else:
+            return False
+
+    def __getitem__(self, value):
+        if self._q_count > 0:
+            try:
+                if isinstance(value, int):
+                    return self._queue[value]
+                elif value.isdecimal():
+                    if len(value) == 17:
+                        return self._queue_times[value]
+                    else:
+                        return self._queue_player[int(value)]
+            except:
+                pass
+        return None
+
+    def __bool__(self):
+        return self._q_count > 0
+
+    def __len__(self):
+        return self._q_count
+
+    def size(self):
+        return self._q_count
+
+    @property
+    def count(self):
+        return self._q_count
+
+    @property
+    def next(self):
+        return [self._queue[0], self._queue_player[0]]
+
+    @next.setter
+    def next(self, player):
+        self.add_to_queue(player.steam_id, player, 0)
+
+    def empty_queue(self):
+        self.clear()
+
+    def in_queue(self, sid=None, player=None):
+        if not sid and not player:
+            return False
+        if player and not sid:
+            sid = player.steam_id
+        return self._q_count > 0 and sid in self._queue
+
+    def add_to_queue(self, sid, player, pos=None):
+        with self._lock:
+            added = False
+            if sid not in self._queue:
+                if pos is None:
+                    self._queue.append(sid)
+                    self._queue_player.append(player)
+                else:
+                    self._queue.insert(pos, sid)
+                    self._queue_player.insert(pos, player)
+                self._q_count += 1
+                self._queue_times[str(sid)] = time.time()
+                added = True
+            else:
+                if pos is not None:
+                    index = self.get_queue_position(sid)
+                    if sid != index:
+                        self._queue.remove(sid)
+                        self._queue_player.remove(player)
+                        self._queue.insert(pos, sid)
+                        self._queue_player.insert(pos, player)
+                        added = True
+                    if str(sid) not in self._queue_times:
+                        self._queue_times[str(sid)] = time.time()
+            return added
+
+    def get_next(self):
+        return self.get_from_index()
+
+    def get_from_queue(self, pos=None):
+        if self._q_count > 0:
+            pos = 0 if pos is None or pos <= 0 else pos - 1
+            if pos >= self._q_count:
+                pos = self._q_count - 1
+            return self.get_from_index(pos)
+
+    def get_from_index(self, pos=None):
+        if self._q_count > 0:
+            with self._lock:
+                pos = 0 if pos is None or pos < 0 else pos
+                if pos >= self._q_count:
+                    pos = self._q_count - 1
+                self._q_count -= 1
+                sid = self._queue.pop(pos)
+                player = self._queue_player.pop(pos)
+                try:
+                    ptime = self._queue_times.pop(str(sid))
+                except IndexError:
+                    ptime = 0
+                return [sid, player, ptime]
+
+    def get_two(self):
+        if self._q_count > 1:
+            with self._lock:
+                self._q_count -= 2
+                sid1 = self._queue.pop(0)
+                player1 = self._queue_player.pop(0)
+                p1time = None
+                try:
+                    p1time = self._queue_times.pop(str(sid1))
+                except KeyError:
+                    pass
+                sid2 = self._queue.pop(0)
+                player2 = self._queue_player.pop(0)
+                p2time = None
+                try:
+                    p2time = self._queue_times.pop(str(sid2))
+                except KeyError:
+                    pass
+                return [sid1, player1, sid2, player2, p1time, p2time]
+
+    def remove_from_queue(self, sid, player):
+        if self._q_count > 0:
+            with self._lock:
+                if sid in self._queue:
+                    self._q_count -= 1
+                    self._queue.remove(sid)
+                    self._queue_player.remove(player)
+                    try:
+                        del self._queue_times[str(sid)]
+                    except KeyError:
+                        pass
+
+    def get_queue_position(self, player):
+        if player in self._queue:
+            return self._queue.index(player)
+        if player in self._queue_player:
+            return self._queue_player.index(player)
+        else:
+            return -1
+
+    def get_queue_time(self, sid):
+        if str(sid) in self._queue_times:
+            return self._queue_times[str(sid)]
+        else:
+            return None
+
+    def add_to_times(self, sid):
+        with self._lock:
+            sid = str(sid)
+            if sid not in self._queue_times:
+                self._queue_times[sid] = time.time()
+                self._q_count += 1
+
+    def remove_from_times(self, sid):
+        if self._q_count > 0:
+            with self._lock:
+                sid = str(sid)
+                if sid in self._queue_times:
+                    del self._queue_times[sid]
+                    self._q_count -= 1
+
+    def get_time(self, sid):
+        sid = str(sid)
+        if sid in self._queue_times:
+            return self._queue_times[sid]
+        else:
+            return None
+
+    def clear(self):
+        self._queue = []
+        self._queue_player = []
+        self._queue_times = {}
+        self._q_count = 0
+
+    def queue(self):
+        with self._lock:
+            return [self._queue.copy(), self._queue_player.copy(), self._queue_times.copy()]
+
+    def sids(self):
+        with self._lock:
+            return self._queue.copy()
+
+    def players(self):
+        with self._lock:
+            return self._queue_player.copy()
+
+    def times(self):
+        with self._lock:
+            return self._queue_times.copy()
+
+
+class specqueue(minqlxtended.Plugin):
+    def __init__(self):
+        self._queue_label = "[]"
+        if ENABLE_LOG:
+            self.queue_log = logging.Logger(__name__)
+            file_dir = os.path.join(minqlxtended.get_cvar("fs_homepath"), "logs")
+            if not os.path.isdir(file_dir):
+                os.makedirs(file_dir)
+
+            file_path = os.path.join(file_dir, "specqueue.log")
+            file_fmt = logging.Formatter("[%(asctime)s] %(message)s", "%Y-%m-%d %H:%M:%S")
+            file_handler = RotatingFileHandler(file_path, encoding="utf-8", maxBytes=3000000, backupCount=5)
+            file_handler.setFormatter(file_fmt)
+            self.queue_log.addHandler(file_handler)
+            self.queue_log.info("============================= Logger started =============================")
+
+        # queue cvars
+        self.set_cvar_once("qlx_queueAdmin", "3")
+        self.set_cvar_once("qlx_queueUseSkillPlacement", "1")
+        self.set_cvar_once("qlx_queueUseRating", "1")
+        self.set_cvar_once("qlx_queuePlaceByTeamScores", "1")
+        self.set_cvar_once("qlx_queueTeamScoresDiff", "3")
+        self.set_cvar_once("qlx_queueQueueMsg", "1")
+        self.set_cvar_once("qlx_queueSpecMsg", "1")
+        self.set_cvar_once("qlx_queueMinPlayers", "2")
+        self.set_cvar_once("qlx_queueMaxPlayers", "30")
+        self.set_cvar_once("qlx_queueSpecByTime", "1")
+        self.set_cvar_once("qlx_queueSpecByScore", "1")
+        self.set_cvar_once("qlx_queueSpecByPrimary", "time")
+        self.set_cvar_once("qlx_queueMaxSpecTime", "9999")  # time in minutes
+        self.set_cvar_once("qlx_queueAdminSpec", "2")  # 0=no Limit, !0=setting * qlx_queueMaxSpecTime
+        self.set_cvar_once("qlx_queueCheckTeamsDelay", "5")
+        self.set_cvar_once("qlx_queueResetPlayerModels", "0")
+        self.set_cvar_once("qlx_queueShuffleOnMapChange", "0")
+        self.set_cvar_once("qlx_queueShuffleTime", "10")
+        self.set_cvar_once("qlx_queueShuffleMessage", "2")
+        self.set_cvar_once("qlx_queueAfkMoveTime", "0")        # seconds; 0 = disabled
+        self.set_cvar_once("qlx_queueAfkExemptLevel", "5")     # permission level exempt from auto-spec
+        self.set_cvar_once("qlx_queueShowQPosition", "1")
+        self.set_cvar_once("qlx_queuePositionLabel", "0")
+        self.set_cvar_once("qlx_queueCleanClanTags", "0")
+        self.set_cvar_once("qlx_queueEnforceEvenTeams", "1")
+        self.set_cvar_once("qlx_queueSaveEloToDatabase", "1")
+        self.set_cvar_once("qlx_queueGetEloRatingsEachMap", "1")
+
+        # Minqlx bot Hooks
+        self.add_hook("new_game", self.handle_new_game)
+        self.add_hook("game_start", self.handle_game_start)
+        self.add_hook("game_end", self.handle_game_end)
+        self.add_hook("round_countdown", self.handle_round_countdown)
+        self.add_hook("round_start", self.handle_round_start)
+        self.add_hook("round_end", self.handle_round_end)
+        self.add_hook("death", self.death_monitor)
+        self.add_hook("player_connect", self.handle_player_connect)
+        self.add_hook("player_loaded", self.handle_player_loaded, priority=minqlxtended.Priority.LOWEST)
+        self.add_hook("player_disconnect", self.handle_player_disconnect, priority=minqlxtended.Priority.HIGH)
+        self.add_hook("team_switch", self.handle_team_switch)
+        self.add_hook("team_switch_attempt", self.handle_team_switch_attempt, priority=minqlxtended.Priority.HIGH)
+        self.add_hook("set_configstring", self.handle_set_config_string, priority=minqlxtended.Priority.HIGHEST)
+        self.add_hook("client_command", self.handle_client_command)
+        self.add_hook("vote_ended", self.handle_vote_ended)
+        self.add_hook("console_print", self.handle_console_print)
+        self.add_hook("map", self.handle_map)
+
+        # Minqlx bot commands
+        self.add_command(("q", "queue"), self.cmd_list_queue)
+        self.add_command(("s", "specs"), self.cmd_list_specs)
+        self.add_command([x for x in SPEC_TAGS], self.cmd_go_afk)
+        self.add_command(("back", "here"), self.cmd_here)
+        self.add_command("tags", self.cmd_tags)
+        self.add_command(("addqueue", "addq"), self.cmd_queue_add)
+        self.add_command(("qversion", "qv"), self.cmd_qversion)
+        self.add_command("ignore", self.ignore_imbalance, self.get_cvar("qlx_queueAdmin", int))
+        self.add_command("latch", self.ignore_imbalance_latch, self.get_cvar("qlx_queueAdmin", int))
+        self.add_command("fix", self.reset_model, self.get_cvar("qlx_queueAdmin", int))
+        self.add_command(("resetqueue", "rq", "fq"), self.reset_queue, self.get_cvar("qlx_queueAdmin", int))
+        self.add_command(("queuestatus", "qs"), self.get_current_settings, 5)
+        self.add_command("getspec", self.get_spec, 5)
+
+        # Script Variables, Lists, and Dictionaries
+        self._queue = PlayerQueue()
+        self._spec = PlayerQueue()
+        self._join = PlayerQueue()
+        self._afk = PlayerQueue()
+        self._players = []
+        self.red_locked = False
+        self.blue_locked = False
+        self.free_locked = False
+        self.end_screen = False
+        self.displaying_queue = False
+        self.displaying_spec = False
+        self.in_countdown = False
+        self.death_count = 0
+        self.q_game_info = [self.game.type_short, self.get_cvar("teamsize", int), self.get_cvar("fraglimit", int)]
+        self._round = 0
+        self.uneven_teams_move_to_spec = {}
+        self._ignore = False
+        self._latch_ignore = False
+        self._ignore_msg_already_said = False
+        self._player_models = {}
+        self._checking_opening = None
+        self._countdown = False
+        self._queue_tags = False
+        self._specPlayer = []
+        self._afk_tag = {}
+        self._afk_last_pos = {}    # sid -> (x, y, z)
+        self._afk_last_moved = {}  # sid -> float timestamp
+        self._afk_pos_lock = RLock()
+        self._afk_poll_stop = Event()
+        self.retrieving_elo = False
+        self.elo_ratings = {}
+        self.elo_lock = RLock()
+
+        # Initialize Commands
+        self.add_spectators()
+        self.add_join_times()
+        self.record_player_models()
+        self.update_queue_tags()
+        self.check_clan_tags()
+        self.remove_conflicting_hooks()
+        self.set_queue_label()
+        self.get_cvars()
+        self._start_afk_position_poll()
+
+    def __del__(self):
+        self._afk_poll_stop.set()
+
+    # ==============================================
+    #               Event Handler's
+    # ==============================================
+    def handle_player_connect(self, player, is_bot):
+        # player_connect gained `is_bot` (_events.py:586).
+        self.process_player_connect(player)
+        return
+
+    def process_player_connect(self, player):
+        try:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process player connect: {}".format(player))
+            if not self._queue.in_queue(player=player):
+                self.add_to_spec(player)
+                self.remove_from_queue(player)
+                self.remove_from_join(player)
+            self.request_elo_rating(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_player_connect Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_player_loaded(self, player):
+        self.process_player_loaded(player)
+        return
+
+    def process_player_loaded(self, player):
+        try:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process player loaded: {}".format(player))
+            self._player_models[player.id] = player.model
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_player_loaded Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_player_disconnect(self, player, reason):
+        self.process_payer_disconnect(player)
+        return
+
+    def process_payer_disconnect(self, player):
+        try:
+            with self.elo_lock:
+                try:
+                    del self.elo_ratings[str(player.steam_id)]
+                except KeyError:
+                    pass
+            sid = str(player.steam_id)
+            with self._afk_pos_lock:
+                self._afk_last_pos.pop(sid, None)
+                self._afk_last_moved.pop(sid, None)
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process player disconnect: {}".format(player))
+            try:
+                self.remove_from_spec(player)
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue remove from spec on disconnect: {} Exception: {}".format(player, e))
+            try:
+                self.remove_from_queue(player)
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue remove from queue on disconnect: {} Exception: {}".format(player, e))
+            try:
+                self.remove_from_join(player)
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue remove from join on disconnect: {} Exception: {}".format(player, e))
+            try:
+                self.remove_from_afk(player, False)
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue remove from afk on disconnect: {} Exception: {}".format(player, e))
+
+            self.check_for_opening(0.5)
+            if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES and not self.end_screen and\
+                    not (self.red_locked or self.blue_locked or self.free_locked):
+                self.look_at_teams(1.0)
+            if player.id in self._player_models:
+                del self._player_models[player.id]
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_player_disconnect Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        self.update_queue_tags()
+
+    def handle_team_switch(self, player, old_team, new_team):
+        self.process_team_switch(player, new_team)
+        return
+
+    def process_team_switch(self, player, new_team):
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue process team switch: {} to {}".format(player, new_team))
+        if new_team != "spectator":
+            try:
+                self.remove_from_spec(player)
+                self.remove_from_queue(player)
+                if str(player.steam_id) not in self._join:
+                    self.add_to_join(player)
+                player.clan = player.clan
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue handle_team_switch not to spectator Exception: {}\n{}"
+                                        .format(type(e).__name__, traceback.format_exc()))
+        else:
+            try:
+                if not self.end_screen:
+                    self.check_for_opening(0.2)
+                    if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES and\
+                            not (self.red_locked or self.blue_locked or self.free_locked):
+                        self.look_at_teams(1.0)
+
+                @minqlxtended.delay(1)
+                def check_spectator():
+                    if not self._queue.in_queue(player=player):
+                        self.add_to_spec(player)
+                    self.remove_from_join(player)
+
+                if player.steam_id in self.uneven_teams_move_to_spec:
+                    del self.uneven_teams_move_to_spec[player.steam_id]
+                else:
+                    check_spectator()
+            except Exception as e:
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue handle_team_switch to spectator Exception: {}\n{}"
+                                        .format(type(e).__name__, traceback.format_exc()))
+        self.update_queue_tags()
+
+    def handle_team_switch_attempt(self, player, old_team, new_team, target):
+        # team_switch_attempt gained `target` (_events.py:771) — the player being
+        # moved when someone else initiated the switch. Not used: this plugin only
+        # gates a player's own join attempt.
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue handle team switch attempt: {} old_team={} new_team={}"
+                                .format(player, old_team, new_team))
+        if self.q_game_info[0] in SUPPORTED_GAMETYPES and new_team != "spectator" and old_team == "spectator":
+            teams = self.teams()
+            at_max_players = False
+            join_locked = False
+            self.remove_from_afk(player)
+            if self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                if len(teams["red"]) + len(teams["blue"]) >= self.get_max_players():
+                    at_max_players = True
+                join_locked = self.free_locked
+            elif self.q_game_info[0] in NONTEAM_BASED_GAMETYPES:
+                if len(self.teams()["free"]) >= self.get_max_players():
+                    at_max_players = True
+                join_locked = self.red_locked or self.blue_locked
+            if self._queue or join_locked or self.game and self.game.state in ["in_progress", "countdown"] or\
+                    at_max_players:
+                self.add_to_queue(player)
+                self.remove_from_spec(player)
+                self.check_for_opening(0.2)
+                self.update_queue_tags()
+                return minqlxtended.Return.STOP_ALL
+
+    def handle_set_config_string(self, index, values):
+        if not values:
+            return
+        if 529 <= index <= 592:
+            if not self.get_cvar("qlx_queueShowQPosition", bool):
+                return
+            args = minqlxtended.parse_infostring(values)
+            # If the config_string is not complete, don't allow it to be set on the server
+            if 'n' not in args:
+                return minqlxtended.Return.STOP_ALL
+            # This check is due to bots being added to the game, which don't have config_string steam ids
+            if 'st' in args:
+                s_id = args['st']
+                sid = int(s_id)
+            else:
+                sid = self.player(index - 529).steam_id
+                s_id = str(sid)
+            # If the player is in spectate and queue tags are on, process the spectator tag
+            if args['t'] == '3' and self._queue_tags:
+                if not self._queue_label:
+                    self._queue_label = "[]"
+                # if the player is in the queue, set the queue position tag
+                if sid in self._queue:
+                    args['xcn'] = args['cn'] = "{}{}{}" \
+                        .format(self._queue_label[0], self._queue.get_queue_position(sid) + 1, self._queue_label[1])
+                # otherwise set the spectator tag
+                else:
+                    clan = None
+                    location = "minqlx:players:{}:clantag".format(s_id)
+                    if location in self.db:
+                        clan = self.db[location]
+                    if s_id in self._afk and clan not in SPEC_TAGS:
+                        args['xcn'] = args['cn'] = "{}{}{}"\
+                            .format(self._queue_label[0], self._afk_tag[s_id], self._queue_label[1])
+                    elif clan in SPEC_TAGS:
+                        if 3 < len(clan):
+                            args['xcn'] = args['cn'] = "{}".format(clan)
+                        else:
+                            args['xcn'] = args['cn'] = "{}{}{}".format(self._queue_label[0], clan, self._queue_label[1])
+                    else:
+                        args['xcn'] = args['cn'] = "{}s{}".format(self._queue_label[0], self._queue_label[1])
+            # Otherwise set the clan tag, if a clan tag is saved
+            else:
+                location = "minqlx:players:{}:clantag".format(s_id)
+                if location in self.db:
+                    args['xcn'] = args['cn'] = self.db[location]
+                else:
+                    args.pop('xcn', None)
+                    args.pop('cn', None)
+            return ''.join(["\\{}\\{}".format(key, value) for key, value in args.items()]).lstrip("\\")
+        # process the server teamsize and fraglimit settings
+        elif index == 0:
+            args = minqlxtended.parse_infostring(values)
+            self.q_game_info[2] = int(args['fraglimit'])
+            teamsize = int(args['teamsize'])
+            if self.q_game_info[1] != teamsize:
+                self.q_game_info[1] = teamsize
+                if not self.end_screen:
+                    self.check_for_opening(1.5)
+
+    def update_queue_tags(self):
+        if self.get_cvar("qlx_queueShowQPosition", bool):
+            self._queue_tags = True
+            for player in self.teams()["spectator"]:
+                player.clan = player.clan
+        else:
+            self._queue_tags = False
+
+    def handle_client_command(self, player, command):
+        self.process_client_command(player, command)
+        return
+
+    def process_client_command(self, player, command):
+        try:
+            @minqlxtended.delay(0.2)
+            def spec_player():
+                if command == "team s" and player in self.teams()["spectator"]:
+                    self.add_to_spec(player)
+                    self.remove_from_queue(player)
+                    self.remove_from_join(player)
+                    if self.get_cvar("qlx_queueSpecMsg", bool):
+                        player.center_print("^6You are set to spectate only")
+            spec_player()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_client_command Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        self.update_queue_tags()
+
+    def handle_new_game(self):
+        self.process_new_game()
+        return
+
+    def process_new_game(self):
+        try:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process new game")
+            self.q_game_info = [self.game.type_short, self.get_cvar("teamsize", int), self.get_cvar("fraglimit", int)]
+            self.end_screen = False
+            self.displaying_queue = False
+            self.displaying_spec = False
+
+            if self.q_game_info[0] not in SUPPORTED_GAMETYPES:
+                self._queue.clear()
+                self.msg("^1This gametype is not supported by the queueing system. Queue functions are not available.")
+            else:
+                self.check_for_opening(0.5)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_new_game Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_game_start(self):
+        # game_start dispatches no arguments here (_events.py:698).
+        self.process_game_start()
+        return
+
+    def process_game_start(self):
+        try:
+            self.check_spec_time()
+
+            @minqlxtended.thread
+            def t():
+                if self.q_game_info[0] == "ft":
+                    countdown = self._specPlayer[5]
+                else:
+                    countdown = self._specPlayer[6]
+                time.sleep(max(countdown / 1000 - 0.8, 0))
+                if not (self.red_locked or self.blue_locked or self.free_locked):
+                    self.even_the_teams()
+
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process game start")
+
+            t()
+
+            if self.get_cvar("qlx_queueResetPlayerModels", bool):
+                self.reset_players_model(5)
+
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_game_start Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_map(self, mapname, factory):
+        self.process_map()
+        self.get_cvars()
+        return
+
+    @minqlxtended.delay(0.3)
+    def process_map(self):
+        try:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue process map")
+            self.q_game_info = [self.game.type_short, self.get_cvar("teamsize", int), self.get_cvar("fraglimit", int)]
+            self._ignore = False
+            self._ignore_msg_already_said = False
+            with self._afk_pos_lock:
+                self._afk_last_pos.clear()
+                self._afk_last_moved.clear()
+            self.end_screen = False
+            self.check_spec_time()
+            self.death_count = 0
+            self.auto_shuffle_player_teams()
+            if self.get_cvar("qlx_queueGetEloRatingsEachMap", bool):
+                players_sid = [p.steam_id for p in self.players()]
+                self.request_elo_rating(players_sid)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_map Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_game_end(self, aborted):
+        # game_end passes the abort flag directly (_events.py:711), where minqlx
+        # passed a stats dict this read as data["ABORTED"].
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue handle game end: aborted={}".format(aborted))
+        if not aborted:
+            self.end_screen = True
+        return
+
+    def handle_round_countdown(self, round_num):
+        self.process_round_countdown(round_num)
+        return
+
+    def process_round_countdown(self, round_num):
+        try:
+            self._countdown = True
+            self._round = round_num
+            self._ignore = False
+            self._ignore_msg_already_said = False
+            self.check_for_opening(0.2)
+            if self.get_cvar("qlx_queueQueueMsg", bool):
+                self.cmd_list_queue()
+            if self.get_cvar("qlx_queueSpecMsg", bool):
+                self.cmd_list_specs()
+            self.check_queue(0.2)
+            self.check_spec(0.2)
+            if self.q_game_info[0] and not (self.red_locked or self.blue_locked or self.free_locked):
+                self.look_at_teams()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_round_countdown Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_round_start(self, number):
+        self.process_round_start()
+        return
+
+    def process_round_start(self):
+        try:
+            if not self._countdown and not (self.red_locked or self.blue_locked or self.free_locked):
+                self.even_the_teams()
+                self.check_queue(2)
+                self.check_spec(2)
+            self._countdown = False
+            self.check_for_opening(0.2)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_round_start Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_round_end(self, round_number, winning_team, time):
+        # round_end is three arguments here (_events.py:738); minqlx passed one
+        # dict. None of them was read then and none is needed now.
+        self.process_round_end()
+        return
+
+    def process_round_end(self):
+        try:
+            if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES:
+                self.check_for_opening(0.2)
+                if not (self.red_locked or self.blue_locked or self.free_locked):
+                    self.even_the_teams(True)
+                if self.get_cvar("qlx_queueQueueMsg", bool):
+                    self.cmd_list_queue()
+                if self.get_cvar("qlx_queueSpecMsg", bool):
+                    self.cmd_list_specs()
+            self.check_spec_time()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_round_end Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def death_monitor(self, victim, killer, mod):
+        # death dispatches the means of death (_events.py:812), not minqlx's stats
+        # dict. Neither was read; the handler only counts deaths.
+        self.process_death_monitor()
+        return
+
+    def process_death_monitor(self):
+        try:
+            if self.game and self.game.state in ["in_progress", "countdown"]:
+                if self.q_game_info[0] in NON_ROUND_BASED_GAMETYPES:
+                    self.death_count += 1
+                    if self.death_count > 5 and self.death_count > self.q_game_info[2] / 5:
+                        self.check_for_opening(0.2)
+                        if self.get_cvar("qlx_queueQueueMsg", bool):
+                            self.cmd_list_queue()
+                        if self.get_cvar("qlx_queueSpecMsg", bool):
+                            self.cmd_list_specs()
+                        self.check_queue(0.2)
+                        self.check_spec(0.2)
+                        self.death_count = 0
+                        self.check_spec_time()
+                if self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                    self.check_for_opening(0.2)
+        except Exception as e:
+            if "NoneType" not in str(e):
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue death_monitor Exception: {}\n{}"
+                                        .format(type(e).__name__, traceback.format_exc()))
+
+    def handle_console_print(self, text):
+        self.process_console_print(text)
+        return
+
+    def process_console_print(self, text):
+        try:
+            if "locked" in text:
+                if text.find("The RED team is now locked") != -1:
+                    self.red_locked = True
+                elif text.find("The BLUE team is now locked") != -1:
+                    self.blue_locked = True
+                if text.find("The FREE team is now locked") != -1:
+                    self.free_locked = True
+                elif text.find("The RED team is now unlocked") != -1:
+                    self.red_locked = False
+                elif text.find("The BLUE team is now unlocked") != -1:
+                    self.blue_locked = False
+                elif text.find("The FREE team is now unlocked") != -1:
+                    self.free_locked = False
+                self.check_for_opening(0.2)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_console_print Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+
+    def handle_vote_ended(self, votes, vote, args, passed):
+        self.process_vote_ended(vote, passed)
+        return
+
+    def process_vote_ended(self, vote, passed):
+        try:
+            if passed and vote == "teamsize":
+                self.check_for_opening(2.5)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue handle_vote_ended Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    # ==============================================
+    #               Plugin functions
+    # ==============================================
+    # set the label used for spectators, if enabled
+    def set_queue_label(self):
+        label = self.get_cvar("qlx_queuePositionLabel", str)
+        try:
+            self._queue_label = POSITION_LABELS[int(label)]
+        except ValueError:
+            self._queue_label = label
+        except IndexError:
+            self._queue_label = POSITION_LABELS[0]
+
+    # removes any set_configstring hooks used by other plugins
+    @minqlxtended.delay(2)
+    def remove_conflicting_hooks(self):
+        if self.get_cvar("qlx_queueShowQPosition", bool):
+            hook_events = ["set_configstring"]
+            remove_from = ["clan"]
+            loaded_scripts = self.plugins
+            loaded_scripts.pop(self.__class__.__name__)
+            for script, handler in loaded_scripts.items():
+                try:
+                    if script in remove_from:
+                        for hook in handler.hooks:
+                            for event in hook_events:
+                                if event == hook[0]:
+                                    if ENABLE_LOG:
+                                        self.queue_log.info("specqueue: Removing event hook ^7{}"
+                                                            " ^1used in ^7{} ^1plugin"
+                                                            .format(event, script))
+                                    handler.remove_hook(event, hook[1], hook[2])
+                except:
+                    continue
+
+    # Deletes saved clan tags that are not simple in formation
+    def check_clan_tags(self):
+        level = self.get_cvar("qlx_queueCleanClanTags", int)
+        if level:
+            keys = self.db.keys("minqlx:players:*:clantag")
+            for tag in keys:
+                clan_tag = self.db.get(tag)
+                if level == 1:
+                    check_tag = [ord(c) for c in clan_tag]
+                    for char in check_tag:
+                        if 0x20 > char or 0x7F < char:
+                            del self.db[tag]
+                            break
+                    length = len(re.sub(r"\^[0-9]", "", clan_tag))
+                    if length == 0 or length > 5:
+                        del self.db[tag]
+                else:
+                    del self.db[tag]
+
+    # Execute a shuffle command if the game is a team based game type
+    @minqlxtended.thread
+    def auto_shuffle_player_teams(self):
+        try:
+            if self.get_cvar("qlx_queueShuffleOnMapChange", bool) and self.q_game_info[0] in TEAM_BASED_GAMETYPES and\
+                    len(self.players()) > 2 and self.game.state == "warmup":
+                count = 0
+                saved_time = self.get_cvar("qlx_queueShuffleTime", int)
+                shuffle_time = saved_time if 10 <= saved_time <= 30 else 10
+                message_setting = self.get_cvar("qlx_queueShuffleMessage", int)
+                if message_setting:
+                    while count < shuffle_time:
+                        execute_time = shuffle_time - count
+                        if message_setting == 2:
+                            if not count % 5:
+                                self.center_print("^7Shuffling teams in {} second{}"
+                                                  .format(execute_time, "s" if execute_time > 1 else ""))
+                        elif message_setting == 3:
+                            self.msg("^6Shuffling teams in {} second{}"
+                                     .format(execute_time, "s" if execute_time > 1 else ""))
+                        elif message_setting == 4:
+                            if not count % 5:
+                                self.msg("^6Shuffling teams in {} second{}"
+                                         .format(execute_time, "s" if execute_time > 1 else ""))
+                        else:
+                            self.center_print("^7Shuffling teams in {} second{}"
+                                              .format(execute_time, "s" if execute_time > 1 else ""))
+                        count += 1
+                        time.sleep(1)
+                    if message_setting < 3:
+                        self.center_print("^7Shuffling teams")
+                    else:
+                        self.msg("^6Shuffling teams")
+                else:
+                    time.sleep(shuffle_time)
+                if ENABLE_LOG:
+                    self.queue_log.info("specqueue auto_shuffle_player_teams Teams")
+                self.shuffle_players()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue auto_shuffle_player_teams Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.next_frame
+    def shuffle_players(self):
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue Shuffling Teams")
+        minqlxtended.console_command("forceshuffle")
+
+    def get_max_players(self):
+        try:
+            max_players = self.get_cvar("teamsize", int)
+            if self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                max_players *= 2
+            if max_players == 0:
+                max_players = self.get_cvar("sv_maxClients", int)
+            return max_players
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get max players Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_queue_pos(self, player, pos):
+        try:
+            self.remove_from_spec(player)
+            if str(player.steam_id) not in self._join:
+                self.add_to_join(player)
+            self._queue.add_to_queue(player.steam_id, player, pos)
+            self.cmd_list_queue()
+            self.check_for_opening(0.5)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add to queue pos Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_queue(self, player):
+        try:
+            self.remove_from_spec(player)
+            if str(player.steam_id) not in self._join:
+                self.add_to_join(player)
+            self._queue.add_to_queue(player.steam_id, player)
+            position = self._queue.get_queue_position(player)
+            player.center_print("^7You are in the ^4Queue^7 position ^1{}^7\nType ^4{}q ^7to show the queue"
+                                .format(position + 1, self.get_cvar("qlx_commandPrefix")))
+            self.check_for_opening(0.2)
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add to queue: {}".format(player))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add to queue Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def remove_from_queue(self, player):
+        try:
+            if player and self._queue.in_queue(player=player):
+                self._queue.remove_from_queue(player.steam_id, player)
+        except Exception as e:
+            if ENABLE_LOG:
+                raise KeyError("remove from queue Exception: {}\n{}"
+                               .format(type(e).__name__, traceback.format_exc()))
+
+    def check_queue(self, delay=0.1):
+        try:
+            if not self.end_screen and not self.displaying_queue and self._queue\
+                    and self.get_cvar("qlx_queueQueueMsg", bool):
+                self.displaying_queue = True
+                self.queue_message(delay)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue check queue Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def queue_message(self, delay):
+        try:
+            n = self._queue.players()
+            time.sleep(delay)
+            queue_show = self.get_cvar("qlx_queueQueueMsg", int)
+            if queue_show == 2 and self._round % 5 != 0:
+                self.displaying_queue = False
+                return
+            count = 1
+            for p in n:
+                try:
+                    p.center_print("^7You are in ^4Queue ^7position ^1{}".format(count))
+                except Exception as e:
+                    if ENABLE_LOG:
+                        self.queue_log.info("specqueue Queue Message Exception: {}\n{}"
+                                            .format(type(e).__name__, traceback.format_exc()))
+                finally:
+                    count += 1
+            self.displaying_queue = False
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue queue message Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_spectators(self):
+        try:
+            for player in self.teams()["spectator"]:
+                self.add_to_spec(player)
+        except Exception as e:
+            raise KeyError("add spectators Exception: {}; {}"
+                           .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_spec(self, player):
+        try:
+            self._spec.add_to_times(player.steam_id)
+            if self.get_cvar("qlx_queueSpecMsg", bool):
+                player.center_print("^6Spectate Mode\n^7Type ^4!s ^7to show spectators.")
+        except Exception as e:
+            raise KeyError("add to spec Exception: {} ; {}"
+                           .format(type(e).__name__, traceback.format_exc()))
+
+    def remove_from_spec(self, player):
+        try:
+            if player:
+                self._spec.remove_from_times(player.steam_id)
+        except Exception as e:
+            raise KeyError("remove from spec Exception: {} ; {}"
+                           .format(type(e).__name__, traceback.format_exc()))
+
+    def check_spec(self, delay=0.0):
+        try:
+            if not self.end_screen and not self.displaying_spec and self._spec.count > 0\
+                    and self.get_cvar("qlx_queueSpecMsg", bool):
+                self.displaying_spec = True
+                self.spec_message(delay)
+        except Exception as e:
+            raise KeyError("check spec Exception: {} ; {}"
+                           .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def spec_message(self, delay=0.0):
+        try:
+            time.sleep(delay)
+            spec_show = self.get_cvar("qlx_queueSpecMsg", int)
+            spectators = self.teams()["spectator"]
+            if self._spec.count > 0 and len(spectators) > 0:
+                s = self._spec.times()
+                for p, t in s.items():
+                    spec = self.player(int(p))
+                    if spec in spectators:
+                        if spec_show == 2 and self._round % 5 != 0:
+                            continue
+                        time_in_spec = round((time.time() - t))
+                        if time_in_spec / 60 > 1:
+                            spec_time = "^7{}^4m^7:{}^4s^7".format(int(time_in_spec / 60), time_in_spec % 60)
+                        else:
+                            spec_time = "^7{}^4s^7".format(time_in_spec)
+                        max_spec_time = self.get_cvar("qlx_queueMaxSpecTime", int)
+                        admin = self.get_cvar("qlx_queueAdmin", int)
+                        admin_multiplier = self.get_cvar("qlx_queueAdminSpec", int)
+                        permission = self.db.get_permission(int(p))
+                        if 0 < max_spec_time < 9998 and permission < admin:
+                            spec.center_print("^6Spectate Mode for {}\n^7Join the game to ^1play ^7or enter the"
+                                              " ^4Queue.\nYou can remain in spectate for ^1{} ^7minutes."
+                                              .format(spec_time, max_spec_time))
+                        elif permission >= admin and admin_multiplier:
+                            spec.center_print("^6Spectate Mode for {}\n^7Join the game to ^1play ^7or enter the"
+                                              " ^4Queue.\nYou can remain in spectate for ^1{} ^7minutes."
+                                              .format(spec_time, max_spec_time * admin_multiplier))
+                        else:
+                            spec.center_print("^6Spectate Mode for {}\n^7Join the game to ^1play ^7or enter the ^4Queue"
+                                              .format(spec_time))
+            self.displaying_spec = False
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue spec message Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def check_queue_status(self):
+        if self._checking_opening and time.time() - self._checking_opening > 1:
+            self._checking_opening = None
+            self.check_for_opening(0.1)
+
+    @minqlxtended.thread
+    def check_for_opening(self, delay=0.0):
+        if self.end_screen:
+            return
+        if self._checking_opening or not self._queue:
+            self.check_queue_status()
+            return
+        self._checking_opening = time.time()
+        if delay > 0.0:
+            time.sleep(delay)
+        finished = False
+        try:
+            teams = self.teams()
+            state = self.game.state
+            max_players = self.get_max_players()
+            red_players = len(teams["red"])
+            blue_players = len(teams["blue"])
+            free_players = len(teams["free"])
+            if self.q_game_info[0] in NONTEAM_BASED_GAMETYPES:
+                if free_players < max_players and not self.free_locked:
+                    finished = self.place_in_team(max_players - free_players, "free")
+                elif state == "warmup" and free_players > max_players:
+                    fixed = self.fix_free(free_players, max_players, teams)
+                    if not fixed:
+                        if ENABLE_LOG:
+                            self.queue_log.info("specqueue check_for_opening Fix Free error.")
+
+            elif self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                team_size = int(max_players / 2)
+                if not self.red_locked and not self.blue_locked and (red_players + blue_players) < max_players:
+                    fix_teams = state == "warmup" and red_players > team_size or blue_players > team_size
+                    if fix_teams:
+                        fixed = self.fix_teams(red_players, blue_players, max_players, teams)
+                        if not fixed:
+                            if ENABLE_LOG:
+                                self.queue_log.info("specqueue check_for_opening Fix Teams error.")
+                    difference = red_players - blue_players
+                    if difference < 0:
+                        finished = self.place_in_team(abs(difference), "red")
+                    elif difference > 0:
+                        finished = self.place_in_team(difference, "blue")
+                    else:
+                        if self._queue.count > 1:
+                            if red_players < team_size and blue_players < team_size:
+                                finished = self.place_in_both()
+                        elif state == "warmup":
+                            if blue_players < team_size:
+                                finished = self.place_in_team(1, "blue")
+                            elif red_players < team_size:
+                                finished = self.place_in_team(1, "red")
+                elif state == "warmup" and (red_players + blue_players) >= max_players or\
+                        red_players > team_size or blue_players > team_size:
+                    self.fix_teams(red_players, blue_players, max_players, teams)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue check_for_opening Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        self._checking_opening = None
+        return finished
+
+    def place_in_team(self, amount, team):
+        try:
+            if not self.end_screen:
+                count = 0
+                teams = self.teams()
+                while count < amount and self._queue:
+                    p = self._queue.get_next()
+                    if p[1] in teams["spectator"]and p[1].connection_state == "active":
+                        self.team_placement(p[1], team)
+                        if team == "red":
+                            placement = "^1red ^7team"
+                        elif team == "blue":
+                            placement = "^4blue ^7team"
+                        else:
+                            placement = "^2battle"
+                        self.msg("{} ^7has joined the {}.".format(p[1], placement))
+                        count += 1
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue Place in Team Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+            for player in self.teams()["spectator"]:
+                player.tell("^1Error in player placement in team. ^6Check your position in the queue.")
+        return True
+
+    def place_in_both(self):
+        try:
+            if not self.end_screen and self._queue.count > 1:
+                teams = self.teams()
+                spectators = teams["spectator"]
+                players = self._queue.get_two()
+                p1 = None
+                p2 = None
+                if players[1].connection_state != "active" or players[1] not in spectators:
+                    p1 = self._queue.get_next()
+                if players[3].connection_state != "active" or players[3] not in spectators:
+                    p2 = self._queue.get_next()
+                if p1 and p2:
+                    players = [p1[0], p1[1], p2[0], p2[1], p1[2], p2[2]]
+                elif p1:
+                    players = [p1[0], p1[1], players[2], players[3], p1[2], players[5]]
+                elif p2:
+                    players = [players[0], players[1], p2[0], p2[1], players[4], p2[2]]
+                # Get red team's and blue team's score so the correct player placements can be executed
+                # Game.red_score / Game.blue_score do not exist on this runtime;
+                # scores come off team_scores, indexed by Team.index (_game.py:190).
+                # Guarded because team_scores reads the live level and raises
+                # NonexistentGameError once the game is gone (_game.py:55) — a bare
+                # Exception subclass, so catching ValueError alone would miss it.
+                try:
+                    scores = self.game.team_scores
+                    red_score = int(scores[minqlxtended.Team.RED.index])
+                    blue_score = int(scores[minqlxtended.Team.BLUE.index])
+                except (ValueError, TypeError, IndexError, AttributeError,
+                        minqlxtended.NonexistentGameError):
+                    red_score = blue_score = 0
+                score_diff = abs(red_score - blue_score) >= self.get_cvar("qlx_queueTeamScoresDiff", int)
+                if self.q_game_info[0] in RANKING_GAMETYPES and self.get_cvar("qlx_queueUseSkillPlacement", bool):
+                    red_rating, blue_rating, p1_rating, p2_rating = self.get_ratings(players[0], players[2], teams)
+                    self.msg('^2Placing players by ^3{} ^2Balance Used ^7Red: ^1{} ^7Blue: ^4{} '
+                             .format('BDM' if self.get_cvar("qlx_queueUseRating", bool) else 'ELO',
+                                     red_rating, blue_rating))
+                    # set team related variables initial values
+                    # If the team's score difference is over "qlx_queuesTeamScoresAmount" and
+                    #  "qlx_queuesPlaceByTeamScore" is enabled players will be placed with the higher BDM/ELO
+                    #  player going to the lower scoring team regardless of average team BDMs/ELOs
+                    place_by_team_scores = False
+                    if self.get_cvar("qlx_queuePlaceByTeamScores", bool) and score_diff:
+                        place_by_team_scores = True
+                        if p1_rating > p2_rating:
+                            placement = ["blue", "red"] if red_score > blue_score else ["red", "blue"]
+                        else:
+                            placement = ["red", "blue"] if red_score > blue_score else ["blue", "red"]
+                    # Executes if the 'place by team score' doesn't execute and sets player
+                    #   with higher BDM/ELO on the team with the lower average BDM/ELO.
+                    else:
+                        if red_rating > blue_rating:
+                            placement = ["blue", "red"] if p1_rating > p2_rating else ["red", "blue"]
+                        elif blue_rating > red_rating:
+                            placement = ["red", "blue"] if p1_rating > p2_rating else ["blue", "red"]
+                        else:
+                            if red_score > blue_score:
+                                placement = ["blue", "red"] if p1_rating > p2_rating else ["red", "blue"]
+                            else:
+                                placement = ["red", "blue"] if p1_rating > p2_rating else ["blue", "red"]
+                    if place_by_team_scores:
+                        self.msg("^3Due to team score difference, placing players based on team score, not {} balance."
+                                 .format('BDM' if self.get_cvar("qlx_queueUseRating", bool) else 'ELO'))
+                    self.team_placement(players[1], placement[0])
+                    self.msg("{0} ^7:{1}{3} ^7has joined the {1}{2} ^7team."
+                             .format(players[1], "^1" if placement[0] == "red" else "^4", placement[0], p1_rating))
+                    self.team_placement(players[3], placement[1])
+                    self.msg("{0} ^7:{1}{3} ^7has joined the {1}{2} ^7team."
+                             .format(players[3], "^1" if placement[1] == "red" else "^4", placement[1], p2_rating))
+                else:
+                    self.team_placement(players[1], "blue")
+                    self.msg("{} ^7has joined the ^4blue ^7team.".format(players[1]))
+                    self.team_placement(players[3], "red")
+                    self.msg("{} ^7has joined the ^1red ^7team.".format(players[3]))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue Place in Both Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+            for player in self.teams()["spectator"]:
+                player.tell("^1Error in player(s) placement in team. ^6Check your position in the queue.")
+        return True
+
+    def fix_teams(self, red, blue, max_players, player_teams):
+        try:
+            teams = player_teams.copy()
+            total = red + blue
+            team_size = int(max_players / 2)
+            while total > max_players:
+                if red > team_size:
+                    self.get_player_for_spec(teams["red"])
+                    self.team_placement(self._players[0], "spectator", True)
+                    red -= 1
+                    total -= 1
+                if blue > team_size:
+                    self.get_player_for_spec(teams["blue"])
+                    self.team_placement(self._players[0], "spectator", True)
+                    blue -= 1
+                    total -= 1
+            difference = red - blue
+            while difference > 0:
+                self.team_placement(teams["red"][0], "blue")
+                teams["blue"].append(teams["red"].pop(0))
+                difference -= 1
+            while difference < 0:
+                self.team_placement(teams["blue"][0], "red")
+                teams["red"].append(teams["blue"].pop(0))
+                difference += 1
+            return True
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue fix_teams Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def fix_free(self, free, max_players, player_teams):
+        try:
+            teams = player_teams.copy()
+            while free > max_players:
+                self.get_player_for_spec(teams["free"])
+                self.team_placement(self._players[0], "spectator", True)
+                teams["free"].remove(self._players[0])
+                free -= 1
+            return True
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue fix_free Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_ratings(self, p1, p2, teams):
+        bdm = self.get_cvar("qlx_queueUseRating", bool)
+        red_rating = self.team_average(teams["red"], bdm)
+        blue_rating = self.team_average(teams["blue"], bdm)
+        p1_rating = self.get_rating(p1, bdm)
+        p2_rating = self.get_rating(p2, bdm)
+        return red_rating, blue_rating, p1_rating, p2_rating
+
+    def team_average(self, team, bdm=True):
+        try:
+            """Calculates the average rating of a team."""
+            avg = 0
+            if team:
+                for p in team:
+                    r = self.get_rating(p.steam_id, bdm)
+                    avg += r
+                avg /= len(team)
+            return int(round(avg))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue team average Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_rating(self, sid, bdm=True):
+        if bdm:
+            return self.get_bdm_rating(sid)
+        else:
+            return self.get_elo_rating(sid)
+
+    def get_gametype(self):
+        if self.get_cvar("g_factory").lower() == "ictf":
+            game_type = "ictf"
+        else:
+            game_type = self.q_game_info[0]
+        return game_type
+
+    def get_bdm_rating(self, sid):
+        try:
+            game_type = self.get_gametype()
+            if self.db.exists(BDM_KEY.format(sid, game_type, "rating")):
+                try:
+                    rating = self.db.get(BDM_KEY.format(sid, game_type, "rating"))
+                    rating = int(float(rating))
+                except (ValueError, TypeError):
+                    rating = 0
+            else:
+                rating = 0
+            if rating == 0:
+                rating = self.get_cvar("qlx_bdmDefaultBDM", int)
+                if not rating or not isinstance(rating, int):
+                    rating = 1022
+            return rating
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get BDM rating Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_elo_rating(self, sid):
+        try:
+            game_type = self.get_gametype()
+            rating = 0
+            sid = str(sid)
+            with self.elo_lock:
+                if sid in self.elo_ratings and game_type in self.elo_ratings[sid]:
+                    rating = self.elo_ratings[sid][game_type]
+            if rating == 0 and self.db.exists(ELO_KEY.format(sid, self.get_gametype())):
+                try:
+                    rating = int(float(self.db.get(ELO_KEY.format(sid, game_type))))
+                    if rating == DEFAULT_ELO:
+                        self.request_elo_rating(sid)
+                except (ValueError, TypeError):
+                    rating = 0
+            if rating == 0:
+                rating = DEFAULT_ELO
+                self.request_elo_rating(sid)
+            return rating
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get ELO rating Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def request_elo_rating(self, sid):
+        with self.elo_lock:
+            if self.retrieving_elo or not sid:
+                return
+            self.retrieving_elo = True
+        if ENABLE_LOG:
+            self.queue_log.info("Requesting ELO rating information from {} for: {}".format(ELO_URL, sid))
+        try:
+            if isinstance(sid, list):
+                sid = '+'.join(str(x) for x in sid)
+            response = False
+            url = "http://{}/elo/{}".format(ELO_URL, sid)
+            attempts = 0
+            while attempts < 3:
+                attempts += 1
+                info = requests.get(url, timeout=ELO_REQUEST_TIMEOUT)
+                if info.status_code != requests.codes.ok:
+                    continue
+                info_js = info.json()
+                if "players" in info_js:
+                    response = True
+                    break
+                else:
+                    time.sleep(0.1)
+            if response:
+                now = int(time.time())
+                save_db = self.get_cvar("qlx_queueSaveEloToDatabase", bool)
+                with self.elo_lock:
+                    for record in info_js["players"]:
+                        p_sid = record['steamid']
+                        if p_sid not in self.elo_ratings:
+                            self.elo_ratings[p_sid] = {}
+                        self.elo_ratings[p_sid]['time'] = now
+                        for gt in SUPPORTED_GAMETYPES:
+                            if gt in record:
+                                elo = record[gt]["elo"]
+                                if save_db:
+                                    self.db.set(ELO_KEY.format(p_sid, gt), elo)
+                                self.elo_ratings[p_sid][gt] = elo
+                            else:
+                                try:
+                                    del self.elo_ratings[p_sid][gt]
+                                except KeyError:
+                                    pass
+                    if ENABLE_LOG:
+                        self.queue_log.info("ELO ratings: {}".format(self.elo_ratings))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue request_elo_rating Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        finally:
+            self.retrieving_elo = False
+
+    @minqlxtended.next_frame
+    def team_placement(self, player, team, add_queue=False):
+        if ENABLE_LOG:
+            self.queue_log.info("specqueue team placement: {} put on team {}".format(player, team))
+        try:
+            player.put(team)
+            if add_queue:
+                self.add_to_queue_pos(player, 0)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue team placement Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def add_join_times(self):
+        try:
+            teams = self.teams()
+            for player in teams["red"] + teams["blue"] + teams["free"]:
+                self._join.add_to_times(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add join times Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def record_player_models(self):
+        try:
+            for player in self.players():
+                try:
+                    model = player.model
+                except KeyError:
+                    model = "sarge"
+                except Exception as e:
+                    model = "sarge"
+                    if ENABLE_LOG:
+                        self.queue_log.info("specqueue get_player_model Exception: {}\n{}"
+                                            .format(type(e).__name__, traceback.format_exc()))
+                self._player_models[player.id] = model
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue record_player_models Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_join(self, player):
+        try:
+            self._join.add_to_times(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add to join Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def remove_from_join(self, player):
+        try:
+            self._join.remove_from_times(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue remove from join Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_join_time(self, player):
+        try:
+            if str(player.steam_id) not in self._join:
+                self.add_to_join(player)
+                return time.time()
+            return self._join.get_time(player.steam_id)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get join time Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_join_times(self):
+        try:
+            return self._join.times()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get join times Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def look_at_teams(self, delay=None):
+        try:
+            if self.game and self.game.state in ["in_progress", "countdown"] and\
+                    self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                if delay:
+                    time.sleep(delay)
+                teams = self.teams()
+                difference = len(teams["red"]) - len(teams["blue"])
+                abs_diff = abs(difference)
+                if abs_diff == 1 and not self.get_cvar("qlx_queueEnforceEvenTeams", bool):
+                    return
+                if abs_diff > 0 and self._latch_ignore or self._ignore:
+                    if not self._ignore_msg_already_said:
+                        self.msg("^6Uneven teams action^7: no action will be taken due to admin setting!")
+                        self._ignore_msg_already_said = True
+                    return
+                p_count = len(teams["red"]) + len(teams["blue"])
+                players = []
+                move_players = []
+                where = None
+                spec_player = None
+
+                if abs_diff > 0 and self._specPlayer[7] <= p_count <= self._specPlayer[8]:
+                    if difference == -1:
+                        self.get_player_for_spec(teams["blue"].copy())
+                        spec_player = self._players[0]
+                    elif difference == 1:
+                        self.get_player_for_spec(teams["red"].copy())
+                        spec_player = self._players[0]
+                    else:
+                        move = int(abs_diff / 2)
+                        if (difference % 2) == 0:
+                            spec = 0
+                        else:
+                            spec = 1
+                        if difference < 0:
+                            self.get_uneven_players(teams["blue"].copy(), move + spec)
+                            where = "red"
+                        else:
+                            self.get_uneven_players(teams["red"].copy(), move + spec)
+                            where = "blue"
+                        if (difference % 2) != 0:
+                            spec_player = self._players[0]
+                            self._players.pop(0)
+                        for p in self._players:
+                            players.append(p.name)
+                            move_players.append(p)
+                    if not delay:
+                        if len(move_players) > 0:
+                            self.msg("^3Uneven Teams Detected^7: {} ^7will be moved to {}^7."
+                                     .format("^7, ".join(players), where))
+                        if spec_player:
+                            self.msg("^3Uneven Teams Detected^7: {} ^7will be moved to ^3spectate^7."
+                                     .format(spec_player))
+                if delay:
+                    if len(players) > 0:
+                        self.msg("^3Uneven Teams Detected^7: {} ^7will be moved to {}^7."
+                                 .format("^7, ".join(players), where))
+                        self.even_the_teams(False)
+                    elif spec_player:
+                        self.msg("^3Uneven Teams Detected^7: {} ^7will be moved to ^3spectate ^7if not fixed."
+                                 .format(spec_player))
+                        self.msg("^2Looking at teams again in {} seconds to assess even status."
+                                 .format(self._specPlayer[9]))
+                        time.sleep(self._specPlayer[9])
+                        self.even_the_teams(False)
+                else:
+                    self.even_the_teams(True)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue look at teams Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def even_the_teams(self, delay=False):
+        if not self.get_cvar("qlx_queueEnforceEvenTeams", bool):
+            return
+        try:
+            if self.game and self.game.state in ["in_progress", "countdown"] and\
+                    self.q_game_info[0] in TEAM_BASED_GAMETYPES:
+                if delay:
+                    if self.game.type_short == "ft":
+                        countdown = self._specPlayer[5]
+                    else:
+                        countdown = self._specPlayer[6]
+                    time.sleep(max(countdown / 1000 - 0.3, 0))
+
+                teams = self.teams()
+                difference = len(teams["red"]) - len(teams["blue"])
+                if abs(difference) > 0 and self._latch_ignore or self._ignore:
+                    if not self._ignore_msg_already_said:
+                        self.msg("^6Uneven teams action^7: no action will be taken due to admin setting!")
+                        self._ignore_msg_already_said = True
+                    return
+                p_count = len(teams["red"] + teams["blue"])
+                players = []
+                move_players = []
+                where = None
+                spec_player = None
+
+                if abs(difference) > 0 and self._specPlayer[3] <= p_count <= self._specPlayer[4]:
+                    if difference == -1:
+                        self.get_player_for_spec(teams["blue"])
+                        spec_player = self._players[0]
+                        if ENABLE_LOG:
+                            self.queue_log.info("Spectating: {}, Settings: {} {} {}"
+                                                .format(spec_player, self.get_cvar("qlx_queueSpecByTime"),
+                                                        self.get_cvar("qlx_queueSpecByScore"),
+                                                        self.get_cvar("qlx_queueSpecByPrimary")))
+                    elif difference == 1:
+                        self.get_player_for_spec(teams["red"])
+                        spec_player = self._players[0]
+                        if ENABLE_LOG:
+                            self.queue_log.info("Spectating: {}, Settings: {} {} {}"
+                                                .format(spec_player, self.get_cvar("qlx_queueSpecByTime"),
+                                                        self.get_cvar("qlx_queueSpecByScore"),
+                                                        self.get_cvar("qlx_queueSpecByPrimary")))
+                    else:
+                        move = int(abs(difference) / 2)
+                        if (difference % 2) == 0:
+                            spec = 0
+                        else:
+                            spec = 1
+                        if difference < 0:
+                            self.get_uneven_players(teams["blue"].copy(), move + spec)
+                            where = "red"
+                        else:
+                            self.get_uneven_players(teams["red"].copy(), move + spec)
+                            where = "blue"
+                        if (difference % 2) != 0:
+                            spec_player = self._players[0]
+                            self._players.pop(0)
+                        for p in self._players:
+                            players.append(p.name)
+                            move_players.append(p)
+                    if len(move_players) > 0:
+                        for player in move_players:
+                            self.team_placement(player, where)
+                        self.msg("^3Uneven Teams Detected^7: {} ^7was moved to {}^7."
+                                 .format("^7, ".join(players), where))
+                    if spec_player:
+                        self.uneven_teams_move_to_spec[spec_player.steam_id] = True
+                        self.team_placement(spec_player, "spectator", True)
+                        self.msg("^3Uneven Teams Detected^7: {} ^7was moved to ^3spectate^7.".format(spec_player))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue even the teams Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_cvars(self):
+        self._specPlayer = [self.get_cvar("qlx_queueSpecByTime", bool), self.get_cvar("qlx_queueSpecByScore", bool),
+                            True if self.get_cvar("qlx_queueSpecByPrimary").lower() == "score" else False,
+                            self.get_cvar("qlx_queueMinPlayers", int), self.get_cvar("qlx_queueMaxPlayers", int),
+                            self.get_cvar("g_freezeRoundDelay", int), self.get_cvar("g_roundWarmupDelay", int),
+                            self.get_cvar("qlx_queueMinPlayers", int), self.get_cvar("qlx_queueMaxPlayers", int),
+                            self.get_cvar("qlx_queueCheckTeamsDelay", int)]
+
+    # Finds the player, that meets the set criteria, to move to spectate and returns that player
+    # Does not start its own thread
+    def get_player_for_spec(self, team):
+        try:
+            t_players = []
+            s_players = []
+            lowest_time = 0
+            lowest_score = 999
+            for player in team.copy():
+                try:
+                    player.update()
+                except minqlxtended.NonexistentPlayerError:
+                    continue
+                p_time = self.get_join_time(player)
+                if p_time > lowest_time:
+                    lowest_time = p_time
+                    t_players = [player]
+                elif p_time == lowest_time:
+                    t_players.append(player)
+                p_score = player.stats.score
+                if p_score < lowest_score:
+                    lowest_score = p_score
+                    s_players = [player]
+                elif p_score == lowest_score:
+                    s_players.append(player)
+            if self.game.state == "in_progress":
+                if self._specPlayer[0] and self._specPlayer[1]:
+                    if self._specPlayer[2]:
+                        if len(s_players) > 1:
+                            lowest_time = 0
+                            temp_player = s_players[0]
+                            for player in s_players:
+                                if self.get_join_time(player) > lowest_time:
+                                    temp_player = player
+                            self._players = [temp_player]
+                        else:
+                            self._players = [s_players[0]]
+                    else:
+                        if len(t_players) > 1:
+                            lowest_score = 999
+                            temp_player = t_players[0]
+                            for player in t_players:
+                                if player.stats.score < lowest_score:
+                                    temp_player = player
+                            self._players = [temp_player]
+                        else:
+                            self._players = [t_players[0]]
+                elif self._specPlayer[1]:
+                    self._players = [s_players[randrange(len(s_players))]]
+                else:
+                    self._players = [t_players[randrange(len(t_players))]]
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get player for spec Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    # Function meant to return the player that would be sent to spectate because
+    #  the get_player_for_spec function does not return anything
+    # Does not start its own thread
+    def return_spec_player(self, team):
+        try:
+            self.get_player_for_spec(team)
+            return [self._players[0]]
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue return spec player Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def get_spec(self, player, msg, channel):
+        @minqlxtended.thread
+        def get_player():
+            teams = self.teams().copy()
+            if self.game.state == "in_progress":
+                difference = len(teams["red"]) - len(teams["blue"])
+                if difference:
+                    team = teams["red"] if difference > 0 else teams["blue"]
+                else:
+                    team = teams["red"] + teams["blue"]
+                spec_player = self.return_spec_player(team)[0]
+            else:
+                spec_player = self.return_spec_player(teams["red"] + teams["blue"])[0]
+            if ENABLE_LOG:
+                self.queue_log.info("Player to Spectate: ^7{}".format(spec_player))
+
+        get_player()
+
+    @minqlxtended.thread
+    def get_uneven_players(self, team, amount):
+        try:
+            t_players = {}
+            s_players = {}
+            self._players = []
+            for player in team:
+                t_players[str(self.get_join_time(player))] = player
+                s_players[str(player.stats.score)] = player
+
+            if self._specPlayer[0] and self._specPlayer[1]:
+                if self._specPlayer[2]:
+                    sorted_players = sorted(((k, v) for k, v in s_players.items()), reverse=False)
+                else:
+                    sorted_players = sorted(((k, v) for k, v in t_players.items()), reverse=True)
+            elif self._specPlayer[1]:
+                sorted_players = sorted(((k, v) for k, v in s_players.items()), reverse=False)
+            else:
+                sorted_players = sorted(((k, v) for k, v in t_players.items()), reverse=True)
+            count = 0
+            for s, player in sorted_players:
+                self._players.append(player)
+                count += 1
+                if count == amount:
+                    break
+            return
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get uneven players Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def check_spec_time(self):
+        time.sleep(5)
+        try:
+            max_spec_time = self.get_cvar("qlx_queueMaxSpecTime", int)
+            if 0 < max_spec_time < 9998:
+                admin = self.get_cvar("qlx_queueAdmin", int)
+                admin_multiplier = self.get_cvar("qlx_queueAdminSpec", int)
+                spectators = self.teams()["spectator"]
+                if self._spec.count > 0 and len(spectators) > 0:
+                    s = self._spec.times()
+                    for p, t in s.items():
+                        spec = self.player(int(p))
+                        permission = self.db.get_permission(int(p))
+                        if spec in spectators:
+                            time_in_spec = round((time.time() - t)) / 60
+                            if permission >= admin:
+                                if admin_multiplier:
+                                    if time_in_spec >= max_spec_time * admin_multiplier:
+                                        @minqlxtended.next_frame
+                                        def do_kick(s=spec):
+                                            s.kick("was in spectate, not the queue, for too long.")
+                                        do_kick()
+                            elif time_in_spec >= max_spec_time:
+                                @minqlxtended.next_frame
+                                def do_kick(s=spec):
+                                    s.kick("was in spectate, not the queue, for too long.")
+                                do_kick()
+                        else:
+                            self.remove_from_spec(spec)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue check spec time Exception:{} {}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def _start_afk_position_poll(self):
+        while not self._afk_poll_stop.wait(1):
+            self._check_afk_positions()
+
+    def _check_afk_positions(self):
+        try:
+            afk_time = self.get_cvar("qlx_queueAfkMoveTime", int)
+            if afk_time <= 0:
+                return
+            if self._queue.count < 1:
+                return
+            exempt_level = self.get_cvar("qlx_queueAfkExemptLevel", int)
+            now = time.time()
+            free_players = self.teams().get("free", [])
+        except Exception:
+            return
+        for player in free_players:
+            sid = str(player.steam_id)
+            try:
+                if self.db.get_permission(player.steam_id) >= exempt_level:
+                    with self._afk_pos_lock:
+                        self._afk_last_pos.pop(sid, None)
+                        self._afk_last_moved.pop(sid, None)
+                    continue
+                pos = player.position()
+                curr = (pos.x, pos.y, pos.z)
+            except Exception:
+                continue
+            with self._afk_pos_lock:
+                last = self._afk_last_pos.get(sid)
+                if last is None or curr != last:
+                    self._afk_last_pos[sid] = curr
+                    self._afk_last_moved[sid] = now
+                elif now - self._afk_last_moved.get(sid, 0) >= afk_time:
+                    self._afk_last_pos.pop(sid, None)
+                    self._afk_last_moved.pop(sid, None)
+                    name = getattr(player, "clean_name", None) or player.name
+
+                    @minqlxtended.next_frame
+                    def move(p=player, n=name):
+                        try:
+                            p.put("spectator")
+                            self.msg("^1{} was moved to spectator for being AFK.".format(n))
+                        except Exception:
+                            pass
+                    move()
+
+    # Search for a player name match using the supplied string
+    def find_player(self, name):
+        try:
+            found_player = None
+            found_count = 0
+            if name.isdigit():
+                _id = int(name)
+                for player in self.players():
+                    if player.id == _id or player.steam_id == _id:
+                        found_player = player
+                        return found_player, int(str([found_player]).split(":")[0].split("(")[1])
+                return -1, -1
+            else:
+                # Remove color codes from the supplied string
+                player_name = re.sub(r"\^[0-9]", "", name).lower()
+                # search through the list of connected players for a name match
+                for player in self.players():
+                    if player_name in re.sub(r"\^[0-9]", "", player.name).lower():
+                        # if match is found return player, player id
+                        found_player = player
+                        found_count += 1
+                # if only one match was found return player, player id
+                if found_count == 1:
+                    return found_player, int(str([found_player]).split(":")[0].split("(")[1])
+                # if more than one match is found return 0, -1
+                elif found_count > 1:
+                    return 0, -1
+                # if no match is found return -1, -1
+                else:
+                    return -1, -1
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue find_player Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def player_in_queue(self, player):
+        if player in self._queue:
+            return self._queue.get_queue_position(player)
+        else:
+            return None
+
+    # ==============================================
+    #               Minqlx Bot Commands
+    # ==============================================
+    def get_current_settings(self, player, msg, channel):
+        try:
+            message = ["^6SpecQueue current variable states:"]
+            if self._queue:
+                message.append("^3Queue: {} Size: {}".format(str(self._queue.players()), self._queue.count))
+            else:
+                message.append("^3Queue is empty")
+            if self._spec.count > 0:
+                message.append("^3Specs: {} Size: {}".format(str(self._spec.times()), self._spec.count))
+            else:
+                message.append("^3Specs is empty")
+            if self._join.count > 0:
+                message.append("^3Join Times: {} Size: {}".format(str(self._join.times()), self._join.count))
+            else:
+                message.append("^3Join Times is empty")
+            if len(self._player_models) > 0:
+                message.append("^3Player Models^7: {}".format(str(self._player_models)))
+            else:
+                message.append("^3Player Models is empty")
+            message.append("^1Red Locked^7: {}^7, ^4Blue Locked^7: {}^7, ^2Free Locked^7: {}"
+                           .format("^5True" if self.red_locked else "^6False",
+                                   "^5True" if self.blue_locked else "^6False",
+                                   "^5True" if self.free_locked else "^6False"))
+            message.append("^3End Screen status^7: {}".format("^5True" if self.end_screen else "^6False"))
+            message.append("^3Displaying status^7- ^2Queue {}^7, ^4Spec {}"
+                           .format("^5True" if self.displaying_queue else "^6False",
+                                   "^5True" if self.displaying_spec else "^6False"))
+            message.append("^3In Countdown^7: {}".format("^5True" if self.in_countdown else "^6False"))
+            message.append("^3Game Info^7: {}".format(self.q_game_info))
+            message.append("^3Ignore Status^7: {} ^3Latch^7: {}"
+                           .format("^5True" if self._ignore else "^6False",
+                                   "^5True" if self._latch_ignore else "^6False"))
+            if self.get_cvar("qlx_queueUseSkillPlacement", bool):
+                message.append("^3Players are being placed using {} rankings."
+                               .format("BDM" if self.get_cvar("qlx_queueUseRating", bool) else "ELO"))
+            else:
+                message.append("^3Players are not being placed using rankings.")
+            if channel != "console":
+                player.tell("\n".join(message))
+            minqlxtended.console_print(message[0])
+            minqlxtended.console_print(message[1])
+            minqlxtended.console_print(message[2])
+            minqlxtended.console_print(message[3])
+            minqlxtended.console_print(message[4])
+            minqlxtended.console_print(" ".join(message[5:8]))
+            minqlxtended.console_print(" ".join(message[8:11]))
+            minqlxtended.console_print(message[11])
+            return minqlxtended.Return.STOP_ALL
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue get_current_settings Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def reset_queue(self, player, msg, channel):
+        try:
+            minqlxtended.console_command("unlock red")
+            minqlxtended.console_command("unlock blue")
+            minqlxtended.console_command("unlock free")
+            if self.red_locked:
+                self.red_locked = False
+            if self.blue_locked:
+                self.blue_locked = False
+            if self.free_locked:
+                self.free_locked = False
+            if self.end_screen:
+                self.end_screen = False
+            if self.in_countdown:
+                self.in_countdown = False
+            if self.displaying_queue:
+                self.displaying_queue = False
+            if self.displaying_spec:
+                self.displaying_spec = False
+            if self._ignore:
+                self._ignore = False
+            if self._latch_ignore:
+                self._latch_ignore = False
+            self.check_for_opening(0.2)
+            specs = self.teams()["spectator"]
+            if len(specs):
+                for player in specs:
+                    player.tell("^1The queue statuses have been reset. Check your position in the queue.")
+            return minqlxtended.Return.STOP_ALL
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue reset_queue Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    @minqlxtended.thread
+    def reset_players_model(self, msg=None):
+        try:
+            sleep = msg if msg else 0.2
+            time.sleep(sleep)
+            players = self.players().copy()
+            for pid, model in self._player_models.items():
+                try:
+                    player = self.player(pid)
+                except minqlxtended.NonexistentPlayerError:
+                    continue
+                count = len(players)
+                while count > 0:
+                    count -= 1
+                    if players[count].id == pid:
+                        del players[count]
+                        break
+                player.model = model
+            for pl in players:
+                if pl.model:
+                    pl.model = pl.model
+                else:
+                    pl.model = "sarge"
+            return True
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue reset_players_model Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def reset_model(self, player=None, msg=None, channel=None):
+        try:
+            if len(msg) > 1:
+                if msg[1] == "all":
+                    self.reset_players_model()
+                    player.tell("^3Player models have been reset")
+                    return minqlxtended.Return.STOP_ALL
+                else:
+                    try:
+                        pid = int(msg[1])
+                        p = self.player(pid)
+                    except minqlxtended.NonexistentPlayerError:
+                        player.tell("Invalid client ID.")
+                        return
+                    except ValueError:
+                        p, pid = self.find_player(" ".join(msg[1:]))
+                        if pid == -1:
+                            if p == 0:
+                                player.tell("^1Too Many players matched your player name")
+                            else:
+                                player.tell("^1No player matching that name found")
+                            return minqlxtended.Return.STOP_ALL
+                    player = p
+            if player.id in self._player_models:
+                player.model = self._player_models[player.id]
+            elif player.model:
+                player.model = player.model
+            else:
+                player.model = "sarge"
+            return
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue reset_model Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def ignore_imbalance(self, player, msg, channel):
+        try:
+            self.msg("^3The move to ^1spectate ^3action will be ignored this round")
+            self._ignore = True
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue ignore imbalance Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def ignore_imbalance_latch(self, player, msg, channel):
+        try:
+            if len(msg) < 2:
+                player.tell("^3Command must include 'ignore', 'spec', or 'setting'")
+                return minqlxtended.Return.STOP_ALL
+            else:
+                setting = msg[1].lower()
+                if setting == "ignore":
+                    self.msg("^3The move to spectate actions will be ^1ignored ^3until ^4re-enabled")
+                    self._latch_ignore = True
+                elif setting == "spec" or setting == "spectate":
+                    self.msg("^3The move to spectate actions have been ^4re-enabled")
+                    self._latch_ignore = False
+                elif setting == "setting" or setting == "set":
+                    self.msg("^3The move to ^1spectate ^3actions are set to {}"
+                             .format("ignore" if self._latch_ignore else "spectate"))
+                else:
+                    player.tell("^3Command must include 'ignore', 'spec', or 'setting'")
+                    return minqlxtended.Return.STOP_ALL
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue ignore imbalance latch Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_queue_add(self, player, msg, channel):
+        try:
+            if len(msg) < 2:
+                self.add_to_queue(player)
+            elif self.db.has_permission(player.steam_id, self.get_cvar("qlx_queueAdmin", int)):
+                try:
+                    i = int(msg[1])
+                    target_player = self.player(i)
+                    if not (0 <= i < 64) or not target_player:
+                        raise ValueError
+                except ValueError:
+                    player.tell("Invalid ID.")
+                    return
+                except minqlxtended.NonexistentPlayerError:
+                    player.tell("Invalid client ID.")
+                    return
+                except Exception as e:
+                    if ENABLE_LOG:
+                        self.queue_log.info("specqueue Cmd Que Add Exception: {}\n{}"
+                                            .format(type(e).__name__, traceback.format_exc()))
+                    return
+                if len(msg) > 2:
+                    try:
+                        pos = int(msg[2])
+                        self.add_to_queue_pos(target_player, pos)
+                    except ValueError:
+                        self.add_to_queue(target_player)
+                else:
+                    self.add_to_queue(target_player)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue cmd queue add Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+        self.update_queue_tags()
+        self.check_for_opening(0.2)
+
+    def cmd_qversion(self, player, msg, channel):
+        channel.reply("^7This server has installed ^2{0} version {1} by BarelyMiSSeD\n"
+                      "https://github.com/BarelyMiSSeD/minqlx-plugins/{0}.py"
+                      .format(self.__class__.__name__, VERSION))
+
+    def cmd_list_queue(self, player=None, msg=None, channel=None):
+        self.exec_list_queue(player, msg, channel)
+
+    @minqlxtended.thread
+    def exec_list_queue(self, player=None, msg=None, channel=None):
+        try:
+            spectators = self.teams()["spectator"]
+            count = 0
+            message = []
+            if self._queue and len(spectators) > 0:
+                for n in range(0, self._queue.count):
+                    sid = self._queue[n]
+                    p = self.player(sid)
+                    if p in spectators:
+                        t = self._queue[str(sid)]
+                        time_in_queue = round((time.time() - t))
+                        if time_in_queue / 60 > 1:
+                            queue_time = "^7{}^4m^7:{}^4s^7".format(int(time_in_queue / 60), time_in_queue % 60)
+                        else:
+                            queue_time = "^7{}^4s^7".format(time_in_queue)
+                        message.append("{} ^7[{}] ^7{}".format(p, count + 1, queue_time))
+                        count += 1
+                    else:
+                        self.remove_from_queue(p)
+            else:
+                self._queue.empty_queue()
+            if count == 0:
+                message = ["^4No one is in the queue."]
+            if channel:
+                channel.reply("^2Queue^7: " + ", ".join(message))
+            elif player or count:
+                self.msg("^2Queue^7: " + ", ".join(message))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue cmd list queue Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_list_specs(self, player=None, msg=None, channel=None):
+        self.exec_list_specs(player, msg, channel)
+
+    @minqlxtended.thread
+    def exec_list_specs(self, player=None, msg=None, channel=None):
+        try:
+            spectators = self.teams()["spectator"]
+            count = 0
+            message = []
+            if self._spec and len(spectators) > 0:
+                s = self._spec.times()
+                for p, t in s.items():
+                    spec = self.player(int(p))
+                    if spec in spectators:
+                        time_in_spec = round((time.time() - t))
+                        if time_in_spec / 60 > 1:
+                            spec_time = "^7{}^4m^7:{}^4s^7".format(int(time_in_spec / 60), time_in_spec % 60)
+                        else:
+                            spec_time = "^7{}^4s^7".format(time_in_spec)
+                        message.append("{} ^7{}".format(spec, spec_time))
+                        count += 1
+                    else:
+                        self.remove_from_spec(spec)
+            if count == 0:
+                message = ["^4No one is set to spectate only."]
+            if channel:
+                channel.reply("^4Spectators^7: " + ", ".join(message))
+            elif player or count:
+                self.msg("^4Spectators^7: " + ", ".join(message))
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue exec list specs Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def specqueue_version(self):
+        return VERSION
+
+    def cmd_go_afk(self, player=None, msg=None, channel=None):
+        if len(msg) > 1:
+            if self.db.get_permission(player.steam_id) >= self.get_cvar("qlx_queueAdmin", int):
+                match = self.find_player(msg[1])
+                if match and match[0] not in (-1, 0):
+                    self.exec_go_afk(match[0], msg[0][1:])
+                else:
+                    player.tell("^1Could not find unique player matching: {}".format(msg[1]))
+        else:
+            self.exec_go_afk(player, msg[0][1:])
+
+    @minqlxtended.thread
+    def exec_go_afk(self, player, afk_tag):
+        try:
+            if player.team != "spectator":
+                self.team_placement(player, "spectator")
+                if not self.end_screen:
+                    self.check_for_opening(0.2)
+                    if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES and \
+                            not (self.red_locked or self.blue_locked or self.free_locked):
+                        self.look_at_teams(1.0)
+            self.remove_from_queue(player)
+            self.add_to_spec(player)
+            self.remove_from_join(player)
+            self.add_to_afk(player, afk_tag)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue exec_go_afk Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_here(self, player=None, msg=None, channel=None):
+        self.exec_here(player)
+
+    @minqlxtended.thread
+    def exec_here(self, player):
+        try:
+            if player.team == "spectator":
+                if not self.end_screen:
+                    self.check_for_opening(0.2)
+                    if self.q_game_info[0] in NO_COUNTDOWN_TEAM_GAMES and \
+                            not (self.red_locked or self.blue_locked or self.free_locked):
+                        self.look_at_teams(1.0)
+                self.add_to_spec(player)
+                self.remove_from_join(player)
+            self.remove_from_afk(player)
+            self.remove_from_queue(player)
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue exec_here Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def add_to_afk(self, player, afk_tag):
+        try:
+            self._afk.add_to_times(player.steam_id)
+            self._afk_tag[str(player.steam_id)] = afk_tag
+
+            @minqlxtended.next_frame
+            def notify(p=player):
+                p.center_print("^6AFK Mode\n^7Type ^4!here ^7when back.")
+                p.clan = p.clan
+            notify()
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue add_to_afk Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def remove_from_afk(self, player, msg=True):
+        try:
+            sid = player.steam_id
+            if str(sid) in self._afk:
+                self._afk.remove_from_times(sid)
+                if msg:
+                    @minqlxtended.next_frame
+                    def notify(p=player):
+                        p.center_print("^3Not marked AFK\n^7Join to play or enter the queue.")
+                        p.clan = p.clan
+                    notify()
+            if str(sid) in self._afk_tag:
+                del self._afk_tag[str(sid)]
+        except Exception as e:
+            if ENABLE_LOG:
+                self.queue_log.info("specqueue remove_from_afk Exception: {}\n{}"
+                                    .format(type(e).__name__, traceback.format_exc()))
+
+    def cmd_tags(self, player=None, msg=None, channel=None):
+        if self._queue_tags:
+            player.tell("^3Allowed spectator tags are: ^6{}".format("^7, ^6".join(SPEC_TAGS)))
+        else:
+            player.tell("^3Spectator tags are not being monitored")

--- a/ql-assets/data/minqlxtended-plugins/suppress_join_msg.py
+++ b/ql-assets/data/minqlxtended-plugins/suppress_join_msg.py
@@ -1,0 +1,15 @@
+# suppress_join_msg.py
+# Suppresses the "X joined the battle/spectators" center-print shown to all players on connect.
+# The message is hardcoded in qagamex64.so and broadcast as a `cp` server command.
+
+import minqlxtended
+
+
+class suppress_join_msg(minqlxtended.Plugin):
+
+    def __init__(self):
+        self.add_hook("server_command", self.handle_server_command)
+
+    def handle_server_command(self, player, cmd):
+        if cmd.startswith('cp "') and "joined the " in cmd:
+            return minqlxtended.Return.STOP_ALL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 import pytest
 from ui import create_app, db
@@ -57,3 +58,29 @@ def app_context(app):
     """An application context for the app."""
     with app.app_context() as ctx:
         yield ctx
+
+
+@pytest.fixture(autouse=True)
+def _reset_minqlxtended_stub_state():
+    """Clear the minqlxtended stub's shared state between tests.
+
+    GameClient caches one live-memory view per client id, the way the engine hands
+    back the same gclient_t for the same slot. That cache is process-wide, so without
+    this a test reading GameClient(2).accuracy_shots sees whatever an earlier test
+    wrote there. Autouse rather than opt-in: the tests that would be misled are the
+    ones that never thought to ask.
+
+    No-op unless the stub has been installed, so it costs nothing for the rest of the
+    suite.
+    """
+    yield
+    stub = sys.modules.get('minqlxtended')
+    if stub is not None and getattr(stub, '_qlsm_stub', False):
+        stub.GameClient.reset_all()
+        stub.cvars.clear()
+        stub.configstrings.clear()
+        stub.console_lines.clear()
+        stub.console_commands.clear()
+        stub.logged_exceptions.clear()
+        stub.Plugin.game = None
+        stub.Plugin.db = None

--- a/tests/stubs/minqlxtended_stub.py
+++ b/tests/stubs/minqlxtended_stub.py
@@ -210,15 +210,45 @@ class GameClient:
         cls._instances.clear()
 
 
+#: Every @thread call the stub deferred, as (function name, args, kwargs). Lets a test
+#: assert that work was scheduled without that work having run.
+THREAD_CALLS = []
+
+
 def thread(func=None, force=False):
-    """Pass-through stand-in for @minqlxtended.thread: run inline, synchronously."""
+    """Stand-in for @minqlxtended.thread (_core.py:694): return at once, run nothing.
+
+    Deliberately not a pass-through. On the engine the decorated body runs on another
+    thread while the caller carries on, so a constructor that kicks off a worker
+    returns immediately. Running it inline instead means any plugin whose worker
+    polls forever hangs the test run at import — specqueue's __init__ ends with
+    _start_afk_position_poll(), which is exactly that loop.
+
+    A test that wants the body calls the undecorated function through __wrapped__,
+    or calls the plain method it delegates to.
+    """
     def decorate(target):
-        return target
+        @functools.wraps(target)
+        def wrapper(*args, **kwargs):
+            THREAD_CALLS.append((target.__name__, args, kwargs))
+        return wrapper
     return decorate(func) if func is not None else decorate
 
 
 class Plugin:
-    """Minimal Plugin base. Tests assign `game`, `_players`, `db` and `cvars`."""
+    """Minimal Plugin base. Tests assign `game`, `_players`, `db` and `cvars`.
+
+    `game` is a class attribute rather than one set in __new__ because on the engine
+    it is a property over global level state (_plugin.py:221), not per-instance data —
+    a plugin's __init__ can and does read it. specqueue's does, on its first line of
+    real work. Assigning `plugin.game = ...` still shadows it per instance, which is
+    how the serverchecker tests use it. `db` is a class attribute for the same
+    reason — it is a property over the shared connection on the engine
+    (_plugin.py:178), and specqueue's __init__ sweeps clan tags through it.
+    """
+
+    game = None
+    db = None
 
     def __new__(cls, *args, **kwargs):
         """Set instance state up here, not in __init__, exactly as _plugin.py:137 does.
@@ -237,8 +267,6 @@ class Plugin:
         instance.sounds = []
         instance._players = []
         instance._loaded_plugins = {cls.__name__: instance}
-        instance.game = None
-        instance.db = None
         return instance
 
     @property
@@ -374,6 +402,7 @@ def install_stub():
     module.Return = Return
     module.Priority = Priority
     module.thread = thread
+    module.THREAD_CALLS = THREAD_CALLS
     module.next_frame = next_frame
     module.delay = delay
     module.parse_infostring = parse_infostring

--- a/tests/stubs/minqlxtended_stub.py
+++ b/tests/stubs/minqlxtended_stub.py
@@ -47,15 +47,89 @@ class Gametype(StrEnum):
     TDM = "tdm"
 
 
+class Return(enum.Enum):
+    """_enums.py:115. Values are arbitrary here; identity is what handlers compare."""
+    NONE = 0
+    STOP = 1
+    STOP_EVENT = 2
+    STOP_ALL = 3
+    USAGE = 4
+
+
+class Priority(enum.IntEnum):
+    """_enums.py:135. Ordering matters — add_hook sorts on it."""
+    LOWEST = 0
+    LOW = 1
+    NORMAL = 2
+    HIGH = 3
+    HIGHEST = 4
+
+
+def next_frame(func):
+    """_core.py:586. Runs inline here; the engine defers one server frame."""
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def delay(time):
+    """_core.py:605. Runs inline here; the engine schedules on a timer."""
+    def decorate(func):
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return wrapper
+    return decorate
+
+
+def parse_infostring(infostring):
+    """_core.py:97. Splits a backslash-delimited infostring into a dict.
+
+    No `ordered` kwarg — dicts preserve insertion order, which is what minqlx's
+    parse_variables(..., ordered=True) was asking for.
+    """
+    parts = [p for p in infostring.split("\\") if p != ""]
+    return dict(zip(parts[::2], parts[1::2]))
+
+
+class _Channel:
+    """Stands in for _commands.py:560-563's channel singletons."""
+
+    def __init__(self, name):
+        self.name = name
+        self.replies = []
+
+    def reply(self, msg, **kwargs):
+        self.replies.append(msg)
+
+    def __str__(self):
+        return self.name
+
+
 # Handler arity per event, excluding `self`. From _events.py at the pinned commit.
+# The line number is the dispatch() that fixes the arity.
 EVENT_ARITIES = {
-    "game_start": 0,
-    "game_end": 1,
-    "player_connect": 2,
-    "player_disconnect": 2,
-    "map": 2,
-    "player_loaded": 1,
-    "player_spawn": 1,
+    "console_print": 1,        # :406  (text)
+    "client_command": 2,       # :450  (player, cmd)
+    "server_command": 2,       # :486  (player, cmd)
+    "set_configstring": 2,     # :522  (index, value)
+    "chat": 3,                 # :557  (player, msg, channel) — recipient is optional
+    "player_connect": 2,       # :586  (player, is_bot)      — was 1 on minqlx
+    "player_loaded": 1,        # :610  (player)
+    "player_disconnect": 2,    # :618  (player, reason)
+    "player_spawn": 1,         # :626  (player)
+    "vote_ended": 4,           # :674  (votes, vote, args, passed)
+    "game_countdown": 0,       # :690  ()
+    "game_start": 0,           # :698  ()                     — was 1 on minqlx
+    "game_end": 1,             # :711  (aborted)              — was a stats dict
+    "round_countdown": 1,      # :719  (round_number)
+    "round_start": 1,          # :727  (round_number)
+    "round_end": 3,            # :738  (round_number, winning_team, time) — was 1
+    "team_switch": 3,          # :750  (player, old_team, new_team)
+    "team_switch_attempt": 4,  # :771  (player, old_team, new_team, target) — was 3
+    "map": 2,                  # :779  (mapname, factory)
+    "new_game": 0,             # :790  ()
+    "kill": 3,                 # :801  (victim, killer, mod)  — mod, not a stats dict
+    "death": 3,                # :812  (victim, killer, mod)  — mod, not a stats dict
 }
 
 
@@ -68,8 +142,62 @@ class NonexistentGameError(Exception):
     """
 
 
+class NonexistentPlayerError(Exception):
+    """_player.py:92. Raised when a client id no longer maps to a player."""
+
+
 class SignatureMismatch(Exception):
     """What the engine raises at registration for a bad handler signature."""
+
+
+class _ExpandedStats:
+    """GameClient(n).expanded_stats — engine_fields.h:467.
+
+    num_kills / num_deaths are INT fields with setters. shots_fired / shots_hit are
+    WEAPONS fields, and python_objects.c:1156 defines QLX_SETTER_WEAPONS as NULL, so
+    they are snapshots with no write path. Assigning raises here as it does there.
+    """
+
+    _READ_ONLY = ("shots_fired", "shots_hit", "num_weapon_kills", "num_weapon_deaths",
+                  "damage_dealt", "damage_taken")
+
+    def __init__(self):
+        object.__setattr__(self, "num_kills", 0)
+        object.__setattr__(self, "num_deaths", 0)
+        for name in self._READ_ONLY:
+            object.__setattr__(self, name, tuple([0] * 16))
+
+    def __setattr__(self, name, value):
+        if name in self._READ_ONLY:
+            raise AttributeError(f"attribute '{name}' of 'ExpandedStats' is not writable")
+        object.__setattr__(self, name, value)
+
+
+class GameClient:
+    """A stand-in for the engine's live gclient_t view (engine_fields.h:536).
+
+    Instances are cached per client id so a plugin that constructs GameClient(id)
+    twice sees the same memory, as it would on the engine.
+    """
+
+    _instances = {}
+
+    def __new__(cls, client_id):
+        if client_id not in cls._instances:
+            instance = super().__new__(cls)
+            instance.client_id = client_id
+            instance.accuracy_shots = 0
+            instance.accuracy_hits = 0
+            instance.round_shots = 0
+            instance.round_hits = 0
+            instance.expanded_stats = _ExpandedStats()
+            cls._instances[client_id] = instance
+        return cls._instances[client_id]
+
+    @classmethod
+    def reset_all(cls):
+        """Clear the per-id cache between tests."""
+        cls._instances.clear()
 
 
 def thread(func=None, force=False):
@@ -84,8 +212,13 @@ class Plugin:
 
     def __init__(self):
         self.hooks = []
+        self.commands = []
         self.cvars = {}
+        self.messages = []
+        self.center_prints = []
+        self.sounds = []
         self._players = []
+        self.plugins = {}
         self.game = None
         self.db = None
 
@@ -109,11 +242,70 @@ class Plugin:
             )
         self.hooks.append((event, handler, priority))
 
+    def add_command(self, name, handler, permission=0, channels=None,
+                    exclude_channels=(), priority=None, client_cmd_pass=False,
+                    client_cmd_perm=5, prefix=True, usage=""):
+        """_plugin.py:281. Records rather than registers; tests call handlers directly."""
+        names = (name,) if isinstance(name, str) else tuple(name)
+        self.commands.append((names, handler, permission, usage))
+
+    def set_cvar_once(self, name, value, flags=0):
+        """_plugin.py:602. True if it set the cvar, False if it already existed."""
+        if name in self.cvars:
+            return False
+        self.cvars[name] = value
+        return True
+
+    def set_cvar(self, name, value, flags=0):
+        self.cvars[name] = value
+        return True
+
     def get_cvar(self, name, return_type=str, default=None):
         return self.cvars.get(name, default)
 
     def players(self):
         return list(self._players)
+
+    def msg(self, msg, chat_channel=None, **kwargs):
+        self.messages.append(msg)
+
+    def center_print(self, msg):
+        self.center_prints.append(msg)
+
+    def play_sound(self, sound_path, player=None):
+        self.sounds.append((sound_path, player))
+
+    @staticmethod
+    def clean_text(text):
+        """_plugin.py:701. Strips Quake colour codes."""
+        import re
+        return re.sub(r"\^[0-9]", "", text)
+
+    def player(self, name, player_list=None):
+        """_plugin.py:644. Accepts a client id or a Player; None when absent."""
+        candidates = player_list if player_list is not None else self._players
+        if isinstance(name, int):
+            for candidate in candidates:
+                if getattr(candidate, "id", None) == name:
+                    return candidate
+            return None
+        return name if name in candidates else None
+
+    def find_player(self, name, player_list=None):
+        """_plugin.py:738. Every player whose cleaned name contains `name`."""
+        candidates = player_list if player_list is not None else self._players
+        needle = self.clean_text(name).lower()
+        return [p for p in candidates
+                if needle in self.clean_text(getattr(p, "name", "")).lower()]
+
+    def teams(self, player_list=None):
+        """_plugin.py:766. Players bucketed by team, keyed by the Team enum's value."""
+        candidates = player_list if player_list is not None else self._players
+        buckets = {team.value: [] for team in Team}
+        for candidate in candidates:
+            team = getattr(candidate, "team", Team.SPECTATOR)
+            buckets[getattr(team, "value", team)].append(candidate)
+        return buckets
 
     @property
     def logger(self):
@@ -137,15 +329,42 @@ def install_stub():
     # These classes are defined in this file, so their __module__ names this
     # stub. On the engine they belong to `minqlxtended`, and a ported plugin is
     # checked against that, so hand them the identity they are impersonating.
-    for impersonator in (Plugin, Team, GameState, Gametype, SignatureMismatch,
-                         NonexistentGameError):
+    for impersonator in (Plugin, Team, GameState, Gametype, Return, Priority,
+                         SignatureMismatch, NonexistentGameError,
+                         NonexistentPlayerError, GameClient, _ExpandedStats):
         impersonator.__module__ = "minqlxtended"
     module.Plugin = Plugin
     module.Team = Team
     module.GameState = GameState
     module.Gametype = Gametype
+    module.Return = Return
+    module.Priority = Priority
     module.thread = thread
+    module.next_frame = next_frame
+    module.delay = delay
+    module.parse_infostring = parse_infostring
+    module.GameClient = GameClient
     module.SignatureMismatch = SignatureMismatch
     module.NonexistentGameError = NonexistentGameError
+    module.NonexistentPlayerError = NonexistentPlayerError
+
+    # Recorded side effects, so a test can assert what a plugin emitted.
+    module.console_lines = []
+    module.console_commands = []
+    module.logged_exceptions = []
+    module.cvars = {}
+    module.configstrings = {}
+
+    module.console_print = lambda text: module.console_lines.append(text)
+    module.console_command = lambda cmd: module.console_commands.append(cmd)
+    module.get_cvar = lambda name, return_type=str, default=None: module.cvars.get(
+        name, default)
+    module.configstring = lambda index, cached=True: module.configstrings.get(index, "")
+    module.log_exception = lambda plugin=None: module.logged_exceptions.append(
+        sys.exc_info())
+
+    module.CHAT_CHANNEL = _Channel("chat")
+    module.SPECTATOR_CHAT_CHANNEL = _Channel("spectator_chat")
+
     sys.modules["minqlxtended"] = module
     return module

--- a/tests/stubs/minqlxtended_stub.py
+++ b/tests/stubs/minqlxtended_stub.py
@@ -210,11 +210,6 @@ class GameClient:
         cls._instances.clear()
 
 
-#: Every @thread call the stub deferred, as (function name, args, kwargs). Lets a test
-#: assert that work was scheduled without that work having run.
-THREAD_CALLS = []
-
-
 def thread(func=None, force=False):
     """Stand-in for @minqlxtended.thread (_core.py:694): return at once, run nothing.
 
@@ -230,13 +225,19 @@ def thread(func=None, force=False):
     def decorate(target):
         @functools.wraps(target)
         def wrapper(*args, **kwargs):
-            THREAD_CALLS.append((target.__name__, args, kwargs))
+            return None
         return wrapper
     return decorate(func) if func is not None else decorate
 
 
 class Plugin:
-    """Minimal Plugin base. Tests assign `game`, `_players`, `db` and `cvars`.
+    """Minimal Plugin base. Tests assign `game`, `connected_players`, `db` and `cvars`.
+
+    The connected-player list is `connected_players`, not `_players`: specqueue owns an
+    attribute called `_players` of its own (specqueue.py:446, its spectator queue) and
+    assigns to it in __init__. A stub backing `players()` with the same name would hand
+    that plugin's internal queue back as the connected-player list — silently, and only
+    for the one plugin where it matters most.
 
     `game` is a class attribute rather than one set in __new__ because on the engine
     it is a property over global level state (_plugin.py:221), not per-instance data —
@@ -265,7 +266,7 @@ class Plugin:
         instance.messages = []
         instance.center_prints = []
         instance.sounds = []
-        instance._players = []
+        instance.connected_players = []
         instance._loaded_plugins = {cls.__name__: instance}
         return instance
 
@@ -326,7 +327,7 @@ class Plugin:
         return self.cvars.get(name, default)
 
     def players(self):
-        return list(self._players)
+        return list(self.connected_players)
 
     def msg(self, msg, chat_channel=None, **kwargs):
         self.messages.append(msg)
@@ -345,7 +346,7 @@ class Plugin:
 
     def player(self, name, player_list=None):
         """_plugin.py:644. Accepts a client id or a Player; None when absent."""
-        candidates = player_list if player_list is not None else self._players
+        candidates = player_list if player_list is not None else self.connected_players
         if isinstance(name, int):
             for candidate in candidates:
                 if getattr(candidate, "id", None) == name:
@@ -355,14 +356,14 @@ class Plugin:
 
     def find_player(self, name, player_list=None):
         """_plugin.py:738. Every player whose cleaned name contains `name`."""
-        candidates = player_list if player_list is not None else self._players
+        candidates = player_list if player_list is not None else self.connected_players
         needle = self.clean_text(name).lower()
         return [p for p in candidates
                 if needle in self.clean_text(getattr(p, "name", "")).lower()]
 
     def teams(self, player_list=None):
         """_plugin.py:766. Players bucketed by team, keyed by the Team enum's value."""
-        candidates = player_list if player_list is not None else self._players
+        candidates = player_list if player_list is not None else self.connected_players
         buckets = {team.value: [] for team in Team}
         for candidate in candidates:
             team = getattr(candidate, "team", Team.SPECTATOR)
@@ -402,7 +403,6 @@ def install_stub():
     module.Return = Return
     module.Priority = Priority
     module.thread = thread
-    module.THREAD_CALLS = THREAD_CALLS
     module.next_frame = next_frame
     module.delay = delay
     module.parse_infostring = parse_infostring

--- a/tests/stubs/minqlxtended_stub.py
+++ b/tests/stubs/minqlxtended_stub.py
@@ -210,17 +210,26 @@ def thread(func=None, force=False):
 class Plugin:
     """Minimal Plugin base. Tests assign `game`, `_players`, `db` and `cvars`."""
 
-    def __init__(self):
-        self.hooks = []
-        self.commands = []
-        self.cvars = {}
-        self.messages = []
-        self.center_prints = []
-        self.sounds = []
-        self._players = []
-        self.plugins = {}
-        self.game = None
-        self.db = None
+    def __new__(cls, *args, **kwargs):
+        """Set instance state up here, not in __init__, exactly as _plugin.py:137 does.
+
+        A plugin's own __init__ overrides this class's and almost never calls
+        super().__init__() — on the engine it does not have to, because __new__ has
+        already run. A stub that initialised in __init__ would raise AttributeError on
+        the first add_hook of every plugin written the normal way.
+        """
+        instance = super().__new__(cls)
+        instance.hooks = []
+        instance.commands = []
+        instance.cvars = {}
+        instance.messages = []
+        instance.center_prints = []
+        instance.sounds = []
+        instance._players = []
+        instance.plugins = {}
+        instance.game = None
+        instance.db = None
+        return instance
 
     def add_hook(self, event, handler, priority=0):
         import inspect

--- a/tests/stubs/minqlxtended_stub.py
+++ b/tests/stubs/minqlxtended_stub.py
@@ -6,6 +6,7 @@ Event arities are taken from _events.py so a handler with a stale signature
 raises here exactly as the engine would raise at plugin load.
 """
 import enum
+import functools
 import sys
 import types
 
@@ -66,7 +67,15 @@ class Priority(enum.IntEnum):
 
 
 def next_frame(func):
-    """_core.py:586. Runs inline here; the engine defers one server frame."""
+    """_core.py:586. Runs inline here; the engine defers one server frame.
+
+    functools.wraps is load-bearing, not tidiness: add_hook checks a handler's
+    signature at registration, and the engine's own decorator wraps (_core.py:598)
+    so a decorated handler still reports the arity it was written with. A stub
+    wrapper without it makes every decorated handler look like it takes no
+    arguments, and every hook registration fail.
+    """
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
     return wrapper
@@ -75,6 +84,7 @@ def next_frame(func):
 def delay(time):
     """_core.py:605. Runs inline here; the engine schedules on a timer."""
     def decorate(func):
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
         return wrapper
@@ -226,10 +236,25 @@ class Plugin:
         instance.center_prints = []
         instance.sounds = []
         instance._players = []
-        instance.plugins = {}
+        instance._loaded_plugins = {cls.__name__: instance}
         instance.game = None
         instance.db = None
         return instance
+
+    @property
+    def plugins(self):
+        """_plugin.py:203. A copy of the loaded-plugin registry, including this one.
+
+        Both halves matter. myFun does
+        `self.plugins.pop(self.__class__.__name__)` to skip itself while scanning for
+        conflicting !sound commands: it needs its own name present or the pop raises,
+        and it needs a copy or the pop would evict a live plugin from the registry.
+        """
+        return self._loaded_plugins.copy()
+
+    @plugins.setter
+    def plugins(self, value):
+        self._loaded_plugins = dict(value)
 
     def add_hook(self, event, handler, priority=0):
         import inspect

--- a/tests/test_commands_minqlxtended.py
+++ b/tests/test_commands_minqlxtended.py
@@ -1,0 +1,101 @@
+"""The ported commands.py lists loaded plugins and their commands.
+
+Upstream ships votecommands.py, which is a different plugin entirely (/pass and /veto),
+so this port drops nothing — see the P3 plan, Finding 6.
+"""
+import importlib.util
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from stubs.minqlxtended_stub import install_stub  # noqa: E402
+
+PLUGIN_PATH = os.path.join('ql-assets', 'data', 'minqlxtended-plugins', 'commands.py')
+
+
+@pytest.fixture(scope='module')
+def module():
+    install_stub()
+    spec = importlib.util.spec_from_file_location('mxt_commands', PLUGIN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakeCommand:
+    def __init__(self, names, permission):
+        self.name = names
+        self.permission = permission
+
+
+class FakePlugin:
+    def __init__(self, commands):
+        self.commands = commands
+
+
+class FakeDb:
+    def __init__(self, permission=5):
+        self._permission = permission
+
+    def get_permission(self, player):
+        return self._permission
+
+
+class FakePlayer:
+    def __init__(self):
+        self.told = []
+
+    def tell(self, msg):
+        self.told.append(msg)
+
+
+@pytest.fixture
+def plugin(module):
+    instance = module.commands()
+    instance.db = FakeDb()
+    instance.plugins = {
+        'essentials': FakePlugin([FakeCommand(['map'], 2), FakeCommand(['kick'], 3)]),
+        'balance': FakePlugin([FakeCommand(['teams'], 0)]),
+    }
+    return instance
+
+
+def test_it_registers_its_commands(plugin):
+    registered = [names for names, _h, _p, _u in plugin.commands]
+    assert ('plugins',) in registered
+    assert ('lc', 'listcmds', 'listcommands') in registered
+
+
+def test_list_plugins_reports_the_count(plugin):
+    player = FakePlayer()
+    plugin.list_plugins(player, ['plugins'], None)
+    assert player.told[0] == '^12 ^3Plugins found:'
+    assert 'balance' in player.told[1] and 'essentials' in player.told[1]
+
+
+def test_cmd_list_hides_commands_above_the_callers_permission(plugin):
+    plugin.db = FakeDb(permission=0)
+    plugin.cvars['qlx_commandsOnlyEligible'] = True
+    player = FakePlayer()
+    plugin.cmd_list(player, ['lc'], None)
+    joined = '\n'.join(player.told)
+    assert 'teams' in joined
+    assert 'kick' not in joined
+
+
+def test_cmd_list_narrows_by_plugin_name(plugin):
+    plugin.cvars['qlx_commandsOnlyEligible'] = False
+    player = FakePlayer()
+    plugin.cmd_list(player, ['lc', 'balance'], None)
+    joined = '\n'.join(player.told)
+    assert 'balance' in joined
+    assert 'essentials' not in joined
+
+
+def test_cmd_list_says_so_when_nothing_matches(plugin):
+    plugin.cvars['qlx_commandsOnlyEligible'] = False
+    player = FakePlayer()
+    plugin.cmd_list(player, ['lc', 'nosuchplugin'], None)
+    assert player.told == ['^3No Plugin matches ^4nosuchplugin']

--- a/tests/test_default_minqlxtended_preset.py
+++ b/tests/test_default_minqlxtended_preset.py
@@ -55,14 +55,25 @@ def test_every_checked_plugin_ships_in_the_preset(checked_plugins):
     assert missing == [], f"checked but not shipped: {missing}"
 
 
-def test_scripts_match_the_vendored_upstream_baseline():
-    """The picker offers exactly what upstream ships. serverchecker is excluded
-    deliberately: it is a SYSTEM_PLUGIN, prepended to qlx_plugins for every
-    instance (ansible_instance_mgmt.py:27) and backfilled from the baseline, so
-    an operator must never be able to untick it."""
+#: Baseline plugins the picker deliberately does not offer.
+#:
+#: serverchecker is a SYSTEM_PLUGIN, prepended to qlx_plugins for every instance
+#: (ansible_instance_mgmt.py:27) and backfilled from the baseline, so an operator must
+#: never be able to untick it.
+#:
+#: reset_acc and suppress_join_msg are not in the minqlx default preset's scripts/
+#: either. The minqlxtended default mirrors the minqlx default's selection, so that an
+#: operator moving between runtimes is offered the same set. Both remain available:
+#: everything in the baseline lands in every instance's plugin directory regardless of
+#: preset, and a host that wants them can enable them by name.
+BASELINE_ONLY = {'serverchecker.py', 'reset_acc.py', 'suppress_join_msg.py'}
+
+
+def test_scripts_match_the_vendored_baseline():
+    """The picker offers the whole baseline bar the three that are deliberately out."""
     preset_scripts = {n for n in os.listdir(os.path.join(PRESET_DIR, 'scripts')) if n.endswith('.py')}
     baseline = {n for n in os.listdir(BASELINE_DIR) if n.endswith('.py')}
-    assert preset_scripts == baseline - {'serverchecker.py'}
+    assert preset_scripts == baseline - BASELINE_ONLY
 
 
 def test_no_minqlx_plugin_leaked_into_the_preset():
@@ -96,3 +107,39 @@ def test_factories_directory_matches_the_minqlx_default():
     ours = sorted(os.listdir(os.path.join(PRESET_DIR, 'factories')))
     theirs = sorted(os.listdir(os.path.join(MINQLX_PRESET_DIR, 'factories')))
     assert ours == theirs
+
+
+# The QLSM ports that are pickable from this preset. myFun, specqueue, player_info and
+# commands ship in the minqlx default preset's scripts/, so their ports ship here.
+# reset_acc and suppress_join_msg do not ship in the minqlx default preset, so they stay
+# baseline-only: present in every instance's plugin directory, not offered by the picker.
+PRESET_VISIBLE_PORTS = ['commands.py', 'myFun.py', 'player_info.py', 'specqueue.py']
+
+
+def test_the_preset_ships_the_pickable_qlsm_ports():
+    missing = [name for name in PRESET_VISIBLE_PORTS
+               if not os.path.isfile(os.path.join(PRESET_DIR, 'scripts', name))]
+    assert missing == [], f"missing from the preset: {missing}"
+
+
+def test_preset_scripts_match_the_baseline_ports():
+    """The preset carries copies, and two copies drift.
+
+    The minqlx side already has exactly this drift: its default preset's
+    specqueue.py has the AFK sweep dedented out of its elif, so it spectates every
+    player on every pass, while ql-assets/data/minqlx-plugins/specqueue.py is
+    correct. This stops the minqlxtended side acquiring its own version of that.
+    """
+    import filecmp
+    drifted = [
+        name for name in PRESET_VISIBLE_PORTS
+        if not filecmp.cmp(os.path.join(BASELINE_DIR, name),
+                           os.path.join(PRESET_DIR, 'scripts', name), shallow=False)
+    ]
+    assert drifted == [], f"preset copies drifted from the baseline: {drifted}"
+
+
+def test_the_system_plugin_is_not_pickable():
+    """serverchecker is backfilled as a SYSTEM_PLUGIN and must never be untickable."""
+    assert not os.path.isfile(
+        os.path.join(PRESET_DIR, 'scripts', 'serverchecker.py'))

--- a/tests/test_default_minqlxtended_preset.py
+++ b/tests/test_default_minqlxtended_preset.py
@@ -130,13 +130,25 @@ def test_preset_scripts_match_the_baseline_ports():
     player on every pass, while ql-assets/data/minqlx-plugins/specqueue.py is
     correct. This stops the minqlxtended side acquiring its own version of that.
     """
+    import difflib
     import filecmp
-    drifted = [
-        name for name in PRESET_VISIBLE_PORTS
-        if not filecmp.cmp(os.path.join(BASELINE_DIR, name),
-                           os.path.join(PRESET_DIR, 'scripts', name), shallow=False)
-    ]
-    assert drifted == [], f"preset copies drifted from the baseline: {drifted}"
+
+    report = []
+    for name in PRESET_VISIBLE_PORTS:
+        baseline = os.path.join(BASELINE_DIR, name)
+        copy = os.path.join(PRESET_DIR, 'scripts', name)
+        if filecmp.cmp(baseline, copy, shallow=False):
+            continue
+        # "files differ" alone sends the reader off to diff 2400 lines by hand.
+        with open(baseline, encoding='utf-8') as a, open(copy, encoding='utf-8') as b:
+            diff = list(difflib.unified_diff(
+                a.readlines(), b.readlines(),
+                fromfile=baseline, tofile=copy, n=1))
+        report.append(''.join(diff[:40]))
+
+    assert report == [], (
+        "preset copies drifted from the baseline; re-copy from "
+        f"{BASELINE_DIR}:\n\n" + "\n".join(report))
 
 
 def test_the_system_plugin_is_not_pickable():

--- a/tests/test_minqlxtended_plugin_baseline.py
+++ b/tests/test_minqlxtended_plugin_baseline.py
@@ -29,6 +29,15 @@ UPSTREAM_PLUGINS = [
 ]
 
 
+# QLSM's own plugins, ported to the minqlxtended API. Not upstream, so a diff against
+# the pinned upstream commit must skip them. Listed rather than derived from the
+# manifest, so that a port silently reclassified as upstream fails here.
+QLSM_PLUGINS = [
+    'commands.py', 'myFun.py', 'player_info.py', 'reset_acc.py', 'serverchecker.py',
+    'specqueue.py', 'suppress_join_msg.py',
+]
+
+
 def _sha256(path):
     with open(path, 'rb') as handle:
         return hashlib.sha256(handle.read()).hexdigest()
@@ -97,3 +106,18 @@ def test_requirements_carry_the_upstream_floors():
         body = handle.read()
     for requirement in ('redis>=5.1.0', 'hiredis>=3.0.0', 'requests>=2.33.0', 'pyzmq>=25.1.1'):
         assert requirement in body, requirement
+
+
+def test_qlsm_ports_are_marked_qlsm(manifest):
+    for name in QLSM_PLUGINS:
+        assert manifest['files'][name]['origin'] == 'qlsm', name
+
+
+def test_every_qlsm_port_is_vendored():
+    missing = [name for name in QLSM_PLUGINS
+               if not os.path.isfile(os.path.join(BASELINE_DIR, name))]
+    assert missing == [], f"missing QLSM ports: {missing}"
+
+
+def test_the_baseline_is_upstream_plus_qlsm_and_nothing_else(manifest):
+    assert set(manifest['files']) == set(UPSTREAM_PLUGINS) | set(QLSM_PLUGINS)

--- a/tests/test_minqlxtended_stub.py
+++ b/tests/test_minqlxtended_stub.py
@@ -1,0 +1,115 @@
+"""The stub must impersonate the pinned engine closely enough to catch real breakage.
+
+If the stub is more permissive than minqlxtended, a port passes CI and fails at plugin
+load on a live server — which is the exact failure mode P3's tests exist to prevent.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from stubs.minqlxtended_stub import install_stub  # noqa: E402
+
+
+@pytest.fixture(scope='module')
+def mxt():
+    return install_stub()
+
+
+def test_return_and_priority_replace_the_ret_and_pri_constants(mxt):
+    assert mxt.Return.STOP_ALL is not None
+    assert mxt.Return.NONE is not None
+    assert mxt.Return.USAGE is not None
+    assert mxt.Return.STOP_EVENT is not None
+    assert mxt.Priority.LOWEST < mxt.Priority.NORMAL < mxt.Priority.HIGHEST
+
+
+def test_the_old_spellings_are_absent(mxt):
+    """_enums.py:591-602 keeps RET_*/PRI_* out of the engine namespace on purpose.
+
+    A stub that still answered to them would let a half-ported plugin pass.
+    """
+    for gone in ('RET_STOP_ALL', 'RET_NONE', 'RET_USAGE', 'RET_STOP_EVENT',
+                 'PRI_LOWEST', 'PRI_HIGH', 'PRI_HIGHEST'):
+        assert not hasattr(mxt, gone), gone
+
+
+def test_parse_infostring_replaces_parse_variables(mxt):
+    assert not hasattr(mxt, 'parse_variables')
+    assert mxt.parse_infostring(r'\name\sarge\team\red') == {'name': 'sarge', 'team': 'red'}
+
+
+def test_parse_infostring_preserves_order(mxt):
+    """specqueue.py:647 used parse_variables(..., ordered=True); dicts are ordered now."""
+    parsed = mxt.parse_infostring(r'\c\1\b\2\a\3')
+    assert list(parsed) == ['c', 'b', 'a']
+
+
+def test_gameclient_int_fields_are_writable(mxt):
+    mxt.GameClient.reset_all()
+    client = mxt.GameClient(3)
+    client.accuracy_shots = 41
+    client.expanded_stats.num_kills = 7
+    assert mxt.GameClient(3).accuracy_shots == 41
+    assert mxt.GameClient(3).expanded_stats.num_kills == 7
+
+
+def test_per_weapon_arrays_reject_writes(mxt):
+    """python_objects.c:1156 — QLX_SETTER_WEAPONS is NULL, so WEAPONS fields are
+    snapshots. A port that tries to zero them must fail here, not on a live server."""
+    mxt.GameClient.reset_all()
+    with pytest.raises(AttributeError):
+        mxt.GameClient(1).expanded_stats.shots_fired = (0,) * 16
+
+
+def test_a_stale_minqlx_signature_is_refused_at_registration(mxt):
+    """_plugin.py:241-242 validates at registration, so this is where it must fail."""
+
+    class StalePlugin(mxt.Plugin):
+        def handle_game_start(self, data):  # minqlx arity, wrong here
+            pass
+
+    plugin = StalePlugin()
+    with pytest.raises(mxt.SignatureMismatch):
+        plugin.add_hook("game_start", plugin.handle_game_start)
+
+
+def test_chat_accepts_the_optional_recipient(mxt):
+    """_events.py:557 dispatches recipient=None, so both arities must register."""
+
+    class ChatPlugin(mxt.Plugin):
+        def three(self, player, msg, channel):
+            pass
+
+        def four(self, player, msg, channel, recipient=None):
+            pass
+
+    plugin = ChatPlugin()
+    plugin.add_hook("chat", plugin.three)
+    plugin.add_hook("chat", plugin.four)
+    assert len(plugin.hooks) == 2
+
+
+def test_plugin_records_commands_and_messages(mxt):
+    class Chatty(mxt.Plugin):
+        def cmd_hello(self, player, msg, channel):
+            self.msg("^2hi")
+
+    plugin = Chatty()
+    plugin.add_command(("hello", "hi"), plugin.cmd_hello, 2, usage="<name>")
+    assert plugin.commands == [(("hello", "hi"), plugin.cmd_hello, 2, "<name>")]
+
+    plugin.cmd_hello(None, ["hello"], None)
+    assert plugin.messages == ["^2hi"]
+
+
+def test_set_cvar_once_does_not_overwrite(mxt):
+    plugin = mxt.Plugin()
+    assert plugin.set_cvar_once("qlx_thing", "1") is True
+    assert plugin.set_cvar_once("qlx_thing", "2") is False
+    assert plugin.get_cvar("qlx_thing") == "1"
+
+
+def test_clean_text_strips_colour_codes(mxt):
+    assert mxt.Plugin.clean_text("^1red ^7white") == "red white"

--- a/tests/test_myfun_minqlxtended.py
+++ b/tests/test_myfun_minqlxtended.py
@@ -1,0 +1,121 @@
+"""myFun's hook arities are unchanged; its constants are not.
+
+38 of the 45 constant substitutions in this file are RET_STOP_ALL. A missed one is an
+AttributeError at the moment a player types the command that reaches it — long after
+plugin load, and only on that code path. Hence the source-level sweep below.
+"""
+import importlib.util
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from stubs.minqlxtended_stub import install_stub  # noqa: E402
+
+PLUGIN_PATH = os.path.join('ql-assets', 'data', 'minqlxtended-plugins', 'myFun.py')
+
+
+@pytest.fixture(scope='module')
+def source():
+    with open(PLUGIN_PATH, 'r', encoding='utf-8') as handle:
+        return handle.read()
+
+
+@pytest.fixture(scope='module')
+def module():
+    install_stub()
+    spec = importlib.util.spec_from_file_location('mxt_myfun', PLUGIN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def bare_minqlx_identifiers(path):
+    """Every place `minqlx` is used as a Python name, ignoring strings and comments.
+
+    Tokenising rather than grepping matters here. This file legitimately contains the
+    word in three kinds of place a text search cannot tell apart from code:
+
+      - Steam Workshop item titles in SOUND_PACKS, matched against the workshop by
+        exact name ("Duke Nukem Voice Sound Pack for minqlx");
+      - Redis key prefixes like "minqlx:myFun:addedTriggers:{}", which are a QLSM
+        contract rather than a minqlx API, exactly as serverchecker's key is;
+      - prose in the module docstring.
+
+    Only a NAME token is a reference to the module.
+    """
+    import tokenize
+    with tokenize.open(path) as handle:
+        return [
+            f"line {token.start[0]}"
+            for token in tokenize.generate_tokens(handle.readline)
+            if token.type == tokenize.NAME and token.string == 'minqlx'
+        ]
+
+
+def test_no_bare_minqlx_attribute_access_survives(source):
+    """`minqlxtended` contains `minqlx`, so match the module name at a word boundary
+    followed by a dot — `minqlx.` but never `minqlxtended.`."""
+    offenders = [
+        f"line {i}: {line.strip()}"
+        for i, line in enumerate(source.splitlines(), 1)
+        if re.search(r'\bminqlx\.(?!\w*tended)', line)
+    ]
+    assert offenders == [], f"un-ported minqlx references: {offenders}"
+
+
+def test_no_bare_minqlx_token_survives_in_code():
+    """Attribute access is not the only way to name the module.
+
+    reset_acc.py reached it as `hasattr(minqlx, "...")`, which a dot-anchored sweep
+    walks straight past.
+    """
+    assert bare_minqlx_identifiers(PLUGIN_PATH) == []
+
+
+def test_no_ret_or_pri_constant_survives(source):
+    """_enums.py:591-602 keeps these out of the namespace; they raise AttributeError."""
+    offenders = [
+        f"line {i}: {line.strip()}" for i, line in enumerate(source.splitlines(), 1)
+        if re.search(r'\b(RET|PRI)_[A-Z_]+', line)
+    ]
+    assert offenders == [], f"stale constants: {offenders}"
+
+
+def test_every_referenced_engine_attribute_exists(source):
+    """Whatever the substitution produced has to be something the engine actually has.
+
+    The set is pinned rather than sampled: a new name appearing here means the sweep
+    rewrote something nobody checked against __init__.py.
+    """
+    referenced = set(re.findall(r'minqlxtended\.[A-Za-z_][A-Za-z_.]*', source))
+    allowed = {
+        'minqlxtended.Plugin',
+        'minqlxtended.Return.NONE',
+        'minqlxtended.Return.STOP_ALL',
+        'minqlxtended.Priority.LOWEST',
+        'minqlxtended.thread',
+        'minqlxtended.delay',
+        'minqlxtended.next_frame',
+        'minqlxtended.console_print',
+        'minqlxtended.console_command',
+        'minqlxtended.log_exception',
+    }
+    assert referenced <= allowed, f"unverified engine attributes: {referenced - allowed}"
+
+
+def test_it_registers_every_hook(module):
+    plugin = module.myFun()
+    events = sorted(event for event, _handler, _priority in plugin.hooks)
+    assert events == sorted([
+        'chat', 'console_print', 'server_command', 'player_disconnect', 'player_loaded',
+    ])
+
+
+def test_player_loaded_hooks_at_lowest_priority(module):
+    import minqlxtended
+    plugin = module.myFun()
+    priorities = {event: priority for event, _h, priority in plugin.hooks}
+    assert priorities['player_loaded'] == minqlxtended.Priority.LOWEST

--- a/tests/test_player_info_minqlxtended.py
+++ b/tests/test_player_info_minqlxtended.py
@@ -147,3 +147,13 @@ def test_find_by_name_or_id_refuses_an_ambiguous_match(module):
     asker = FakePlayer(client_id=1, name='doom')
     assert plugin.find_by_name_or_id(asker, 'sarge') is None
     assert 'players matched' in asker.told[0]
+
+
+def test_it_does_not_call_a_nonexistent_plugin_kick(source):
+    """`self.kick(...)` is not a Plugin method on either runtime.
+
+    The minqlx original calls it in the deactivated-account path, where it would have
+    raised AttributeError. The port uses Player.kick(reason) (_player.py:926), which
+    exists and takes the reason directly rather than an id plus a reason.
+    """
+    assert 'self.kick(' not in source

--- a/tests/test_player_info_minqlxtended.py
+++ b/tests/test_player_info_minqlxtended.py
@@ -126,7 +126,7 @@ def test_find_by_name_or_id_is_available_on_the_plugin(module):
 
 def test_find_by_name_or_id_reports_when_nothing_matches(module):
     plugin = module.player_info()
-    plugin._players = []
+    plugin.connected_players = []
     asker = FakePlayer()
     assert plugin.find_by_name_or_id(asker, 'nobody') is None
     assert 'no players matched' in asker.told[0]
@@ -135,14 +135,14 @@ def test_find_by_name_or_id_reports_when_nothing_matches(module):
 def test_find_by_name_or_id_returns_a_single_match(module):
     plugin = module.player_info()
     target = FakePlayer(client_id=4, name='sarge')
-    plugin._players = [target]
+    plugin.connected_players = [target]
     asker = FakePlayer(client_id=1, name='doom')
     assert plugin.find_by_name_or_id(asker, 'sarge') is target
 
 
 def test_find_by_name_or_id_refuses_an_ambiguous_match(module):
     plugin = module.player_info()
-    plugin._players = [FakePlayer(client_id=4, name='sarge'),
+    plugin.connected_players = [FakePlayer(client_id=4, name='sarge'),
                        FakePlayer(client_id=5, name='sarge2')]
     asker = FakePlayer(client_id=1, name='doom')
     assert plugin.find_by_name_or_id(asker, 'sarge') is None

--- a/tests/test_player_info_minqlxtended.py
+++ b/tests/test_player_info_minqlxtended.py
@@ -1,0 +1,149 @@
+"""The ported player_info must accept player_connect's new arity, and must not carry
+the iouonegirl abstract base across.
+
+Two independent things are checked here:
+
+1. _events.py:586 dispatches (player, is_bot); minqlx passed (player) alone.
+   minqlxtended validates at registration (_plugin.py:241), so a stale signature stops
+   the whole plugin from loading rather than failing on the first connect.
+
+2. On minqlx this plugin subclasses iouonegirlPlugin, an abstract base that downloads
+   itself from github.com/dsverdlo/minqlx-plugins at import time and ships an
+   auto-updater for *minqlx* plugins. That base is not in the minqlxtended baseline,
+   and pulling it in would fetch minqlx-API code onto a minqlxtended host. The port
+   subclasses minqlxtended.Plugin and inlines the one helper it actually used.
+"""
+import importlib.util
+import inspect
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from stubs.minqlxtended_stub import install_stub  # noqa: E402
+
+PLUGIN_PATH = os.path.join('ql-assets', 'data', 'minqlxtended-plugins', 'player_info.py')
+
+
+@pytest.fixture(scope='module')
+def source():
+    with open(PLUGIN_PATH, 'r', encoding='utf-8') as handle:
+        return handle.read()
+
+
+@pytest.fixture(scope='module')
+def module():
+    install_stub()
+    spec = importlib.util.spec_from_file_location('mxt_player_info', PLUGIN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakePlayer:
+    def __init__(self, client_id=0, steam_id=76561198000000001, name='sarge'):
+        self.id = client_id
+        self.steam_id = steam_id
+        self.name = name
+        self.clean_name = name
+        self.told = []
+
+    def tell(self, msg):
+        self.told.append(msg)
+
+
+def test_the_module_imports_without_a_minqlx_module(module):
+    """Importing at all proves nothing in the file reaches for bare `minqlx`."""
+    assert hasattr(module, 'player_info')
+
+
+def test_it_does_not_import_the_iouonegirl_base(source):
+    """The name still appears in the file — in the original author's copyright header,
+    in the comment explaining why the base was dropped, and in a user-facing "Contact
+    iouonegirl" string. None of those pulls the base in. What must not survive is an
+    import of it or a reference to the class itself.
+    """
+    assert 'iouonegirlPlugin' not in source
+    assert 'import iouonegirl' not in source
+    assert 'from .iouonegirl' not in source
+
+
+def test_it_subclasses_the_engine_plugin_directly(module):
+    import minqlxtended
+    assert module.player_info.__bases__ == (minqlxtended.Plugin,)
+
+
+def test_it_makes_no_network_call_at_import(source):
+    """The minqlx original does requests.get() at module scope to self-install its base.
+
+    Anything that runs at import runs on every plugin load, on a game server with no
+    guarantee of outbound access.
+    """
+    module_level = [
+        line for line in source.splitlines()
+        if line and not line[0].isspace() and 'requests.get' in line
+    ]
+    assert module_level == []
+
+
+def test_player_connect_registers_with_the_new_arity(module):
+    """Registration is where the engine checks, so registration is where we check."""
+    plugin = module.player_info()
+    events = [event for event, _handler, _priority in plugin.hooks]
+    assert 'player_connect' in events
+
+
+def test_player_connect_handler_takes_player_and_is_bot(module):
+    params = list(
+        inspect.signature(module.player_info.handle_player_connect).parameters
+    )
+    assert params == ['self', 'player', 'is_bot']
+
+
+def test_it_hooks_at_lowest_priority(module):
+    import minqlxtended
+    plugin = module.player_info()
+    priorities = {event: priority for event, _handler, priority in plugin.hooks}
+    assert priorities['player_connect'] == minqlxtended.Priority.LOWEST
+
+
+def test_a_bot_connecting_triggers_no_lookup(module):
+    """is_bot is authoritative here, where minqlx had to guess from the steam id."""
+    plugin = module.player_info()
+    plugin.fetched = []
+    plugin.fetch = lambda *args, **kwargs: plugin.fetched.append(args)
+    plugin.cvars['qlx_pinfo_display_auto'] = 1
+
+    plugin.handle_player_connect(FakePlayer(steam_id=90000000000000001), True)
+    assert plugin.fetched == []
+
+
+def test_find_by_name_or_id_is_available_on_the_plugin(module):
+    """The one helper the dropped base class actually provided."""
+    assert callable(module.player_info.find_by_name_or_id)
+
+
+def test_find_by_name_or_id_reports_when_nothing_matches(module):
+    plugin = module.player_info()
+    plugin._players = []
+    asker = FakePlayer()
+    assert plugin.find_by_name_or_id(asker, 'nobody') is None
+    assert 'no players matched' in asker.told[0]
+
+
+def test_find_by_name_or_id_returns_a_single_match(module):
+    plugin = module.player_info()
+    target = FakePlayer(client_id=4, name='sarge')
+    plugin._players = [target]
+    asker = FakePlayer(client_id=1, name='doom')
+    assert plugin.find_by_name_or_id(asker, 'sarge') is target
+
+
+def test_find_by_name_or_id_refuses_an_ambiguous_match(module):
+    plugin = module.player_info()
+    plugin._players = [FakePlayer(client_id=4, name='sarge'),
+                       FakePlayer(client_id=5, name='sarge2')]
+    asker = FakePlayer(client_id=1, name='doom')
+    assert plugin.find_by_name_or_id(asker, 'sarge') is None
+    assert 'players matched' in asker.told[0]

--- a/tests/test_reset_acc_minqlxtended.py
+++ b/tests/test_reset_acc_minqlxtended.py
@@ -1,0 +1,222 @@
+"""reset_acc's C patch becomes pure Python on minqlxtended.
+
+The engine exposes gclient_t as writable memory (engine_fields.h:536), so the three
+patched functions QLSM added to minqlx are replaced by attribute writes. One thing the
+patch did cannot be reproduced: the per-weapon shotsFired/shotsHit arrays are WEAPONS
+fields, and python_objects.c:1156 gives WEAPONS no setter. See the P3 plan, Finding 5.
+"""
+import importlib.util
+import inspect
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from stubs.minqlxtended_stub import install_stub  # noqa: E402
+
+PLUGIN_PATH = os.path.join('ql-assets', 'data', 'minqlxtended-plugins', 'reset_acc.py')
+
+
+@pytest.fixture(scope='module')
+def source():
+    with open(PLUGIN_PATH, 'r', encoding='utf-8') as handle:
+        return handle.read()
+
+
+@pytest.fixture(scope='module')
+def module():
+    install_stub()
+    spec = importlib.util.spec_from_file_location('mxt_reset_acc', PLUGIN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakePlayer:
+    def __init__(self, client_id=0, steam_id=76561198000000001, name='sarge'):
+        self.id = client_id
+        self.steam_id = steam_id
+        self.name = name
+        self.clean_name = name
+        self.score = 99
+        self.told = []
+
+    def tell(self, msg):
+        self.told.append(msg)
+
+
+class FakeDb(dict):
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+    def set(self, key, value):
+        self[key] = value
+
+    def delete(self, *keys):
+        for key in keys:
+            self.pop(key, None)
+
+
+@pytest.fixture
+def plugin(module):
+    import minqlxtended
+    minqlxtended.GameClient.reset_all()
+    instance = module.reset_acc()
+    instance.db = FakeDb()
+    return instance
+
+
+def _dirty(client_id):
+    """Put non-zero values everywhere the C patch used to zero."""
+    import minqlxtended
+    client = minqlxtended.GameClient(client_id)
+    client.accuracy_shots = 120
+    client.accuracy_hits = 44
+    client.round_shots = 12
+    client.round_hits = 5
+    client.expanded_stats.num_kills = 9
+    client.expanded_stats.num_deaths = 3
+    return client
+
+
+def test_the_patched_functions_are_gone(source):
+    """minqlx.reset_player_stats / reset_player_accuracy / set_score do not exist here."""
+    assert 'minqlxtended.reset_player_stats' not in source
+    assert 'minqlxtended.reset_player_accuracy' not in source
+    assert 'minqlxtended.set_score' not in source
+
+
+def test_kill_hook_takes_mod_not_a_stats_dict(module):
+    """_events.py:801 dispatches (victim, killer, mod). Same arity, different meaning."""
+    params = list(inspect.signature(module.reset_acc.handle_kill).parameters)
+    assert params == ['self', 'victim', 'killer', 'mod']
+
+
+def test_it_registers_every_hook(plugin):
+    events = sorted(event for event, _handler, _priority in plugin.hooks)
+    assert events == ['kill', 'player_disconnect', 'player_loaded']
+
+
+def test_zero_stats_clears_accuracy_kills_and_deaths(module):
+    client = _dirty(2)
+    assert module._zero_stats(2) is True
+    assert client.accuracy_shots == 0
+    assert client.accuracy_hits == 0
+    assert client.round_shots == 0
+    assert client.round_hits == 0
+    assert client.expanded_stats.num_kills == 0
+    assert client.expanded_stats.num_deaths == 0
+
+
+def test_zero_accuracy_leaves_kills_and_deaths_alone(module):
+    client = _dirty(3)
+    assert module._zero_accuracy(3) is True
+    assert client.accuracy_shots == 0
+    assert client.accuracy_hits == 0
+    assert client.expanded_stats.num_kills == 9
+    assert client.expanded_stats.num_deaths == 3
+
+
+def test_zero_stats_does_not_try_to_write_the_per_weapon_arrays(module):
+    """Writing them raises (python_objects.c:1156). If the port tried, this would error
+    rather than return True."""
+    _dirty(4)
+    assert module._zero_stats(4) is True
+
+
+def test_reset_all_zeroes_the_score(plugin):
+    player = FakePlayer(client_id=5)
+    _dirty(5)
+    plugin._reset_all(player, player)
+    assert player.score == 0
+
+
+def test_reset_all_tells_the_player_what_it_did(plugin):
+    player = FakePlayer(client_id=6)
+    _dirty(6)
+    plugin._reset_all(player, player)
+    said = ' '.join(player.told).lower()
+    assert 'reset' in said
+
+
+def test_no_message_promises_the_per_weapon_breakdown_was_cleared(source):
+    """The minqlx original told the player "WEAP and +acc are now 0". WEAP no longer
+    resets, so saying so would promise something the port does not deliver.
+
+    Scoped to lines that talk to a player: the docstrings explain the WEAPONS field
+    limitation at length, and should.
+    """
+    spoken = [line for line in source.splitlines()
+              if '.tell(' in line or 'self.msg(' in line]
+    offenders = [line.strip() for line in spoken if 'WEAP' in line]
+    assert offenders == [], offenders
+
+
+def test_silent_reset_says_nothing(plugin):
+    player = FakePlayer(client_id=7)
+    _dirty(7)
+    plugin._reset_all(player, player, silent=True)
+    assert player.told == []
+
+
+def test_resetting_someone_else_tells_both_parties(plugin):
+    admin = FakePlayer(client_id=8, name='admin')
+    target = FakePlayer(client_id=9, name='sarge')
+    _dirty(9)
+    plugin._reset_all(admin, target)
+    assert admin.told and target.told
+
+
+class KillPlayer(FakePlayer):
+    def __init__(self, client_id, steam_id, team):
+        super().__init__(client_id=client_id, steam_id=steam_id)
+        self.team = team
+
+
+def _scheduled(plugin):
+    """Record who the kill handler scheduled a reset for, without timers."""
+    calls = []
+    plugin._schedule_auto_reset = lambda player, trigger: calls.append(
+        (player.steam_id, trigger))
+    return calls
+
+
+def test_a_normal_kill_schedules_for_both_killer_and_victim(plugin):
+    import minqlxtended
+    calls = _scheduled(plugin)
+    killer = KillPlayer(1, 111, minqlxtended.Team.RED)
+    victim = KillPlayer(2, 222, minqlxtended.Team.BLUE)
+    plugin.handle_kill(victim, killer, None)
+    assert calls == [(111, 'kill'), (222, 'death')]
+
+
+def test_a_teamkill_credits_no_kill(plugin):
+    import minqlxtended
+    calls = _scheduled(plugin)
+    killer = KillPlayer(1, 111, minqlxtended.Team.RED)
+    victim = KillPlayer(2, 222, minqlxtended.Team.RED)
+    plugin.handle_kill(victim, killer, None)
+    assert calls == [(222, 'death')]
+
+
+def test_an_ffa_kill_is_not_a_teamkill(plugin):
+    """Everyone is on the free team in FFA, which is this plugin's main use case.
+
+    Treating same-team as a teamkill without excluding `free` would suppress the
+    killer's auto-reset on every FFA kill.
+    """
+    import minqlxtended
+    calls = _scheduled(plugin)
+    killer = KillPlayer(1, 111, minqlxtended.Team.FREE)
+    victim = KillPlayer(2, 222, minqlxtended.Team.FREE)
+    plugin.handle_kill(victim, killer, None)
+    assert calls == [(111, 'kill'), (222, 'death')]
+
+
+def test_a_suicide_credits_no_kill(plugin):
+    import minqlxtended
+    calls = _scheduled(plugin)
+    player = KillPlayer(1, 111, minqlxtended.Team.FREE)
+    plugin.handle_kill(player, player, None)
+    assert calls == [(111, 'death')]

--- a/tests/test_serverchecker_minqlxtended.py
+++ b/tests/test_serverchecker_minqlxtended.py
@@ -90,7 +90,7 @@ def _build(module, game=None, players=()):
     plugin.hooks = []
     plugin.cvars = {'net_port': '27960', 'sv_hostname': 'QLSM Test',
                     'sv_maxclients': '16', 'fs_basepath': '/home/ql/steamcmd/steamapps'}
-    plugin._players = list(players)
+    plugin.connected_players = list(players)
     plugin.game = game
     plugin.db = FakeRedis()
     plugin._match_start_time = None

--- a/tests/test_specqueue_minqlxtended.py
+++ b/tests/test_specqueue_minqlxtended.py
@@ -1,0 +1,184 @@
+"""specqueue changes on six hooks, one Game property, and two module functions.
+
+Every one of them is a registration-time or first-use failure on a live server, so each
+gets an assertion here. See the P3 plan, Findings 3, 4 and 7.
+"""
+import importlib.util
+import inspect
+import os
+import re
+import sys
+import tokenize
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from stubs.minqlxtended_stub import install_stub  # noqa: E402
+
+PLUGIN_PATH = os.path.join('ql-assets', 'data', 'minqlxtended-plugins', 'specqueue.py')
+
+
+@pytest.fixture(scope='module')
+def source():
+    with open(PLUGIN_PATH, 'r', encoding='utf-8') as handle:
+        return handle.read()
+
+
+@pytest.fixture(scope='module')
+def module():
+    install_stub()
+    spec = importlib.util.spec_from_file_location('mxt_specqueue', PLUGIN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_no_bare_minqlx_attribute_access_survives(source):
+    offenders = [
+        f"line {i}: {line.strip()}"
+        for i, line in enumerate(source.splitlines(), 1)
+        if re.search(r'\bminqlx\.(?!\w*tended)', line)
+    ]
+    assert offenders == [], f"un-ported minqlx references: {offenders}"
+
+
+def test_no_bare_minqlx_token_survives_in_code():
+    """Only a NAME token is a module reference; the Redis keys and prose are not."""
+    with tokenize.open(PLUGIN_PATH) as handle:
+        offenders = [
+            f"line {token.start[0]}"
+            for token in tokenize.generate_tokens(handle.readline)
+            if token.type == tokenize.NAME and token.string == 'minqlx'
+        ]
+    assert offenders == []
+
+
+def test_no_ret_or_pri_constant_survives(source):
+    offenders = [
+        f"line {i}: {line.strip()}" for i, line in enumerate(source.splitlines(), 1)
+        if re.search(r'\b(RET|PRI)_[A-Z_]+', line)
+    ]
+    assert offenders == [], f"stale constants: {offenders}"
+
+
+@pytest.mark.parametrize('handler,expected', [
+    ('handle_game_start', ['self']),
+    ('handle_game_end', ['self', 'aborted']),
+    ('handle_player_connect', ['self', 'player', 'is_bot']),
+    ('handle_round_end', ['self', 'round_number', 'winning_team', 'time']),
+    ('handle_team_switch_attempt',
+     ['self', 'player', 'old_team', 'new_team', 'target']),
+    ('death_monitor', ['self', 'victim', 'killer', 'mod']),
+])
+def test_changed_handler_signatures(module, handler, expected):
+    """_events.py fixes these arities; _plugin.py:241 checks them at registration."""
+    assert list(inspect.signature(
+        getattr(module.specqueue, handler)).parameters) == expected
+
+
+class FakeGame:
+    """Enough of Game for specqueue's constructor, which reads it immediately."""
+    type_short = 'ca'
+    state = 'warmup'
+    map = 'campgrounds'
+    team_scores = (0, 0, 0, 0)
+
+
+class FakeDb(dict):
+    """Redis stand-in. specqueue's __init__ sweeps clan tags via db.keys()."""
+
+    def keys(self, pattern='*'):
+        return []
+
+    def get(self, key, default=None):
+        return dict.get(self, key, default)
+
+    def set(self, key, value):
+        self[key] = value
+
+    def delete(self, *keys):
+        for key in keys:
+            self.pop(key, None)
+
+
+@pytest.fixture
+def constructed(module, tmp_path):
+    """A live specqueue, with the two pieces of global state its __init__ reads.
+
+    __init__ opens a RotatingFileHandler under fs_homepath/logs (specqueue.py:367)
+    and reads self.game.type_short on its first line of real work.
+    """
+    import minqlxtended
+    minqlxtended.cvars['fs_homepath'] = str(tmp_path)
+    minqlxtended.Plugin.game = FakeGame()
+    minqlxtended.Plugin.db = FakeDb()
+    try:
+        yield module.specqueue()
+    finally:
+        minqlxtended.Plugin.game = None
+        minqlxtended.Plugin.db = None
+        minqlxtended.cvars.pop('fs_homepath', None)
+
+
+def test_every_hook_registers(constructed):
+    """If any signature is stale the constructor raises, so reaching here is the test."""
+    plugin = constructed
+    events = {event for event, _handler, _priority in plugin.hooks}
+    assert events == {
+        'new_game', 'game_start', 'game_end', 'round_countdown', 'round_start',
+        'round_end', 'death', 'player_connect', 'player_loaded', 'player_disconnect',
+        'team_switch', 'team_switch_attempt', 'set_configstring', 'client_command',
+        'vote_ended', 'console_print', 'map',
+    }
+
+
+def test_scores_come_from_team_scores_not_red_score(source):
+    """Game.red_score / Game.blue_score do not exist on this runtime (_game.py:190)."""
+    code_only = '\n'.join(
+        re.sub(r'#.*', '', line) for line in source.splitlines()
+    )
+    assert '.red_score' not in code_only
+    assert '.blue_score' not in code_only
+    assert 'team_scores' in code_only
+
+
+def test_game_end_reads_the_aborted_flag_directly(source):
+    """The minqlx original read data["ABORTED"] out of the stats dict it was passed.
+
+    Scoped to code: the port explains the change in a comment, and that explanation
+    quotes the expression it replaced.
+    """
+    code_only = '\n'.join(
+        line for line in source.splitlines() if not line.lstrip().startswith('#')
+    )
+    assert 'ABORTED' not in code_only
+
+
+def test_parse_infostring_replaces_parse_variables(source):
+    assert 'parse_variables' not in source
+    assert 'parse_infostring' in source
+
+
+def test_the_afk_sweep_only_moves_a_player_who_stopped_moving(source):
+    """The default preset's copy of this file has this block dedented out of its elif,
+    which spectates every player on every sweep. Port from the baseline, not that.
+    See the P3 plan, Finding 7."""
+    lines = source.splitlines()
+    marker = next(
+        i for i, line in enumerate(lines)
+        if 'was moved to spectator for being AFK' in line
+    )
+    name_line = next(
+        i for i in range(marker, 0, -1)
+        if 'clean_name' in lines[i] and 'name =' in lines[i]
+    )
+    elif_line = next(
+        i for i in range(name_line, 0, -1) if lines[i].lstrip().startswith('elif ')
+    )
+
+    def indent(text):
+        return len(text) - len(text.lstrip())
+
+    assert indent(lines[name_line]) > indent(lines[elif_line]), (
+        "the AFK move is not nested inside its elif; it will spectate everyone"
+    )

--- a/tests/test_suppress_join_msg_minqlxtended.py
+++ b/tests/test_suppress_join_msg_minqlxtended.py
@@ -1,0 +1,59 @@
+"""The ported suppress_join_msg must register on this runtime and still swallow the
+"joined the battle" center-print.
+
+server_command's arity is unchanged (_events.py:486), so the only real risk is the
+constant rename — minqlx.RET_STOP_ALL does not exist on minqlxtended (_enums.py:591).
+"""
+import importlib.util
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from stubs.minqlxtended_stub import install_stub  # noqa: E402
+
+PLUGIN_PATH = os.path.join(
+    'ql-assets', 'data', 'minqlxtended-plugins', 'suppress_join_msg.py'
+)
+
+
+@pytest.fixture(scope='module')
+def module():
+    install_stub()
+    spec = importlib.util.spec_from_file_location('mxt_suppress_join_msg', PLUGIN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def plugin(module):
+    return module.suppress_join_msg()
+
+
+@pytest.fixture
+def handler(plugin):
+    _event, callback, _priority = plugin.hooks[0]
+    return callback
+
+
+def test_it_registers_its_hook(plugin):
+    assert [event for event, _handler, _priority in plugin.hooks] == ['server_command']
+
+
+@pytest.mark.parametrize('cmd', [
+    'cp "sarge^7 joined the battle.\n"',
+    'cp "sarge^7 joined the spectators.\n"',
+])
+def test_it_stops_the_join_message(handler, cmd):
+    import minqlxtended
+    assert handler(None, cmd) is minqlxtended.Return.STOP_ALL
+
+
+@pytest.mark.parametrize('cmd', [
+    'cp "sarge^7 was kicked.\n"',            # a cp that is not a join
+    'print "sarge^7 joined the battle.\n"',  # a join phrase on the wrong command
+])
+def test_it_leaves_other_server_commands_alone(handler, cmd):
+    assert handler(None, cmd) is None


### PR DESCRIPTION
## P3: the 6 remaining QLSM plugin ports

Ports `myFun`, `suppress_join_msg`, `specqueue`, `reset_acc`, `player_info` and
`commands` from the minqlx API to minqlxtended, completing the QLSM-owned half of the
plugin migration. Bases onto `feature/minqlxtended`, not `main`.

Every port lands in `ql-assets/data/minqlxtended-plugins/` with a test that imports it
against an extended `tests/stubs/minqlxtended_stub.py`, so a stale handler signature or
a missing engine attribute fails in CI rather than at plugin load on a live server.

**108 tests green.** `ql-assets/data/minqlx-plugins/` and
`configs/presets/_builtin/default/` are byte-identical to the base branch.

### The three API deltas that drove the work

- **`RET_*` / `PRI_*` do not exist.** `_enums.py:591-602` keeps them out of the module
  namespace deliberately, so `minqlxtended.RET_STOP_ALL` raises `AttributeError`. 45
  substitutions to `Return.*` / `Priority.*`.
- **Six handler signatures changed**, on top of the three P2 recorded. The dangerous one
  is `kill`/`death`: same arity, but the third argument is now the means of death rather
  than a stats dict, so a lazy port registers fine and then raises on the first kill.
- **`Game.red_score` / `blue_score` are gone** — scores come off `team_scores` indexed by
  `Team.index`, guarded for `NonexistentGameError` as the ported serverchecker guards it.

### Four things the plan did not anticipate

1. 🔴 **`reset_acc` cannot fully replace its C patch.** The per-weapon
   `shotsFired[16]`/`shotsHit[16]` arrays are `WEAPONS` fields and
   `python_objects.c:1156` defines `QLX_SETTER_WEAPONS` as `NULL` — read-only snapshots.
   Aggregate accuracy, round counters and K/D reset; the end-of-match WEAP breakdown does
   not. The `!resetacc` message no longer claims it does.
2. **`player_info` had an undeclared dependency.** It subclassed an abstract base from
   `iouonegirl.py`, which installs itself at import by downloading from a *minqlx* plugin
   repository. Carrying that across would have put a minqlx-plugin auto-updater on a
   minqlxtended host and made every plugin load depend on outbound GitHub access. It used
   one method from that base; the port inlines it and subclasses `Plugin` directly.
3. **`handle_kill` read `data["TEAMKILL"]`**, which no longer exists. Derived from the
   two players' teams instead — excluding the free team, because this plugin targets FFA
   practice servers where everyone is on it and every kill would otherwise be a teamkill.
4. **`self.kick(...)` in `player_info` never existed** on either runtime. Found by a
   static sweep; now `Player.kick(reason)`.

### Registration

Baseline is 33 upstream plugins + 7 QLSM ports, all seven marked `"origin": "qlsm"`.
`myFun`, `specqueue`, `player_info` and `commands` also go into
`default-minqlxtended/scripts/`, mirroring the minqlx default preset. `reset_acc` and
`suppress_join_msg` stay baseline-only alongside `serverchecker`, because they are not in
the minqlx default preset either. `checked_plugins.json` is unchanged.

### ⚠️ Unrelated bug found, not fixed here

`configs/presets/_builtin/default/scripts/specqueue.py:1978-1987` has its AFK sweep
dedented out of its `elif`, so it moves **every player to spectator on every pass**. The
`ql-assets/data/minqlx-plugins/` copy is correct; the two have diverged. This is a
**minqlx-side** bug and needs its own fix on `main` — `feature/minqlxtended` must not
carry unrelated minqlx changes. P3 ports from the correct copy and adds a test pinning
the nesting, plus one pinning the minqlxtended preset copies to the baseline so the same
drift cannot happen on this side.

### Not verified

Every test here is static or stubbed. Nothing has run on a real minqlxtended host. In
particular: whether `handle_game_end` and `handle_round_end` still rotate the queue
correctly now their `data` dict is gone, and whether the partial accuracy reset reads as
broken in-game. Both need hardware before the integration PR to `main`.
