### PR TITLE
fix: carry the two main-side plugin fixes onto the minqlxtended ports

### DIFF
--- a/configs/presets/_builtin/default-minqlxtended/scripts/myFun.py
+++ b/configs/presets/_builtin/default-minqlxtended/scripts/myFun.py
@@ -238,6 +238,22 @@ SOUND_PACKS = ["Default Quake Live Sounds", "Prestige Worldwide Soundhonks", "Fu
 ADDITIONAL_SOUNDPACKS = ['doompack.pk3', 'doompack2.pk3']
 
 
+SOUND_PATH_ALLOWED = re.compile(r"^[A-Za-z0-9_./-]+\Z")
+
+
+def is_safe_sound_path(value):
+    """Whether `value` is safe to interpolate into a console command.
+
+    The engine console treats ';' as a command separator, so an unfiltered value
+    reaching console_command() lets the caller append arbitrary commands. Callers of
+    !sound are permission-gated, but a moderator should not be silently handed the
+    whole console, and a path is a path: letters, digits, dot, slash, dash, underscore.
+
+    Anchored with \\Z rather than $, which also matches just before a trailing newline.
+    """
+    return bool(value) and bool(SOUND_PATH_ALLOWED.match(value))
+
+
 class myFun(minqlxtended.Plugin):
     Enabled_SoundPacks = []
     soundPacks = []
@@ -1087,6 +1103,11 @@ class myFun(minqlxtended.Plugin):
             player.tell("^3You have {} seconds before you can call another sound.".format(int(stop)))
         else:
             # check for a valid sound file
+            if not is_safe_sound_path(msg[1]):
+                player.tell("^1Invalid sound path^7: only letters, digits and ^3_ . / -^7 are allowed.")
+                minqlxtended.console_print("^3Admin {} tried calling sound with an unsafe path: {}"
+                                           .format(player, msg[1]))
+                return
             self.checking_file = True
             self.file_status = False
             minqlxtended.console_command("fdir {}".format(msg[1]))

--- a/configs/presets/_builtin/default-minqlxtended/scripts/player_info.py
+++ b/configs/presets/_builtin/default-minqlxtended/scripts/player_info.py
@@ -58,6 +58,7 @@ TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 EXT_SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm", "duel", "ffa")
 RATING_KEY = "minqlx:players:{0}:ratings:{1}" # 0 == steam_id, 1 == short gametype.
 MAX_ATTEMPTS = 3
+HTTP_TIMEOUT_SECONDS = 10
 CACHE_EXPIRE = 60*30 # 30 minutes TTL.
 DEFAULT_RATING = 1500
 SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm")
@@ -287,7 +288,9 @@ class player_info(minqlxtended.Plugin):
         while attempts < MAX_ATTEMPTS:
             attempts += 1
             url = f"{self.api_url}{sid}"
-            res = requests.get(url)
+            # Without a timeout this blocks its worker thread for as long as the
+            # remote takes to answer, which for an unreachable qlstats is forever.
+            res = requests.get(url, timeout=HTTP_TIMEOUT_SECONDS)
             last_status = res.status_code
             if res.status_code != requests.codes.ok:
                 continue

--- a/ql-assets/data/minqlxtended-plugins/manifest.json
+++ b/ql-assets/data/minqlxtended-plugins/manifest.json
@@ -74,7 +74,7 @@
     },
     "myFun.py": {
       "origin": "qlsm",
-      "sha256": "3bbd5bef33136cbed1db7e7b8cfd0c62e81e4f16e1246440bb05acf4ac8ce048"
+      "sha256": "c41ab804adf77b7048e2aa2183c5da2604823bed0a2895c16e02586b0b1b4a24"
     },
     "names.py": {
       "origin": "upstream",
@@ -86,7 +86,7 @@
     },
     "player_info.py": {
       "origin": "qlsm",
-      "sha256": "92fb51e6568a1bc0191c1faa182f88c5ce6697842c2e00c093429958123bb193"
+      "sha256": "6faabd4794a0153430eb78aae8025fa5b21fa8cafed64930a7686852787bbf4d"
     },
     "plugin_manager.py": {
       "origin": "upstream",

--- a/ql-assets/data/minqlxtended-plugins/myFun.py
+++ b/ql-assets/data/minqlxtended-plugins/myFun.py
@@ -238,6 +238,22 @@ SOUND_PACKS = ["Default Quake Live Sounds", "Prestige Worldwide Soundhonks", "Fu
 ADDITIONAL_SOUNDPACKS = ['doompack.pk3', 'doompack2.pk3']
 
 
+SOUND_PATH_ALLOWED = re.compile(r"^[A-Za-z0-9_./-]+\Z")
+
+
+def is_safe_sound_path(value):
+    """Whether `value` is safe to interpolate into a console command.
+
+    The engine console treats ';' as a command separator, so an unfiltered value
+    reaching console_command() lets the caller append arbitrary commands. Callers of
+    !sound are permission-gated, but a moderator should not be silently handed the
+    whole console, and a path is a path: letters, digits, dot, slash, dash, underscore.
+
+    Anchored with \\Z rather than $, which also matches just before a trailing newline.
+    """
+    return bool(value) and bool(SOUND_PATH_ALLOWED.match(value))
+
+
 class myFun(minqlxtended.Plugin):
     Enabled_SoundPacks = []
     soundPacks = []
@@ -1087,6 +1103,11 @@ class myFun(minqlxtended.Plugin):
             player.tell("^3You have {} seconds before you can call another sound.".format(int(stop)))
         else:
             # check for a valid sound file
+            if not is_safe_sound_path(msg[1]):
+                player.tell("^1Invalid sound path^7: only letters, digits and ^3_ . / -^7 are allowed.")
+                minqlxtended.console_print("^3Admin {} tried calling sound with an unsafe path: {}"
+                                           .format(player, msg[1]))
+                return
             self.checking_file = True
             self.file_status = False
             minqlxtended.console_command("fdir {}".format(msg[1]))

--- a/ql-assets/data/minqlxtended-plugins/player_info.py
+++ b/ql-assets/data/minqlxtended-plugins/player_info.py
@@ -58,6 +58,7 @@ TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 EXT_SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm", "duel", "ffa")
 RATING_KEY = "minqlx:players:{0}:ratings:{1}" # 0 == steam_id, 1 == short gametype.
 MAX_ATTEMPTS = 3
+HTTP_TIMEOUT_SECONDS = 10
 CACHE_EXPIRE = 60*30 # 30 minutes TTL.
 DEFAULT_RATING = 1500
 SUPPORTED_GAMETYPES = ("ca", "ctf", "dom", "ft", "tdm")
@@ -287,7 +288,9 @@ class player_info(minqlxtended.Plugin):
         while attempts < MAX_ATTEMPTS:
             attempts += 1
             url = f"{self.api_url}{sid}"
-            res = requests.get(url)
+            # Without a timeout this blocks its worker thread for as long as the
+            # remote takes to answer, which for an unreachable qlstats is forever.
+            res = requests.get(url, timeout=HTTP_TIMEOUT_SECONDS)
             last_status = res.status_code
             if res.status_code != requests.codes.ok:
                 continue

--- a/tests/test_myfun_minqlxtended.py
+++ b/tests/test_myfun_minqlxtended.py
@@ -119,3 +119,35 @@ def test_player_loaded_hooks_at_lowest_priority(module):
     plugin = module.myFun()
     priorities = {event: priority for event, _h, priority in plugin.hooks}
     assert priorities['player_loaded'] == minqlxtended.Priority.LOWEST
+
+
+def test_sound_paths_are_validated_before_reaching_the_console(module):
+    """`!sound <path>` reaches console_command("fdir {}"), and the engine console
+    treats ';' as a command separator — so an unfiltered argument hands the caller
+    the rest of the console. Permission 3 gates who can try it, which makes this a
+    moderator-scope hole rather than an open one, but a moderator asking for a sound
+    should not get the console.
+
+    Fixed on the minqlx copy in `8f4c8e3` on main. The port predates that fix, so it
+    is applied here too — otherwise the same input is safe on one runtime and not the
+    other.
+    """
+    assert module.is_safe_sound_path('sound/vo/crash.ogg')
+    assert module.is_safe_sound_path('doompack/hi-there_1.wav')
+    assert module.is_safe_sound_path('a-b_c.d/e')
+
+    assert not module.is_safe_sound_path('')
+    assert not module.is_safe_sound_path('x; quit')
+    assert not module.is_safe_sound_path('sound/a b.ogg')
+    assert not module.is_safe_sound_path('"; rcon')
+    # re's `$` also matches just before a trailing newline, so the anchor has to be
+    # `\Z`. Unreachable via chat (args arrive whitespace-split) but free to get right.
+    assert not module.is_safe_sound_path('sound/ok.ogg\n')
+
+
+def test_the_fdir_call_is_guarded_by_that_check(source):
+    """A helper nothing calls is not a fix. Assert the guard precedes the call."""
+    code_only = [re.sub(r'#.*', '', line) for line in source.splitlines()]
+    guard = next(i for i, line in enumerate(code_only) if 'is_safe_sound_path(msg[1])' in line)
+    call = next(i for i, line in enumerate(code_only) if 'console_command("fdir' in line)
+    assert guard < call, "the fdir call is not gated by the path check"

--- a/tests/test_player_info_minqlxtended.py
+++ b/tests/test_player_info_minqlxtended.py
@@ -157,3 +157,29 @@ def test_it_does_not_call_a_nonexistent_plugin_kick(source):
     exists and takes the reason directly rather than an id plus a reason.
     """
     assert 'self.kick(' not in source
+
+
+def test_every_outbound_http_call_passes_a_timeout(source):
+    """requests.get with no timeout blocks its worker thread until the remote answers,
+    which for an unreachable qlstats is indefinitely. This plugin retries MAX_ATTEMPTS
+    times inside a @thread, so a hung endpoint parks the thread for good.
+
+    Fixed on the minqlx copy in `8f4c8e3` on main; the port predates it. Walked as an
+    AST rather than grepped so a second call site cannot be added without a timeout.
+    """
+    import ast
+    # The file carries a UTF-8 BOM; the `source` fixture decodes as plain utf-8,
+    # so the mark survives as \ufeff and ast.parse would reject it.
+    tree = ast.parse(source.lstrip('\ufeff'))
+    calls = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in ('get', 'post')
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == 'requests'
+    ]
+    assert calls, "expected at least one requests call; has the fetch moved?"
+    untimed = [node.lineno for node in calls
+               if not any(kw.arg == 'timeout' for kw in node.keywords)]
+    assert untimed == [], f"requests calls with no timeout at lines {untimed}"


### PR DESCRIPTION
## What

Carries the two plugin fixes from `8f4c8e3` on `main` onto the minqlxtended ports of the same two files.

`8f4c8e3` fixed three pre-existing minqlx plugin bugs that the PR #182 review surfaced. Two of them live in files P3 had already ported, and those ports were taken **before** the fix existed — so right now the same input is safe on minqlx and unsafe on minqlxtended. This closes that gap before the integration branch reaches `main`.

## The two fixes

**1. `myFun.py` — unsanitised chat input reaching `console_command("fdir {}")`**

The engine console treats `;` as a command separator, so an unfiltered `!sound` argument let the caller append arbitrary console commands. `!sound` is registered at permission 3, so this is moderator-scope rather than open to any player — but a moderator asking for a sound should not be handed the console.

Sound paths are now restricted to letters, digits, `_ . / -`.

One deliberate difference from the `main` copy: the anchor here is `\Z`, not `$`. Python's `$` also matches just before a *trailing newline*, so `"ok.ogg\n"` slips through the `main` version. Unreachable in practice — command arguments arrive whitespace-split — but free to get right. **Worth syncing the same one-character change back to the two minqlx copies** so the runtimes read identically; not done here to keep this PR to one branch.

**2. `player_info.py` — `requests.get(url)` with no timeout**

The qlstats fetch runs inside a `@thread` and retries `MAX_ATTEMPTS` times. With no timeout, an unreachable endpoint parked that worker thread indefinitely. Now 10s.

## Also in here

- Both files re-synced into `configs/presets/_builtin/default-minqlxtended/scripts/`, which `test_default_minqlxtended_preset.py` pins byte-for-byte to the baseline.
- `manifest.json` regenerated via `scripts/gen_plugin_manifest.py` (40 files).

## Testing

Three new tests, all confirmed red before the fix and green after:

- `test_sound_paths_are_validated_before_reaching_the_console` — the accept/reject table, including the trailing-newline case that motivated `\Z`.
- `test_the_fdir_call_is_guarded_by_that_check` — a helper nothing calls is not a fix, so this asserts the guard precedes the call.
- `test_every_outbound_http_call_passes_a_timeout` — walks the AST rather than grepping, so a second `requests` call site cannot be added without a timeout.

`player_info.py` carries a UTF-8 BOM. It is preserved through the edit, and the test strips it before parsing.

```
159 passed   # pytest -k "minqlxtended or myfun or player_info or specqueue or commands or reset_acc or suppress_join or serverchecker"
```

## Notes for review

- Base is `feature/minqlxtended`, not `main`.
- No version bump — per the branch strategy, that lands on the final integration PR to `main`.
