### PR TITLE
fix: restore sv_serverType on minqlxtended, keyed to the forced 99k policy

### DIFF
--- a/tests/test_task_deploy_instance.py
+++ b/tests/test_task_deploy_instance.py
@@ -347,6 +347,55 @@ def test_build_qlds_args_always_injects_empty_net_ip(test_app):
             assert '+set net_ip ""' in result
 
 
+def test_build_qlds_args_pairs_sv_servertype_with_lan_force_rate(test_app):
+    """sv_serverType must track the 99k toggle, alongside sv_lanForceRate.
+
+    The 99k trick is two mechanisms, not one: force_rate.so patches
+    Sys_IsLANAddress so sv_lanForceRate 1 assigns rate 99999, and
+    sv_serverType 1 tells the engine it is a LAN server. PR #100 removed the
+    second on the premise that the hook made it redundant -- true for the rate
+    number, false for how the server actually plays -- and every 99k instance
+    ran degraded from 2026-06-01.
+
+    Nothing covered either cvar at the time, which is why the removal shipped
+    unnoticed. Assert them as a pair, so the two halves cannot drift apart
+    again.
+    """
+    with test_app.app_context():
+        enabled = _build_qlds_args_string(
+            _make_instance_for_args(lan_rate_enabled=True))
+        assert '+set sv_serverType 1' in enabled
+        assert '+set sv_lanForceRate 1' in enabled
+        assert '+set sv_serverType 2' not in enabled
+
+        disabled = _build_qlds_args_string(
+            _make_instance_for_args(lan_rate_enabled=False))
+        assert '+set sv_serverType 2' in disabled
+        assert '+set sv_lanForceRate 0' in disabled
+        assert '+set sv_serverType 1' not in disabled
+
+
+def test_build_qlds_args_sv_servertype_follows_forced_99k_on_minqlxtended(test_app):
+    """A forced-99k host gets sv_serverType 1 even with the column set False.
+
+    This is the branch-specific half. QLSM fixes 99k on for every minqlxtended
+    host (lan_rate_forced_on), and instance.lan_rate_enabled keeps whatever the
+    column happened to store -- often False. Deriving sv_serverType from the
+    raw column instead of effective_lan_rate() would hand every minqlxtended
+    instance sv_serverType 2 alongside sv_lanForceRate 1: exactly the broken
+    pairing this fix exists to eliminate, and with no toggle to escape it.
+    """
+    with test_app.app_context():
+        forced = _make_instance_for_args(
+            lan_rate_enabled=False,
+            host=SimpleNamespace(provider='standalone', runtime='minqlxtended'))
+        result = _build_qlds_args_string(forced)
+
+        assert '+set sv_serverType 1' in result
+        assert '+set sv_lanForceRate 1' in result
+        assert '+set sv_serverType 2' not in result
+
+
 # Pure unit tests for _extract_pip_warning (no mocks required)
 from ui.task_logic.ansible_instance_mgmt import _extract_pip_warning
 

--- a/ui/task_logic/ansible_instance_mgmt.py
+++ b/ui/task_logic/ansible_instance_mgmt.py
@@ -121,9 +121,9 @@ def _build_qlds_args_string(instance):
     # minqlxtended hosts at 99k as a policy choice, and what the UI shows has to
     # be the cvar that actually lands here.
     if effective_lan_rate(instance):
-        parts += ['+set sv_lanForceRate 1']
+        parts += ['+set sv_serverType 1', '+set sv_lanForceRate 1']
     else:
-        parts += ['+set sv_lanForceRate 0']
+        parts += ['+set sv_serverType 2', '+set sv_lanForceRate 0']
 
     redis_db_index = resolve_redis_db(instance)
     parts += [


### PR DESCRIPTION
## The minqlxtended half of the `sv_serverType` regression

Companion to **#187** — now **merged to `main`** — which carries the full history, the evidence against PR #100's two premises, and the live-host verification.

Base is `feature/minqlxtended`, not `main`. **Two files, one commit.**

## The change

```python
 if effective_lan_rate(instance):
-    parts += ['+set sv_lanForceRate 1']
+    parts += ['+set sv_serverType 1', '+set sv_lanForceRate 1']
 else:
-    parts += ['+set sv_lanForceRate 0']
+    parts += ['+set sv_serverType 2', '+set sv_lanForceRate 0']
```

The one thing that differs from the main-side fix: **`effective_lan_rate(instance)`, not `instance.lan_rate_enabled`** — matching the `sv_lanForceRate` line directly above it.

QLSM fixes 99k **on** for every minqlxtended host as a policy choice (`lan_rate_forced_on`), while the stored column keeps whatever it happened to hold — usually `False`, because the toggle is disabled in the UI on that runtime. Keying the new cvar to the raw column would hand every minqlxtended instance `sv_serverType 2` alongside `sv_lanForceRate 1`: the exact broken pairing this fix exists to remove, **with no toggle to escape it**.

A naive merge of the main-side fix produces precisely that, so there is a test pinning it.

## Testing

Both tests were verified against mutants, not merely run:

| Test | Fails against |
|---|---|
| `test_build_qlds_args_pairs_sv_servertype_with_lan_force_rate` | PR #100's exact code |
| `test_build_qlds_args_sv_servertype_follows_forced_99k_on_minqlxtended` | the raw-column derivation |

70 passed across the deploy-args, preset, lan-rate-policy and lan-rate-branching suites; **767 passed** across every suite importing `ansible_instance_mgmt` or touching presets and lan-rate policy.

## What changed since the first revision of this PR

**The preset edits were removed.** An earlier revision commented out `set sv_serverType "2"` in both `_builtin/default` and `_builtin/default-minqlxtended`, on the premise that a literal value in `server.cfg` would fight the launch args.

**Live testing disproved that premise.** A deployed instance whose `server.cfg:67` said `"2"` reported `sv_serverType` `is:"1"` at runtime — the command line wins for this cvar, exactly as PR #75 found for `net_ip` (`CVAR_INIT`). The preset lines are **inert**, so editing them was cosmetic, and it pulled `_builtin/default` — a file shared with `main` — into a minqlxtended-only PR for no functional gain.

⚠️ The previous review listed that preset change under **Strengths**, saying it "prevents future operators from re-adding it and creating the same conflict." There is no conflict to create; that assessment rested on the same premise the live test disproved.

The review's one Minor finding — a missing `/` in the config comment — was **not reproducible**. Both the working tree and the reviewed commit contain `//`. Moot now regardless, since those files are no longer in the diff.

## Verification status — read this before merging

#187's live checks (`rcon sv_serverType` → `1`, real IPs at 99999 simultaneously, server still listed in the browser) ran on a **minqlx** host, since this branch's runtime cannot be built from `main`. They validate the shared arg-builder change and retire the one real risk: `sv_serverType 1` does not prevent master-server listing.

**Not verified on a live minqlxtended host:** the forced-99k path — the specific thing this PR adds. No minqlxtended host has taken real playtime yet; that is an outstanding P6 criterion for the migration, not something this PR can close.

## Expect a conflict with `main`

`main` now carries #187's version of this block (`instance.lan_rate_enabled`); this branch carries `effective_lan_rate(instance)`. When the two lines of history meet, **resolve toward this branch's version** — `feature/minqlxtended` is where the forced-99k policy lives.

The user-doc and CodeMirror updates from #187 are deliberately not duplicated here. This branch does not touch those files, so they arrive intact with no conflict.

No version bump — phase PR into the integration branch, per branch strategy.

https://claude.ai/code/session_018T5f3ryb4q1kFavSjAaJFH
