### PR TITLE
feat: make the Add Host runtime an explicit choice, with per-runtime tooltips

### DIFF
--- a/docs/user/getting-started/add-host.md
+++ b/docs/user/getting-started/add-host.md
@@ -4,10 +4,12 @@ Hosts are added from **Servers** -> **Add New Host**. <img src="../../images/add
 
 ## Server Runtime
 
-Every host runs one of two Quake Live server runtimes, chosen from the **Server Runtime** picker on the Add Host form, right below **Provider**:
+Every host runs one of two Quake Live server runtimes, chosen from the **Server Runtime** radio buttons on the Add Host form, right below **Provider**:
 
 - **minqlx** — the original runtime, and every plugin QLSM ships today. Provisions/expects **Debian 12**.
 - **minqlxtended** — a hard fork with no plugin compatibility with minqlx. Provisions/expects **Ubuntu 24.04**, and requires **Python 3.12 or newer** on the target machine.
+
+**Neither option is pre-selected.** QLSM will not make this choice for you: it is permanent, so the form refuses to submit until you pick one and shows *Server runtime is required.* if you try. Each option has an ⓘ tooltip with a one-line description, what it means for the provider you have selected, and a link to that runtime's GitHub repository.
 
 For Vultr cloud hosts, QLSM provisions the matching OS image automatically — there's no separate OS choice.
 

--- a/frontend-react/src/components/common/InfoTooltip.jsx
+++ b/frontend-react/src/components/common/InfoTooltip.jsx
@@ -6,7 +6,8 @@ import { Info } from 'lucide-react';
 /**
  * Reusable info tooltip with instant hover response and themed design.
  *
- * @param {string}  text       - Tooltip message text
+ * @param {React.ReactNode} text - Tooltip content. A string for plain messages;
+ *                               a node where the tooltip needs markup, e.g. a link.
  * @param {number}  [size=14]  - Icon size in px
  * @param {'top'|'bottom'|'left'|'right'} [placement='top'] - Preferred placement
  * @param {string}  [iconClassName] - Extra classes for the icon wrapper

--- a/frontend-react/src/components/hosts/AddHostFormFields.jsx
+++ b/frontend-react/src/components/hosts/AddHostFormFields.jsx
@@ -3,7 +3,8 @@ import FloatingListbox from '../common/FloatingListbox';
 import { providerOptions } from '../../utils/providerData';
 import { HOST_NAME_MAX_LENGTH, HOST_NAME_PATTERN } from '../../utils/resourceValidation';
 import { STANDALONE_TIMEZONES } from '../../utils/formatters';
-import { RUNTIME_OPTIONS } from '../../constants/runtimes';
+import { RUNTIME_OPTIONS, runtimeTooltipTail } from '../../constants/runtimes';
+import InfoTooltip from '../common/InfoTooltip';
 import SelfHostFields from './SelfHostFields';
 import StandaloneAuthSection from './StandaloneAuthSection';
 
@@ -96,20 +97,46 @@ function AddHostFormFields({
         }}
       />
 
-      {/* Runtime -- immutable once the host is created */}
+      {/* Runtime -- immutable once the host is created, so nothing is
+          pre-selected: the operator picks, QLSM never picks for them. */}
       <div data-testid="runtime-picker">
-        <FloatingListbox
-          label="Server Runtime"
-          value={runtime}
-          onChange={onRuntimeChange}
-          options={RUNTIME_OPTIONS}
-          getOptionKey={(opt) => opt.id}
-          getOptionDisplay={(opt) => opt.name}
-          getSelectedDisplay={(val, opts) => opts.find(o => o.id === val)?.name || 'minqlx'}
-        />
-        <p className="mt-1.5 text-xs text-theme-muted">
-          {RUNTIME_OPTIONS.find(o => o.id === runtime)?.description}
-        </p>
+        <label className={labelClass}>Server Runtime</label>
+        <fieldset className="mt-3 flex flex-wrap gap-x-6 gap-y-2" aria-label="Server runtime">
+          {RUNTIME_OPTIONS.map((option) => (
+            <div key={option.id} className="inline-flex items-center gap-1.5">
+              <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-theme-secondary">
+                <input
+                  type="radio"
+                  name="host-runtime"
+                  value={option.id}
+                  checked={runtime === option.id}
+                  onChange={() => onRuntimeChange(option.id)}
+                  className="h-4 w-4"
+                  style={{ accentColor: 'var(--accent-primary)' }}
+                />
+                <span className="text-theme-primary">{option.name}</span>
+              </label>
+              <InfoTooltip
+                testId={`runtime-tooltip-${option.id}`}
+                text={(
+                  <span className="block space-y-1.5">
+                    <span className="block">{option.description}</span>
+                    <span className="block">{runtimeTooltipTail(option.id, provider)}</span>
+                    <a
+                      href={option.repoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block underline"
+                      style={{ color: 'var(--accent-info)' }}
+                    >
+                      {option.repoUrl.replace('https://', '')}
+                    </a>
+                  </span>
+                )}
+              />
+            </div>
+          ))}
+        </fieldset>
         <p
           data-testid="runtime-immutable-warning"
           className="mt-1.5 text-xs"

--- a/frontend-react/src/components/hosts/AddHostFormFields.jsx
+++ b/frontend-react/src/components/hosts/AddHostFormFields.jsx
@@ -53,6 +53,7 @@ function AddHostFormFields({
   osInfo,
   runtime,
   onRuntimeChange,
+  runtimeError,
 }) {
   const isStandalone = provider === 'standalone';
   const isSelf = provider === 'self';
@@ -101,7 +102,11 @@ function AddHostFormFields({
           pre-selected: the operator picks, QLSM never picks for them. */}
       <div data-testid="runtime-picker">
         <label className={labelClass}>Server Runtime</label>
-        <fieldset className="mt-3 flex flex-wrap gap-x-6 gap-y-2" aria-label="Server runtime">
+        <fieldset
+          className="mt-3 flex flex-wrap gap-x-6 gap-y-2"
+          aria-label="Server runtime"
+          aria-describedby={runtimeError ? 'runtime-error' : undefined}
+        >
           {RUNTIME_OPTIONS.map((option) => (
             <div key={option.id} className="inline-flex items-center gap-1.5">
               <label className="inline-flex cursor-pointer items-center gap-2 text-sm text-theme-secondary">
@@ -137,6 +142,16 @@ function AddHostFormFields({
             </div>
           ))}
         </fieldset>
+        {runtimeError && (
+          <p
+            id="runtime-error"
+            role="alert"
+            className="mt-1.5 text-xs"
+            style={{ color: 'var(--accent-danger)' }}
+          >
+            {runtimeError}
+          </p>
+        )}
         <p
           data-testid="runtime-immutable-warning"
           className="mt-1.5 text-xs"

--- a/frontend-react/src/components/hosts/AddHostModal.jsx
+++ b/frontend-react/src/components/hosts/AddHostModal.jsx
@@ -33,6 +33,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   // No default: the runtime is immutable once the host exists, so the operator
   // picks it explicitly or the form does not submit.
   const [runtime, setRuntime] = useState('');
+  const [runtimeError, setRuntimeError] = useState(null);
   const [selfHostExists, setSelfHostExists] = useState(false);
   const [providerOptionsReady, setProviderOptionsReady] = useState(false);
   const [selectedContinent, setSelectedContinent] = useState('');
@@ -139,6 +140,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
     setNameError(null);
     setProvider(selfHostExists ? 'standalone' : 'self');
     setRuntime('');
+    setRuntimeError(null);
     setSelectedContinent('');
     setRegion('');
     setMachineSize('');
@@ -251,9 +253,13 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
     setNameError(null);
 
     if (!runtime) {
-      setError('Server runtime is required.');
+      // Belongs to the field, not the modal's generic error slot at the bottom
+      // of the form: the radios sit near the top, and an unassociated message
+      // announces nothing to a screen reader landing on them.
+      setRuntimeError('Server runtime is required.');
       return;
     }
+    setRuntimeError(null);
 
     if (provider === 'standalone') {
       if (!ipAddress || !ipAddress.trim()) {
@@ -450,7 +456,11 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
                         onSwitchToSelfHost={handleSwitchToSelfHost}
                         osInfo={selfHostOsInfo}
                         runtime={runtime}
-                        onRuntimeChange={setRuntime}
+                        runtimeError={runtimeError}
+                        onRuntimeChange={(value) => {
+                          setRuntime(value);
+                          setRuntimeError(null);
+                        }}
                       />
                     ) : (
                       <div className="text-sm text-theme-muted">Loading host options...</div>

--- a/frontend-react/src/components/hosts/AddHostModal.jsx
+++ b/frontend-react/src/components/hosts/AddHostModal.jsx
@@ -7,7 +7,6 @@ import { providerOptions } from '../../utils/providerData';
 import AddHostFormFields from './AddHostFormFields';
 import { validateHostName } from '../../utils/resourceValidation';
 import { getTimezoneForRegion } from '../../utils/formatters';
-import { DEFAULT_RUNTIME } from '../../constants/runtimes';
 
 const PROVIDER_LIST_OPTIONS = [
   { id: 'self', name: 'QLSM Host (self-deployment)' },
@@ -31,7 +30,9 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
   const [name, setName] = useState('');
   const [nameError, setNameError] = useState(null);
   const [provider, setProvider] = useState('self');
-  const [runtime, setRuntime] = useState(DEFAULT_RUNTIME);
+  // No default: the runtime is immutable once the host exists, so the operator
+  // picks it explicitly or the form does not submit.
+  const [runtime, setRuntime] = useState('');
   const [selfHostExists, setSelfHostExists] = useState(false);
   const [providerOptionsReady, setProviderOptionsReady] = useState(false);
   const [selectedContinent, setSelectedContinent] = useState('');
@@ -137,7 +138,7 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
     setName('');
     setNameError(null);
     setProvider(selfHostExists ? 'standalone' : 'self');
-    setRuntime(DEFAULT_RUNTIME);
+    setRuntime('');
     setSelectedContinent('');
     setRegion('');
     setMachineSize('');
@@ -248,6 +249,11 @@ function AddHostModal({ isOpen, onClose, onHostAdded }) {
       return;
     }
     setNameError(null);
+
+    if (!runtime) {
+      setError('Server runtime is required.');
+      return;
+    }
 
     if (provider === 'standalone') {
       if (!ipAddress || !ipAddress.trim()) {

--- a/frontend-react/src/components/hosts/__tests__/AddHostFormFields.test.jsx
+++ b/frontend-react/src/components/hosts/__tests__/AddHostFormFields.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import AddHostFormFields from '../AddHostFormFields';
@@ -103,5 +103,70 @@ describe('AddHostFormFields runtime picker', () => {
   it('tells the operator the choice cannot be changed later', () => {
     render(<AddHostFormFields {...baseProps} />);
     expect(screen.getByTestId('runtime-immutable-warning')).toHaveTextContent(/cannot be changed/i);
+  });
+});
+
+describe('AddHostFormFields runtime radios', () => {
+  it('starts with neither runtime selected', () => {
+    // The choice is irreversible, so QLSM makes no pick on the operator's
+    // behalf -- an unaware operator can never land on a runtime by default.
+    render(<AddHostFormFields {...baseProps} runtime="" />);
+    const radios = screen.getAllByRole('radio', { name: /minqlx/i });
+    expect(radios).toHaveLength(2);
+    radios.forEach(radio => expect(radio).not.toBeChecked());
+  });
+
+  it('checks only the selected runtime', () => {
+    render(<AddHostFormFields {...baseProps} runtime="minqlxtended" />);
+    expect(screen.getByRole('radio', { name: /^minqlxtended$/i })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /^minqlx$/i })).not.toBeChecked();
+  });
+
+  it('reports the runtime the operator picked', () => {
+    const onRuntimeChange = vi.fn();
+    render(<AddHostFormFields {...baseProps} runtime="" onRuntimeChange={onRuntimeChange} />);
+    fireEvent.click(screen.getByRole('radio', { name: /^minqlxtended$/i }));
+    expect(onRuntimeChange).toHaveBeenCalledWith('minqlxtended');
+  });
+});
+
+describe('AddHostFormFields runtime tooltips', () => {
+  const openTooltip = (runtimeId) => {
+    fireEvent.mouseEnter(screen.getByTestId(`runtime-tooltip-${runtimeId}`));
+    return screen.getByRole('tooltip');
+  };
+
+  it.each([
+    ['minqlx', 'https://github.com/MinoMino/minqlx'],
+    ['minqlxtended', 'https://github.com/tjone270/minqlxtended'],
+  ])('links %s to its upstream repo', (runtimeId, repoUrl) => {
+    // One render per runtime: InfoTooltip's close is debounced, so opening both
+    // in a single render leaves two bubbles mounted at once.
+    render(<AddHostFormFields {...baseProps} runtime="" />);
+    expect(within(openTooltip(runtimeId)).getByRole('link')).toHaveAttribute('href', repoUrl);
+  });
+
+  it('opens repo links in a new tab without leaking the opener', () => {
+    render(<AddHostFormFields {...baseProps} runtime="" />);
+    const link = within(openTooltip('minqlx')).getByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('tells a cloud operator QLSM provisions the OS', () => {
+    render(<AddHostFormFields {...baseProps} provider="vultr" runtime="" />);
+    expect(openTooltip('minqlxtended')).toHaveTextContent('QLSM provisions Ubuntu 24.04.');
+  });
+
+  it('tells a standalone operator the requirement is checked before creation', () => {
+    render(<AddHostFormFields {...baseProps} provider="standalone" runtime="" />);
+    expect(openTooltip('minqlxtended')).toHaveTextContent(/Ubuntu 24.04 or newer.*checked before the host is created/i);
+  });
+
+  it('warns a self-host operator that nothing is checked up front', () => {
+    // This is the one path with no pre-check: the host is created, setup fails,
+    // and it lands in Error with deleting it the only way back.
+    render(<AddHostFormFields {...baseProps} provider="self" runtime="" />);
+    expect(openTooltip('minqlxtended')).toHaveTextContent(/not checked up front/i);
   });
 });

--- a/frontend-react/src/components/hosts/__tests__/AddHostFormFields.test.jsx
+++ b/frontend-react/src/components/hosts/__tests__/AddHostFormFields.test.jsx
@@ -111,7 +111,9 @@ describe('AddHostFormFields runtime radios', () => {
     // The choice is irreversible, so QLSM makes no pick on the operator's
     // behalf -- an unaware operator can never land on a runtime by default.
     render(<AddHostFormFields {...baseProps} runtime="" />);
-    const radios = screen.getAllByRole('radio', { name: /minqlx/i });
+    // The runtime radios are the only ones on the form for a cloud provider,
+    // so no name filter is needed -- and none of them may start checked.
+    const radios = screen.getAllByRole('radio');
     expect(radios).toHaveLength(2);
     radios.forEach(radio => expect(radio).not.toBeChecked());
   });
@@ -168,5 +170,25 @@ describe('AddHostFormFields runtime tooltips', () => {
     // and it lands in Error with deleting it the only way back.
     render(<AddHostFormFields {...baseProps} provider="self" runtime="" />);
     expect(openTooltip('minqlxtended')).toHaveTextContent(/not checked up front/i);
+  });
+});
+
+describe('AddHostFormFields runtime error', () => {
+  it('renders no error region when no runtime error is set', () => {
+    render(<AddHostFormFields {...baseProps} runtime="" runtimeError={null} />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('announces the runtime error and ties it to the radio group', () => {
+    // Without the association a screen-reader user tabbing onto the radios is
+    // told nothing -- the message sits elsewhere in the document.
+    render(<AddHostFormFields {...baseProps} runtime="" runtimeError="Server runtime is required." />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Server runtime is required.');
+
+    const group = screen.getByRole('group', { name: /server runtime/i });
+    expect(group).toHaveAttribute('aria-describedby', alert.id);
+    expect(alert.id).toBeTruthy();
   });
 });

--- a/frontend-react/src/components/hosts/__tests__/AddHostModal.test.jsx
+++ b/frontend-react/src/components/hosts/__tests__/AddHostModal.test.jsx
@@ -54,6 +54,7 @@ vi.mock('../AddHostFormFields', () => ({
       <input aria-label="SSH Password" value={props.sshPassword || ''} onChange={props.onSshPasswordChange} />
       <textarea aria-label="SSH Private Key" value={props.sshKey || ''} onChange={props.onSshKeyChange} />
       <div data-testid="runtime-value">{props.runtime}</div>
+      <div data-testid="runtime-error">{props.runtimeError || ''}</div>
       <button type="button" onClick={() => props.onRuntimeChange('minqlx')}>Choose minqlx runtime</button>
       <button type="button" onClick={() => props.onRuntimeChange('minqlxtended')}>Choose minqlxtended runtime</button>
       <div data-testid="connection-status">{props.connectionTestStatus}</div>
@@ -321,20 +322,35 @@ describe('AddHostModal runtime selection', () => {
     render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
 
     await waitFor(() => expect(mocks.getHosts).toHaveBeenCalledTimes(1));
-    expect(screen.getByTestId('runtime-value')).toHaveTextContent('');
+    expect(await screen.findByTestId('runtime-value')).toHaveTextContent('');
   });
 
   it('refuses to create a host until a runtime is picked', async () => {
     render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
 
     await waitFor(() => expect(mocks.getHosts).toHaveBeenCalledTimes(1));
-    fireEvent.change(screen.getByLabelText('Host Name'), { target: { value: 'self-host' } });
+    fireEvent.change(await screen.findByLabelText('Host Name'), { target: { value: 'self-host' } });
     await waitFor(() => expect(screen.getByLabelText('SSH User')).toHaveValue('rage'));
     fireEvent.click(screen.getByRole('button', { name: /set timezone/i }));
     fireEvent.click(screen.getByRole('button', { name: /add host/i }));
 
-    expect(await screen.findByText('Server runtime is required.')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('runtime-error')).toHaveTextContent('Server runtime is required.'));
     expect(mocks.createHost).not.toHaveBeenCalled();
+  });
+
+  it('clears the runtime error once a runtime is picked', async () => {
+    render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
+
+    await waitFor(() => expect(mocks.getHosts).toHaveBeenCalledTimes(1));
+    fireEvent.change(await screen.findByLabelText('Host Name'), { target: { value: 'self-host' } });
+    await waitFor(() => expect(screen.getByLabelText('SSH User')).toHaveValue('rage'));
+    fireEvent.click(screen.getByRole('button', { name: /set timezone/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add host/i }));
+    await waitFor(() => expect(screen.getByTestId('runtime-error')).toHaveTextContent('Server runtime is required.'));
+
+    fireEvent.click(screen.getByRole('button', { name: /choose minqlx runtime/i }));
+
+    await waitFor(() => expect(screen.getByTestId('runtime-error')).toHaveTextContent(''));
   });
 
   it('sends the runtime the operator picked', async () => {
@@ -342,7 +358,7 @@ describe('AddHostModal runtime selection', () => {
     render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
 
     await waitFor(() => expect(mocks.getHosts).toHaveBeenCalledTimes(1));
-    fireEvent.change(screen.getByLabelText('Host Name'), { target: { value: 'self-host' } });
+    fireEvent.change(await screen.findByLabelText('Host Name'), { target: { value: 'self-host' } });
     await waitFor(() => expect(screen.getByLabelText('SSH User')).toHaveValue('rage'));
     fireEvent.click(screen.getByRole('button', { name: /set timezone/i }));
     fireEvent.click(screen.getByRole('button', { name: /choose minqlxtended runtime/i }));

--- a/frontend-react/src/components/hosts/__tests__/AddHostModal.test.jsx
+++ b/frontend-react/src/components/hosts/__tests__/AddHostModal.test.jsx
@@ -53,6 +53,9 @@ vi.mock('../AddHostFormFields', () => ({
       <button type="button" onClick={() => props.onStandaloneAuthMethodChange?.('key')}>Use ssh key</button>
       <input aria-label="SSH Password" value={props.sshPassword || ''} onChange={props.onSshPasswordChange} />
       <textarea aria-label="SSH Private Key" value={props.sshKey || ''} onChange={props.onSshKeyChange} />
+      <div data-testid="runtime-value">{props.runtime}</div>
+      <button type="button" onClick={() => props.onRuntimeChange('minqlx')}>Choose minqlx runtime</button>
+      <button type="button" onClick={() => props.onRuntimeChange('minqlxtended')}>Choose minqlxtended runtime</button>
       <div data-testid="connection-status">{props.connectionTestStatus}</div>
       <div data-testid="connection-message">{props.connectionTestMessage}</div>
       <button type="button" onClick={props.onTestConnection}>Test connection</button>
@@ -88,6 +91,7 @@ describe('AddHostModal self provider', () => {
     await waitFor(() => expect(screen.getByLabelText('SSH User')).toHaveValue('rage'));
     await waitFor(() => expect(screen.getByLabelText('Server address')).toHaveValue('203.0.113.10'));
     fireEvent.click(screen.getByRole('button', { name: /set timezone/i }));
+    fireEvent.click(screen.getByRole('button', { name: /choose minqlx runtime/i }));
     fireEvent.click(screen.getByRole('button', { name: /add host/i }));
 
     await waitFor(() => expect(mocks.createHost).toHaveBeenCalledWith({
@@ -156,6 +160,7 @@ describe('AddHostModal self provider', () => {
     await waitFor(() => expect(screen.getByTestId('connection-status')).toHaveTextContent('success'));
     await waitFor(() => expect(screen.getByTestId('connection-message')).toHaveTextContent('Connection successful. Detected OS: Ubuntu 24.04.2 LTS.'));
 
+    fireEvent.click(screen.getByRole('button', { name: /choose minqlx runtime/i }));
     fireEvent.click(screen.getByRole('button', { name: /add host/i }));
 
     await waitFor(() => expect(mocks.createHost).toHaveBeenCalledWith({
@@ -296,5 +301,55 @@ describe('AddHostModal — QLSM-detected redirect', () => {
     await waitFor(() =>
       expect(screen.getByTestId('connection-status')).toHaveTextContent('success')
     );
+  });
+});
+
+describe('AddHostModal runtime selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getHosts.mockResolvedValue([]);
+    mocks.getSelfHostDefaults.mockResolvedValue({
+      ssh_user: 'rage',
+      host_ip: '203.0.113.10',
+      provider_capabilities: { vultr: { configured: true } },
+    });
+  });
+
+  it('opens with no runtime selected', async () => {
+    // The runtime is immutable once the host exists, so QLSM refuses to make
+    // the irreversible pick for an operator who never looked at the field.
+    render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
+
+    await waitFor(() => expect(mocks.getHosts).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('runtime-value')).toHaveTextContent('');
+  });
+
+  it('refuses to create a host until a runtime is picked', async () => {
+    render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
+
+    await waitFor(() => expect(mocks.getHosts).toHaveBeenCalledTimes(1));
+    fireEvent.change(screen.getByLabelText('Host Name'), { target: { value: 'self-host' } });
+    await waitFor(() => expect(screen.getByLabelText('SSH User')).toHaveValue('rage'));
+    fireEvent.click(screen.getByRole('button', { name: /set timezone/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add host/i }));
+
+    expect(await screen.findByText('Server runtime is required.')).toBeInTheDocument();
+    expect(mocks.createHost).not.toHaveBeenCalled();
+  });
+
+  it('sends the runtime the operator picked', async () => {
+    mocks.createHost.mockResolvedValue({ message: 'Self host queued.' });
+    render(<AddHostModal isOpen={true} onClose={vi.fn()} onHostAdded={vi.fn()} />);
+
+    await waitFor(() => expect(mocks.getHosts).toHaveBeenCalledTimes(1));
+    fireEvent.change(screen.getByLabelText('Host Name'), { target: { value: 'self-host' } });
+    await waitFor(() => expect(screen.getByLabelText('SSH User')).toHaveValue('rage'));
+    fireEvent.click(screen.getByRole('button', { name: /set timezone/i }));
+    fireEvent.click(screen.getByRole('button', { name: /choose minqlxtended runtime/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add host/i }));
+
+    await waitFor(() => expect(mocks.createHost).toHaveBeenCalledWith(
+      expect.objectContaining({ runtime: 'minqlxtended' }),
+    ));
   });
 });

--- a/frontend-react/src/constants/__tests__/runtimes.test.js
+++ b/frontend-react/src/constants/__tests__/runtimes.test.js
@@ -1,9 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { RUNTIME_OPTIONS, DEFAULT_RUNTIME, defaultPresetNameForRuntime, runtimeLabel, runtimeLogFilename } from '../runtimes';
+import { RUNTIME_OPTIONS, DEFAULT_RUNTIME, defaultPresetNameForRuntime, runtimeLabel, runtimeLogFilename, runtimeTooltipTail } from '../runtimes';
 
 describe('runtime constants', () => {
   it('defaults to minqlx', () => {
     expect(DEFAULT_RUNTIME).toBe('minqlx');
+  });
+
+  it('gives every runtime the upstream repo its tooltip links to', () => {
+    expect(RUNTIME_OPTIONS.find(o => o.id === 'minqlx').repoUrl)
+      .toBe('https://github.com/MinoMino/minqlx');
+    expect(RUNTIME_OPTIONS.find(o => o.id === 'minqlxtended').repoUrl)
+      .toBe('https://github.com/tjone270/minqlxtended');
   });
 
   it('offers exactly the two runtimes, minqlx first', () => {
@@ -49,5 +56,57 @@ describe('defaultPresetNameForRuntime', () => {
     expect(defaultPresetNameForRuntime(null)).toBe('default');
     expect(defaultPresetNameForRuntime(undefined)).toBe('default');
     expect(defaultPresetNameForRuntime('nonsense')).toBe('default');
+  });
+});
+
+describe('runtimeTooltipTail', () => {
+  // The runtime choice is irreversible, so the tooltip has to be accurate about
+  // what the operator is committing to -- and that differs by provider. On a
+  // cloud host QLSM picks the OS image; on the operator's own machine it does
+  // not, and only minqlxtended has a floor to miss.
+  it('tells cloud operators QLSM provisions the OS for them', () => {
+    expect(runtimeTooltipTail('minqlx', 'vultr')).toBe('QLSM provisions Debian 12.');
+    expect(runtimeTooltipTail('minqlxtended', 'vultr')).toBe('QLSM provisions Ubuntu 24.04.');
+  });
+
+  it('names the distro, not the Python version, for minqlxtended on an operator-owned machine', () => {
+    // "Python 3.12+" sends operators to apt, which has no python3.12 on Debian
+    // 12 -- and the build links -lpython3.12, so a sideloaded one would not
+    // satisfy it either. The actionable requirement is the distro release.
+    expect(runtimeTooltipTail('minqlxtended', 'standalone')).toContain('Ubuntu 24.04 or newer');
+    expect(runtimeTooltipTail('minqlxtended', 'standalone')).not.toContain('Python');
+    expect(runtimeTooltipTail('minqlxtended', 'self')).toContain('Ubuntu 24.04 or newer');
+    expect(runtimeTooltipTail('minqlxtended', 'self')).not.toContain('Python');
+  });
+
+  it('says a standalone host is checked before it is created', () => {
+    // _validate_runtime_python() rejects the submission, so the operator finds
+    // out before anything irreversible happens.
+    expect(runtimeTooltipTail('minqlxtended', 'standalone')).toMatch(/checked before the host is created/i);
+  });
+
+  it('warns that a self host is not checked up front and fails during setup', () => {
+    // There is no pre-check for self: the host record is created, setup fails
+    // on the playbook assert, and the host lands in Error.
+    expect(runtimeTooltipTail('minqlxtended', 'self')).toMatch(/not checked up front/i);
+    expect(runtimeTooltipTail('minqlxtended', 'self')).toMatch(/setup fails/i);
+  });
+
+  it('tells operator-owned machines that minqlx has no version floor', () => {
+    // min_python is None for minqlx: it runs on whatever python3 the distro
+    // ships, so there is nothing here for an operator to get wrong.
+    ['standalone', 'self'].forEach(provider => {
+      expect(runtimeTooltipTail('minqlx', provider)).toMatch(/no version floor/i);
+    });
+  });
+
+  it('treats an unknown provider as a provisioned cloud host', () => {
+    // Every provider other than standalone/self is one QLSM images itself --
+    // the same split AddHostFormFields already makes.
+    expect(runtimeTooltipTail('minqlxtended', 'somefuturecloud')).toBe('QLSM provisions Ubuntu 24.04.');
+  });
+
+  it('falls back to minqlx copy for an unknown runtime', () => {
+    expect(runtimeTooltipTail('garbage', 'vultr')).toBe('QLSM provisions Debian 12.');
   });
 });

--- a/frontend-react/src/constants/runtimes.js
+++ b/frontend-react/src/constants/runtimes.js
@@ -1,18 +1,23 @@
-// The minqlx runtime a host builds and runs. Chosen when the host is created
-// and immutable afterwards -- moving a live host between runtimes is
-// destructive, so QLSM offers no edit path. Mirrors ui/runtime.py.
+// The runtime a host with no recorded value is understood to be running. This
+// is a *label* fallback for host rows that predate the runtime column -- it is
+// deliberately NOT the Add Host form's starting value. That form starts with
+// nothing selected, because the choice is immutable once the host is created
+// and QLSM will not make an irreversible pick on the operator's behalf.
+// Mirrors ui/runtime.py.
 export const DEFAULT_RUNTIME = 'minqlx';
 
 export const RUNTIME_OPTIONS = [
   {
     id: 'minqlx',
     name: 'minqlx',
-    description: 'The original runtime. Debian 12, and every plugin QLSM ships today.',
+    description: 'The original Quake Live server runtime. Every plugin QLSM ships today is written for it.',
+    repoUrl: 'https://github.com/MinoMino/minqlx',
   },
   {
     id: 'minqlxtended',
     name: 'minqlxtended',
-    description: 'The tjone270 fork. Ubuntu 24.04 and Python 3.12. Plugins are not interchangeable with minqlx.',
+    description: 'A hard fork by tjone270. Its plugins are not interchangeable with minqlx.',
+    repoUrl: 'https://github.com/tjone270/minqlxtended',
   },
 ];
 
@@ -21,6 +26,36 @@ const KNOWN = new Set(RUNTIME_OPTIONS.map(option => option.id));
 // A host with no recorded runtime predates the column, and nothing but minqlx
 // has ever existed.
 export const runtimeLabel = (value) => (KNOWN.has(value) ? value : DEFAULT_RUNTIME);
+
+// The closing line of a runtime's tooltip, which depends on who supplies the
+// machine. On a cloud host QLSM writes the OS image, so the operator cannot get
+// this wrong. On a standalone or self host the OS is already whatever it is,
+// and minqlxtended is compiled on the host against libpython3.12
+// (ansible/playbooks/setup_host.yml:665) -- so it needs a distro whose python3
+// is already 3.12. Naming the distro rather than the Python version is
+// deliberate: Debian 12 has no python3.12 in its archive, so "install Python
+// 3.12" is a dead end and "use Ubuntu 24.04" is the actionable instruction.
+const TOOLTIP_TAILS = {
+  minqlx: {
+    provisioned: 'QLSM provisions Debian 12.',
+    // min_python is None for minqlx -- it runs on whatever python3 ships.
+    operatorOwned: "Runs on the distro's own python3 — no version floor.",
+  },
+  minqlxtended: {
+    provisioned: 'QLSM provisions Ubuntu 24.04.',
+    // _validate_runtime_python() rejects the submission before the host row exists.
+    standalone: 'Needs Ubuntu 24.04 or newer. Checked before the host is created.',
+    // No pre-check exists for self: the playbook assert fails during setup and
+    // the host lands in Error, with deleting it the only way back.
+    self: "Needs Ubuntu 24.04 or newer. Not checked up front — setup fails if it isn't.",
+  },
+};
+
+export function runtimeTooltipTail(runtime, provider) {
+  const tails = TOOLTIP_TAILS[runtimeLabel(runtime)];
+  if (provider !== 'standalone' && provider !== 'self') return tails.provisioned;
+  return tails[provider] || tails.operatorOwned;
+}
 
 // The live (unrotated) log filename each runtime writes. Mirrors
 // runtime_paths()['log_filename'] in ui/runtime.py. Used only to seed a log

--- a/ui/runtime.py
+++ b/ui/runtime.py
@@ -16,8 +16,12 @@ MINQLXTENDED = 'minqlxtended'
 
 VALID_RUNTIMES = (MINQLX, MINQLXTENDED)
 
-# The default is minqlx and stays minqlx until P6 flips it. It is what an
-# unaware operator gets, and the choice is irreversible.
+# Nothing ever "flips" this: the Add Host form pre-selects no runtime at all,
+# because the choice is irreversible and QLSM will not make it on an operator's
+# behalf. This constant is the fallback for the two cases where no human is
+# choosing -- a host row that predates the runtime column, and an API payload
+# that omits the field -- and it points at minqlx because that is the
+# conservative answer, not because it is anyone's default.
 DEFAULT_RUNTIME = MINQLX
 
 _RUNTIME_PATHS = {


### PR DESCRIPTION
## What this changes

The Add Host **Server Runtime** picker becomes two radio buttons with **neither pre-selected**. The form refuses to submit until the operator picks one, with `Server runtime is required.`

Each option carries an `InfoTooltip` with a one-line description, a **provider-aware** requirement line, and a link to its upstream repo.

## Why not just flip the default

This **replaces** P6's planned "flip the default to minqlxtended" scope, by operator decision.

The runtime is immutable once the host exists. A pre-selected value means an operator who never looked at the field still made an irreversible decision — and that's true whichever runtime is pre-selected. So no runtime is the default now: minqlxtended does not become one, and minqlx stops being one.

`DEFAULT_RUNTIME` survives in both `ui/runtime.py` and `constants/runtimes.js`, but only for the two cases where no human is choosing: a host row that predates the runtime column, and an API payload that omits the field.

## Why the tooltip tail is provider-aware

One fixed string per runtime would be wrong somewhere. QLSM writes the OS image on a cloud host; on standalone and self it provisions no OS at all, and only minqlxtended has a floor to miss.

| provider | minqlx | minqlxtended |
|---|---|---|
| cloud | QLSM provisions Debian 12. | QLSM provisions Ubuntu 24.04. |
| standalone | Runs on the distro's own python3 — no version floor. | Needs Ubuntu 24.04 or newer. Checked before the host is created. |
| self | Runs on the distro's own python3 — no version floor. | Needs Ubuntu 24.04 or newer. Not checked up front — setup fails if it isn't. |

The tail names **the distro, not the Python version**, deliberately. minqlxtended is compiled on the host against `libpython3.12` (`setup_host.yml:665`); Debian 12 ships no `python3.12` in its archive; and host setup installs the distro's own `python3`/`python3-dev`/`python3-pip` (`setup_host.yml:297`) rather than any specific version — so setup cannot rescue a host below the floor, it asserts and aborts (`setup_host.yml:49`). "Install Python 3.12" is a dead end; "use Ubuntu 24.04" is actionable.

The **self** row is the one that matters most: it's the only path with no pre-check, so the host record is created, setup fails, and it lands in Error with deleting it the only way back.

## Backend

Unchanged. `_validate_runtime` still resolves an absent `runtime` to minqlx — the conservative direction for any caller that isn't this form.

## Verification

- Frontend **733 passed** (81 files)
- Backend **237 passed** across the runtime / host-route suites
- `eslint` **0 errors** (6 warnings, all pre-existing)
- `vite build` clean
- **Driven live in the dev server** with Playwright: `input[name="host-runtime"]:checked` is 0 on open, all six tooltip variants verified against the running app, and the required-runtime guard confirmed reachable.

One thing worth recording: the first live check of the guard used an invalid scenario — submitting with **Server address** empty, so the browser's native `required` validation fired first and the guard never ran. jsdom doesn't enforce native constraint validation, so no test could have caught that. Redone with every other required field filled. Native validation therefore runs *before* the runtime guard, making it the last check an operator hits rather than the first.

## Two pre-existing tests changed

`AddHostModal.test.jsx` had two tests asserting `runtime: 'minqlx'` in the create payload while never touching the field — they were passing on the default this PR removes. Both now pick the runtime explicitly rather than having the assertion weakened.

## Not in scope

The two P6 live criteria (LD_PRELOAD hooks observed working, real playtime) are unchanged and still gate the single PR from `feature/minqlxtended` to `main`. Removing the default does not relax them.

No `VERSION` / `releases.md` bump — per the branch strategy that belongs on the final PR to `main`.

https://claude.ai/code/session_018T5f3ryb4q1kFavSjAaJFH
