### PR TITLE
docs: cover minqlxtended in the user docs it was missing from

### DIFF
--- a/docs/user/features/hooks.md
+++ b/docs/user/features/hooks.md
@@ -16,6 +16,8 @@ System hooks are managed by QLSM and are read-only. They appear in the Hooks tab
 
 The only current system hook is **`force_rate.so`**, which is automatically registered when [99k LAN rate](99k-lan-rate.md) is enabled for an instance.
 
+**On a minqlxtended host, `force_rate.so` is never loaded — and that is correct.** Every minqlxtended instance runs at 99k LAN rate, but the fork implements that behaviour itself rather than through a preloaded library, so QLSM deliberately leaves the hook out. If you look at the Hooks tab on a minqlxtended instance and find no `force_rate.so` while the rate reads 99k, nothing is wrong or missing. Loading it there would in fact stop the server from starting, because both it and minqlxtended patch the same function. See [Server Runtime](../getting-started/add-host.md#server-runtime).
+
 ### User Hooks
 
 User hooks are `.so` files you upload yourself. They are fully under your control: you can upload, enable/disable, reorder, and delete them.

--- a/docs/user/getting-started/introduction.md
+++ b/docs/user/getting-started/introduction.md
@@ -14,9 +14,10 @@ QLSM supports three ways to run your Quake Live servers:
 
 ## Key Features
 
+- **[Choice of server runtime](add-host.md#server-runtime)** — each host runs either **minqlx** or **minqlxtended**, picked when the host is created. Neither is pre-selected and the choice is permanent, so QLSM asks rather than guessing. Plugins are not interchangeable between the two; QLSM ships a plugin baseline for each and converts what it can when you load a preset across runtimes.
 - **[Live server status](https://dngrtech.github.io/qlsm/operations/live-status/)** — current map, gametype, match state, players, and scores visible at a glance. ZMQ credentials auto-generated and displayed.
-- **[99k LAN rate mode](../features/99k-lan-rate.md)** — patches the QLDS LAN-detection function via LD_PRELOAD so every client is treated as LAN, enabling the high-bandwidth rate path. Real improvement for LG-heavy or large CA/FFA servers.
-- **[LD_PRELOAD hooks](../features/hooks.md)** — upload custom native `.so` libraries loaded into each QLDS process at launch. System hooks (like `force_rate.so`) are managed automatically.
+- **[99k LAN rate mode](../features/99k-lan-rate.md)** — every client is treated as LAN, enabling the high-bandwidth rate path. Real improvement for LG-heavy or large CA/FFA servers. On minqlx hosts this is a per-instance toggle implemented by patching the QLDS LAN-detection function via LD_PRELOAD; on minqlxtended hosts it is always on and native to the runtime.
+- **[LD_PRELOAD hooks](../features/hooks.md)** — upload custom native `.so` libraries loaded into each QLDS process at launch. System hooks (like `force_rate.so`, used only on minqlx hosts) are managed automatically.
 - **In-browser [config editors](https://dngrtech.github.io/qlsm/operations/edit-configs/)** — CodeMirror-powered editors for `server.cfg`, `mappool.txt`, `access.txt`, and `workshop.txt`. Syntax highlighting, search/replace, and inline validation.
 - **minqlx [plugin management](https://dngrtech.github.io/qlsm/operations/edit-configs/)** — enable plugins with checkboxes. Python validation built in.
 - **[Factory](https://dngrtech.github.io/qlsm/operations/edit-configs/#factories) file management** — select which factory files deploy to each instance.

--- a/docs/user/help/deployment-troubleshooting.md
+++ b/docs/user/help/deployment-troubleshooting.md
@@ -31,6 +31,28 @@ If something isn't working, start by clicking "Re-run host setup" from the [host
 - Restart affected instances (manual or from the workshop update modal).
 - Configure scheduled host restart to keep updates consistent: [Configure Auto-Restart](../operations/auto-restart.md)
 
+## Problem: A minqlxtended host fails setup and lands in Error
+
+minqlxtended is compiled on the host itself and links against Python 3.12, so the machine's
+distribution must already provide it. **Host setup does not install a Python version** — it
+installs the distribution's own `python3`, whatever that happens to be — so a machine below the
+floor cannot be rescued by re-running setup. Setup checks the version first and stops before
+changing anything.
+
+Where you find out depends on the provider:
+
+- **Cloud hosts** — cannot hit this. QLSM provisions Ubuntu 24.04 for the minqlxtended runtime.
+- **Standalone hosts** — the Add Host form checks the detected version and refuses the
+  submission with an explanation, so the host is never created. An *undetectable* version is
+  also refused, deliberately: the runtime choice cannot be undone later.
+- **Self hosts** — there is no pre-check. The host record is created, setup fails on the version
+  check, and the host lands in **Error**.
+
+The fix is the distribution, not the package: Debian 12 has no `python3.12` in its archive, so
+installing one by hand is a dead end. Use **Ubuntu 24.04 or newer**, or create the host with the
+**minqlx** runtime, which has no version floor. Because the runtime is permanent, an Error host
+here has to be deleted and recreated. See [Server Runtime](../getting-started/add-host.md#server-runtime).
+
 ## Problem: Self-host stuck in REBOOTING state
 
 - QLSM auto-recovers this state on container startup — no manual action is needed.

--- a/docs/user/operations/minqlx-logs.md
+++ b/docs/user/operations/minqlx-logs.md
@@ -1,19 +1,22 @@
 # MinQLX Logs
 
-Use **View MinQLX Logs** from the instance action menu to read `minqlx.log` and rotated archives. This is the MinQLX plugin log — player events, chat/console output, votes, and plugin activity — as opposed to service/runtime output ([Server Logs](server-logs.md)) or the dedicated chat history ([Chat Logs](chat-logs.md)).
+Use **View MinQLX Logs** from the instance action menu to read the plugin log and its rotated archives. This is the plugin log — player events, chat/console output, votes, and plugin activity — as opposed to service/runtime output ([Server Logs](server-logs.md)) or the dedicated chat history ([Chat Logs](chat-logs.md)).
+
+**The filename depends on the host's [Server Runtime](../getting-started/add-host.md#server-runtime).** A minqlx host writes `minqlx.log`; a minqlxtended host writes `minqlxtended.log`. The menu item is called *View MinQLX Logs* on both — QLSM selects the right file for you when the modal opens.
 
 ![Instance Actions: View MinQLX Logs](../images/instance-actions-menu-view-minqlx-logs.png)
 
 ## File Selection
 
-The modal loads available files and keeps valid names only:
+The modal loads available files and keeps valid names only. Read `<log>` below as
+`minqlx.log` on a minqlx host and `minqlxtended.log` on a minqlxtended host:
 
-- `minqlx.log`
-- `minqlx.log.<number>` (for example `minqlx.log.1`)
+- `<log>`
+- `<log>.<number>` (for example `minqlx.log.1`, or `minqlxtended.log.1`)
 
 Sorting behavior:
 
-1. `minqlx.log` first
+1. `<log>` first
 2. then numeric archives in ascending order (`.1`, `.2`, ...)
 
 The UI keeps at most 11 entries (current file + 10 archives).


### PR DESCRIPTION
## What this changes

The migration already updated `add-host`, `presets/overview`, `99k-lan-rate` and `deploy-new-instance`. This covers four pages that were left describing a minqlx-only world — each one something an operator on a minqlxtended host would read and be actively misled by.

| Page | What was wrong |
|---|---|
| `operations/minqlx-logs.md` | Named `minqlx.log` throughout. A minqlxtended host writes `minqlxtended.log`. |
| `features/hooks.md` | Said `force_rate.so` is registered whenever 99k LAN rate is enabled. |
| `help/deployment-troubleshooting.md` | Nothing at all on the Python floor. |
| `getting-started/introduction.md` | Feature list never mentioned that a host has a runtime. |

## The two that actually mattered

**`hooks.md`** — on minqlxtended, every instance runs at 99k *and* `force_rate.so` is deliberately never loaded, because the fork patches the same function itself and loading both stops the server from starting. An operator looking at the Hooks tab, seeing 99k active and no hook, would reasonably conclude something was broken and try to add it. The page now says the absence is correct and why.

**`deployment-troubleshooting.md`** — the Python floor had no troubleshooting entry, and the failure differs sharply by provider: cloud can't hit it, standalone is refused at the form before the host exists, and **self** has no pre-check at all — the host is created, setup fails, and it lands in Error with deletion the only way back. The entry also says to change the *distribution* rather than install a package, since Debian 12 has no `python3.12` in its archive, so "install Python 3.12" sends people down a dead end.

The log-filename fix is a documentation-only correction: `ViewMinqlxLogsModal` already picks the right file via `runtimeLogFilename`. Only the page was wrong.

## Verification

`mkdocs build --strict` — exit 0, zero warnings, all four new cross-links to `add-host.md#server-runtime` resolve.

No `VERSION` / `releases.md` bump — per the branch strategy that belongs on the final PR to `main`.

https://claude.ai/code/session_018T5f3ryb4q1kFavSjAaJFH
