### PR TITLE
fix: keep backup files out of preset export archives

### DIFF
--- a/tests/test_preset_download_routes.py
+++ b/tests/test_preset_download_routes.py
@@ -274,6 +274,7 @@ def test_download_preset_excludes_backup_files(client, app, tmp_path):
         'old\n',
     )
     write_file(preset_dir / 'scripts' / 'ranked.py.bak', 'older\n')
+    write_file(preset_dir / 'scripts' / 'ranked.py.bak.1', 'oldest\n')
     write_file(preset_dir / 'scripts' / 'ranked.py.orig', 'pre-merge\n')
     write_file(preset_dir / 'server.cfg.bak', 'set sv_hostname "Old"\n')
     write_file(preset_dir / 'scripts' / 'bakery.py', 'class bakery: pass\n')
@@ -288,6 +289,7 @@ def test_download_preset_excludes_backup_files(client, app, tmp_path):
         names = set(archive.namelist())
         assert 'scripts/ranked.py.bak-pre-player-ip-connected-20260704-222233' not in names
         assert 'scripts/ranked.py.bak' not in names
+        assert 'scripts/ranked.py.bak.1' not in names
         assert 'scripts/ranked.py.orig' not in names
         assert 'server.cfg.bak' not in names
         assert 'scripts/bakery.py' in names

--- a/tests/test_preset_download_routes.py
+++ b/tests/test_preset_download_routes.py
@@ -260,3 +260,34 @@ def test_download_builtin_preset_returns_403(client, app, tmp_path):
 
     assert response.status_code == 403
     assert response.get_json()['error']['message'] == 'Cannot download a built-in preset.'
+
+
+def test_download_preset_excludes_backup_files(client, app, tmp_path):
+    """Backups sitting in a preset must stay out of the export archive.
+
+    The import validator only accepts known script extensions, so exporting a
+    stray .bak would produce an archive QLSM itself refuses to import.
+    """
+    preset_id, preset_dir = create_preset(app, tmp_path, name='backup-cruft')
+    write_file(
+        preset_dir / 'scripts' / 'ranked.py.bak-pre-player-ip-connected-20260704-222233',
+        'old\n',
+    )
+    write_file(preset_dir / 'scripts' / 'ranked.py.bak', 'older\n')
+    write_file(preset_dir / 'scripts' / 'ranked.py.orig', 'pre-merge\n')
+    write_file(preset_dir / 'server.cfg.bak', 'set sv_hostname "Old"\n')
+    write_file(preset_dir / 'scripts' / 'bakery.py', 'class bakery: pass\n')
+
+    response = client.get(
+        f'/api/presets/{preset_id}/download',
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 200
+    with read_zip(response) as archive:
+        names = set(archive.namelist())
+        assert 'scripts/ranked.py.bak-pre-player-ip-connected-20260704-222233' not in names
+        assert 'scripts/ranked.py.bak' not in names
+        assert 'scripts/ranked.py.orig' not in names
+        assert 'server.cfg.bak' not in names
+        assert 'scripts/bakery.py' in names

--- a/tests/test_preset_import_validation.py
+++ b/tests/test_preset_import_validation.py
@@ -328,3 +328,30 @@ def test_does_not_unwrap_when_manifest_already_at_root():
     raw = build_zip(extra={'notes/readme.txt': 'note\n'})
     bundle = parse_import_archive(raw)
     assert bundle['configs']['notes/readme.txt'] == 'note\n'
+
+
+def test_skips_backup_files_left_beside_scripts():
+    """A stray editor/tooling backup must not fail the whole import."""
+    raw = build_zip(extra={
+        'scripts/ranked.py': 'class ranked: pass\n',
+        'scripts/ranked.py.bak-pre-player-ip-connected-20260704-222233': 'old\n',
+        'scripts/ranked.py.bak': 'older\n',
+        'scripts/ranked.py.bak.1': 'oldest\n',
+        'scripts/ranked.py.orig': 'pre-merge\n',
+        'scripts/ranked.py.rej': 'rejected hunk\n',
+        'server.cfg.bak': 'set sv_hostname "Old"\n',
+    })
+    bundle = parse_import_archive(raw)
+    assert set(bundle['scripts']) == {'ranked.py'}
+    assert 'server.cfg.bak' not in bundle['configs']
+
+
+def test_keeps_scripts_whose_name_merely_contains_bak():
+    """The backup filter must not swallow legitimately named files."""
+    raw = build_zip(extra={
+        'scripts/bakery.py': 'class bakery: pass\n',
+        'notes/bakery.txt': 'not a backup\n',
+    })
+    bundle = parse_import_archive(raw)
+    assert 'bakery.py' in bundle['scripts']
+    assert 'notes/bakery.txt' in bundle['configs']

--- a/tests/test_preset_routes.py
+++ b/tests/test_preset_routes.py
@@ -1651,3 +1651,43 @@ def test_update_preset_from_draft_drops_backup_files(client, app):
     preset_hooks = os.path.join(preset_path, 'user-hooks')
     assert os.path.exists(os.path.join(preset_hooks, 'myhook.so'))
     assert not os.path.exists(os.path.join(preset_hooks, 'myhook.so.bak'))
+
+
+def test_create_preset_from_draft_drops_backup_files(client, app):
+    """The create route copies drafts through its own call site -- cover it too.
+
+    create_preset_api and update_preset_api each carry their own near-identical
+    draft->preset copy, so a fix applied to one of them is not proof about the
+    other. This repo has been bitten by exactly that shape before.
+    """
+    draft_id = str(uuid.uuid4())
+    draft_base = os.path.join(app.config['DRAFTS_BASE'], draft_id)
+    draft_scripts = os.path.join(draft_base, 'scripts')
+    draft_hooks = os.path.join(draft_base, 'user-hooks')
+    os.makedirs(draft_scripts, exist_ok=True)
+    os.makedirs(draft_hooks, exist_ok=True)
+    backup_name = 'ranked.py.bak-pre-player-ip-connected-20260704-222233'
+    with open(os.path.join(draft_scripts, 'ranked.py'), 'w') as f:
+        f.write('print("ranked")')
+    with open(os.path.join(draft_scripts, backup_name), 'w') as f:
+        f.write('print("old ranked")')
+    with open(os.path.join(draft_hooks, 'myhook.so'), 'wb') as f:
+        f.write(b'\x7fELF')
+    with open(os.path.join(draft_hooks, 'myhook.so.bak'), 'wb') as f:
+        f.write(b'\x7fELF old')
+
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.post('/api/presets/', headers=headers, json={
+        'name': 'create-drops-backups',
+        'description': 'created from a draft holding backups',
+        'draft_id': draft_id,
+    })
+
+    assert response.status_code == 201
+    preset_path = os.path.join('configs', 'presets', 'create-drops-backups')
+    assert os.path.exists(os.path.join(preset_path, 'scripts', 'ranked.py'))
+    assert not os.path.exists(os.path.join(preset_path, 'scripts', backup_name))
+    assert os.path.exists(os.path.join(preset_path, 'user-hooks', 'myhook.so'))
+    assert not os.path.exists(
+        os.path.join(preset_path, 'user-hooks', 'myhook.so.bak')
+    )

--- a/tests/test_preset_routes.py
+++ b/tests/test_preset_routes.py
@@ -1625,6 +1625,15 @@ def test_update_preset_from_draft_drops_backup_files(client, app):
     with open(os.path.join(draft_scripts, 'bakery.py'), 'w') as f:
         f.write('class bakery: pass')
 
+    # user-hooks travels the same draft->preset copy and must be filtered too,
+    # or the preset keeps a file its own export drops.
+    draft_hooks = os.path.join(app.config['DRAFTS_BASE'], draft_id, 'user-hooks')
+    os.makedirs(draft_hooks, exist_ok=True)
+    with open(os.path.join(draft_hooks, 'myhook.so'), 'wb') as f:
+        f.write(b'\x7fELF')
+    with open(os.path.join(draft_hooks, 'myhook.so.bak'), 'wb') as f:
+        f.write(b'\x7fELF old')
+
     preset_id, preset_path = _create_preset_folder(app, 'draft-drops-backups')
 
     headers = auth_headers(app, DEFAULT_USER)
@@ -1638,3 +1647,7 @@ def test_update_preset_from_draft_drops_backup_files(client, app):
     assert not os.path.exists(os.path.join(preset_scripts, backup_name))
     # The filter must not swallow a legitimately named script.
     assert os.path.exists(os.path.join(preset_scripts, 'bakery.py'))
+
+    preset_hooks = os.path.join(preset_path, 'user-hooks')
+    assert os.path.exists(os.path.join(preset_hooks, 'myhook.so'))
+    assert not os.path.exists(os.path.join(preset_hooks, 'myhook.so.bak'))

--- a/tests/test_preset_routes.py
+++ b/tests/test_preset_routes.py
@@ -1607,11 +1607,12 @@ def test_overwriting_a_preset_with_an_unfiltered_draft_is_allowed(client, app):
     assert os.path.exists(os.path.join(preset_path, 'scripts', 'essentials.py'))
 
 
-def test_update_preset_from_draft_keeps_user_backup_files(client, app):
-    """Backups a user keeps beside their scripts survive the draft round-trip.
+def test_update_preset_from_draft_drops_backup_files(client, app):
+    """A backup that reaches a draft must not be written into the preset.
 
-    Preset archives drop .bak files, but saving a preset rewrites the real
-    scripts directory -- filtering there would delete the user's own backups.
+    A preset is a curated artefact, and its own export drops .bak files -- so
+    letting one land here would make the preset on disk differ from the archive
+    it produces, and the file could never survive a round-trip anyway.
     """
     draft_id = str(uuid.uuid4())
     draft_scripts = os.path.join(app.config['DRAFTS_BASE'], draft_id, 'scripts')
@@ -1621,8 +1622,10 @@ def test_update_preset_from_draft_keeps_user_backup_files(client, app):
         f.write('print("ranked")')
     with open(os.path.join(draft_scripts, backup_name), 'w') as f:
         f.write('print("old ranked")')
+    with open(os.path.join(draft_scripts, 'bakery.py'), 'w') as f:
+        f.write('class bakery: pass')
 
-    preset_id, preset_path = _create_preset_folder(app, 'draft-keeps-backups')
+    preset_id, preset_path = _create_preset_folder(app, 'draft-drops-backups')
 
     headers = auth_headers(app, DEFAULT_USER)
     response = client.put(f'/api/presets/{preset_id}', headers=headers, json={
@@ -1632,4 +1635,6 @@ def test_update_preset_from_draft_keeps_user_backup_files(client, app):
     assert response.status_code == 200
     preset_scripts = os.path.join(preset_path, 'scripts')
     assert os.path.exists(os.path.join(preset_scripts, 'ranked.py'))
-    assert os.path.exists(os.path.join(preset_scripts, backup_name))
+    assert not os.path.exists(os.path.join(preset_scripts, backup_name))
+    # The filter must not swallow a legitimately named script.
+    assert os.path.exists(os.path.join(preset_scripts, 'bakery.py'))

--- a/tests/test_preset_routes.py
+++ b/tests/test_preset_routes.py
@@ -1605,3 +1605,31 @@ def test_overwriting_a_preset_with_an_unfiltered_draft_is_allowed(client, app):
 
     assert response.status_code == 200
     assert os.path.exists(os.path.join(preset_path, 'scripts', 'essentials.py'))
+
+
+def test_update_preset_from_draft_keeps_user_backup_files(client, app):
+    """Backups a user keeps beside their scripts survive the draft round-trip.
+
+    Preset archives drop .bak files, but saving a preset rewrites the real
+    scripts directory -- filtering there would delete the user's own backups.
+    """
+    draft_id = str(uuid.uuid4())
+    draft_scripts = os.path.join(app.config['DRAFTS_BASE'], draft_id, 'scripts')
+    os.makedirs(draft_scripts, exist_ok=True)
+    backup_name = 'ranked.py.bak-pre-player-ip-connected-20260704-222233'
+    with open(os.path.join(draft_scripts, 'ranked.py'), 'w') as f:
+        f.write('print("ranked")')
+    with open(os.path.join(draft_scripts, backup_name), 'w') as f:
+        f.write('print("old ranked")')
+
+    preset_id, preset_path = _create_preset_folder(app, 'draft-keeps-backups')
+
+    headers = auth_headers(app, DEFAULT_USER)
+    response = client.put(f'/api/presets/{preset_id}', headers=headers, json={
+        'draft_id': draft_id,
+    })
+
+    assert response.status_code == 200
+    preset_scripts = os.path.join(preset_path, 'scripts')
+    assert os.path.exists(os.path.join(preset_scripts, 'ranked.py'))
+    assert os.path.exists(os.path.join(preset_scripts, backup_name))

--- a/ui/routes/preset_api_routes.py
+++ b/ui/routes/preset_api_routes.py
@@ -51,13 +51,15 @@ PROTECTED_CONFIG_FILES = set(CONFIG_FILE_MAP.keys())
 EXPORT_FORMAT_VERSION = 1
 EXPORT_EXCLUDED_DIRS = {'__pycache__'}
 EXPORT_EXCLUDED_FILES = {'.DS_Store', '.gitkeep'}
-EXPORT_EXCLUDED_PATTERNS = ('*.pyc', '*.pyo', '*.swp', '*.tmp', '*~')
-# Backup copies left by editors and tooling (foo.py.bak, foo.py.bak-pre-x-<stamp>,
-# foo.py.orig). Archives must drop them: their extensions aren't in the import
-# validator's allowlist, so exporting one produced a ZIP QLSM itself rejected with
-# "Unsupported script file". Only the archive filter uses these -- draft saves
-# rewrite the real scripts directory, where a user's backups have to survive.
-ARCHIVE_EXCLUDED_PATTERNS = ('*.bak', '*.bak-*', '*.bak.*', '*.orig', '*.rej')
+# The trailing five are backup copies left by editors and tooling (foo.py.bak,
+# foo.py.bak-pre-x-<stamp>, foo.py.bak.1, foo.py.orig, foo.py.rej). A preset is a
+# curated artefact, so they are junk on every path, not just in archives: their
+# extensions aren't in the import validator's allowlist, so a preset holding one
+# exports to a ZIP QLSM itself rejects with "Unsupported script file".
+EXPORT_EXCLUDED_PATTERNS = (
+    '*.pyc', '*.pyo', '*.swp', '*.tmp', '*~',
+    '*.bak', '*.bak-*', '*.bak.*', '*.orig', '*.rej',
+)
 
 
 def _safe_export_filename(name):
@@ -68,7 +70,13 @@ def _safe_export_filename(name):
     return safe or 'preset'
 
 
-def _matches_excluded_path(relative_path, is_dir, patterns):
+def _should_skip_export_path(relative_path, is_dir=False):
+    """Return True for generated/editor junk that should not enter a preset.
+
+    One filter for every path -- export, import and draft save -- so a preset on
+    disk, the archive it exports to, and the archive that imports back are all the
+    same set of files.
+    """
     parts = relative_path.replace(os.sep, '/').split('/')
     if any(part in EXPORT_EXCLUDED_DIRS for part in parts):
         return True
@@ -77,32 +85,15 @@ def _matches_excluded_path(relative_path, is_dir, patterns):
         return name in EXPORT_EXCLUDED_DIRS
     if name in EXPORT_EXCLUDED_FILES:
         return True
-    return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
-
-
-def _should_skip_export_path(relative_path, is_dir=False):
-    """Return True for junk that should not enter a preset archive.
-
-    Shared by export and import so an archive QLSM writes is one QLSM accepts.
-    """
-    return _matches_excluded_path(
-        relative_path, is_dir, EXPORT_EXCLUDED_PATTERNS + ARCHIVE_EXCLUDED_PATTERNS
-    )
+    return any(fnmatch.fnmatch(name, pattern) for pattern in EXPORT_EXCLUDED_PATTERNS)
 
 
 def _ignore_generated_script_cruft(directory, names):
-    """Return generated/editor junk to skip when saving draft scripts.
-
-    Narrower than the archive filter on purpose: saving a preset replaces its
-    scripts directory outright, so backups the user keeps there must be copied
-    through rather than silently deleted.
-    """
+    """Return generated/editor junk to skip when saving draft scripts."""
     ignored = []
     for name in names:
         path = os.path.join(directory, name)
-        if _matches_excluded_path(
-            name, os.path.isdir(path), EXPORT_EXCLUDED_PATTERNS
-        ):
+        if _should_skip_export_path(name, is_dir=os.path.isdir(path)):
             ignored.append(name)
     return ignored
 

--- a/ui/routes/preset_api_routes.py
+++ b/ui/routes/preset_api_routes.py
@@ -51,7 +51,7 @@ PROTECTED_CONFIG_FILES = set(CONFIG_FILE_MAP.keys())
 EXPORT_FORMAT_VERSION = 1
 EXPORT_EXCLUDED_DIRS = {'__pycache__'}
 EXPORT_EXCLUDED_FILES = {'.DS_Store', '.gitkeep'}
-# The trailing five are backup copies left by editors and tooling (foo.py.bak,
+# The trailing group are backup copies left by editors and tooling (foo.py.bak,
 # foo.py.bak-pre-x-<stamp>, foo.py.bak.1, foo.py.orig, foo.py.rej). A preset is a
 # curated artefact, so they are junk on every path, not just in archives: their
 # extensions aren't in the import validator's allowlist, so a preset holding one
@@ -89,7 +89,10 @@ def _should_skip_export_path(relative_path, is_dir=False):
 
 
 def _ignore_generated_script_cruft(directory, names):
-    """Return generated/editor junk to skip when saving draft scripts."""
+    """Return generated/editor junk to skip when copying a draft into a preset.
+
+    Used for both directories a draft contributes: scripts and user-hooks.
+    """
     ignored = []
     for name in names:
         path = os.path.join(directory, name)

--- a/ui/routes/preset_api_routes.py
+++ b/ui/routes/preset_api_routes.py
@@ -1137,7 +1137,12 @@ def create_preset_api():
             draft_user_hooks = _get_draft_user_hooks_path(draft_id)
             preset_user_hooks = os.path.join(preset_path, 'user-hooks')
             if os.path.isdir(draft_user_hooks):
-                shutil.copytree(draft_user_hooks, preset_user_hooks, dirs_exist_ok=True)
+                shutil.copytree(
+                    draft_user_hooks,
+                    preset_user_hooks,
+                    dirs_exist_ok=True,
+                    ignore=_ignore_generated_script_cruft,
+                )
             # Don't delete the draft — the form continues using it after preset save
         elif 'scripts' in data:
             _write_preset_scripts(
@@ -1406,7 +1411,12 @@ def update_preset_api(preset_id):
             draft_user_hooks = _get_draft_user_hooks_path(draft_id)
             preset_user_hooks = os.path.join(preset.path, 'user-hooks')
             if os.path.isdir(draft_user_hooks):
-                shutil.copytree(draft_user_hooks, preset_user_hooks, dirs_exist_ok=True)
+                shutil.copytree(
+                    draft_user_hooks,
+                    preset_user_hooks,
+                    dirs_exist_ok=True,
+                    ignore=_ignore_generated_script_cruft,
+                )
             # Don't delete the draft — the form continues using it after preset save
         elif 'scripts' in data:
             _write_preset_scripts(

--- a/ui/routes/preset_api_routes.py
+++ b/ui/routes/preset_api_routes.py
@@ -52,6 +52,12 @@ EXPORT_FORMAT_VERSION = 1
 EXPORT_EXCLUDED_DIRS = {'__pycache__'}
 EXPORT_EXCLUDED_FILES = {'.DS_Store', '.gitkeep'}
 EXPORT_EXCLUDED_PATTERNS = ('*.pyc', '*.pyo', '*.swp', '*.tmp', '*~')
+# Backup copies left by editors and tooling (foo.py.bak, foo.py.bak-pre-x-<stamp>,
+# foo.py.orig). Archives must drop them: their extensions aren't in the import
+# validator's allowlist, so exporting one produced a ZIP QLSM itself rejected with
+# "Unsupported script file". Only the archive filter uses these -- draft saves
+# rewrite the real scripts directory, where a user's backups have to survive.
+ARCHIVE_EXCLUDED_PATTERNS = ('*.bak', '*.bak-*', '*.bak.*', '*.orig', '*.rej')
 
 
 def _safe_export_filename(name):
@@ -62,8 +68,7 @@ def _safe_export_filename(name):
     return safe or 'preset'
 
 
-def _should_skip_export_path(relative_path, is_dir=False):
-    """Return True for generated/editor junk that should not enter exports."""
+def _matches_excluded_path(relative_path, is_dir, patterns):
     parts = relative_path.replace(os.sep, '/').split('/')
     if any(part in EXPORT_EXCLUDED_DIRS for part in parts):
         return True
@@ -72,15 +77,32 @@ def _should_skip_export_path(relative_path, is_dir=False):
         return name in EXPORT_EXCLUDED_DIRS
     if name in EXPORT_EXCLUDED_FILES:
         return True
-    return any(fnmatch.fnmatch(name, pattern) for pattern in EXPORT_EXCLUDED_PATTERNS)
+    return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
+
+
+def _should_skip_export_path(relative_path, is_dir=False):
+    """Return True for junk that should not enter a preset archive.
+
+    Shared by export and import so an archive QLSM writes is one QLSM accepts.
+    """
+    return _matches_excluded_path(
+        relative_path, is_dir, EXPORT_EXCLUDED_PATTERNS + ARCHIVE_EXCLUDED_PATTERNS
+    )
 
 
 def _ignore_generated_script_cruft(directory, names):
-    """Return generated/editor junk to skip when saving draft scripts."""
+    """Return generated/editor junk to skip when saving draft scripts.
+
+    Narrower than the archive filter on purpose: saving a preset replaces its
+    scripts directory outright, so backups the user keeps there must be copied
+    through rather than silently deleted.
+    """
     ignored = []
     for name in names:
         path = os.path.join(directory, name)
-        if _should_skip_export_path(name, is_dir=os.path.isdir(path)):
+        if _matches_excluded_path(
+            name, os.path.isdir(path), EXPORT_EXCLUDED_PATTERNS
+        ):
             ignored.append(name)
     return ignored
 


### PR DESCRIPTION
## Problem

Importing a preset export failed with `400`:

```
Unsupported script file: scripts/ranked.py.bak-pre-player-ip-connected-20260704-222233
```

Export and import disagreed about what belongs in a preset archive:

- **Export** (`_build_preset_export_zip`) walks the whole preset directory and includes anything not matching `EXPORT_EXCLUDED_PATTERNS` — only `*.pyc, *.pyo, *.swp, *.tmp, *~`. A backup file left beside a script didn't match, so it went into the ZIP.
- **Import** (`_validate_script_path`) allows only `.py`, `.txt`, `.so` and font extensions under `scripts/`, and hard-fails the entire archive on anything else.

So QLSM was writing archives QLSM itself refuses to import.

## Fix

Add `ARCHIVE_EXCLUDED_PATTERNS = ('*.bak', '*.bak-*', '*.bak.*', '*.orig', '*.rej')` and apply it in `_should_skip_export_path`, which export **and** import both call. Archives already exported with a stray backup now import cleanly — no re-export needed.

Patterns are deliberately precise rather than `*.bak*`, so a legitimately named `bakery.py` isn't swallowed.

## What is intentionally not changed

`_ignore_generated_script_cruft` stays on the narrower list. It feeds the `copytree` that repopulates a preset's `scripts/` directory after an `rmtree` (`preset_api_routes.py:1122`, `:1391`), so filtering backups there would silently delete a user's own `.bak` files on the next preset save. The helper is split into `_matches_excluded_path` so the archive filter can be broad while the draft-save filter stays narrow.

## Tests

- `test_skips_backup_files_left_beside_scripts` — the reported filename plus `.bak`, `.bak.1`, `.orig`, `.rej`, and a root-level `server.cfg.bak`
- `test_keeps_scripts_whose_name_merely_contains_bak` — guards against over-broad patterns
- `test_download_preset_excludes_backup_files` — export side
- `test_update_preset_from_draft_keeps_user_backup_files` — regression guard for the deletion side effect above

The first three fail without the fix. The fourth passes before and after — that's its purpose.

## Known limitation

This addresses the backup-file class. The underlying export/import asymmetry remains: any other unexpected extension under `scripts/` (a stray `.md`, `.json`) still 400s the whole import. Making the importer skip-with-warning instead of hard-failing is a behavior change with a security-boundary tradeoff, so it's left for a separate discussion.