### PR TITLE
fix: symlink CLAUDE.md and .claude/ into new worktrees

### DIFF
--- a/setup-worktree.sh
+++ b/setup-worktree.sh
@@ -55,6 +55,8 @@ if [[ -n "$source_worktree" && "$source_worktree" != "$script_dir" ]]; then
         ln -s "$source_worktree/CLAUDE.md" CLAUDE.md
     elif [[ -e CLAUDE.md ]]; then
         log "CLAUDE.md already exists."
+    else
+        warn "No CLAUDE.md found in this worktree or $source_worktree."
     fi
 
     if [[ ! -e .claude && -d "$source_worktree/.claude" ]]; then

--- a/setup-worktree.sh
+++ b/setup-worktree.sh
@@ -49,6 +49,20 @@ if [[ -n "$source_worktree" && "$source_worktree" != "$script_dir" ]]; then
         mkdir -p configs
         cp -an "$source_worktree/configs/." configs/
     fi
+
+    if [[ ! -e CLAUDE.md && -f "$source_worktree/CLAUDE.md" ]]; then
+        log "Linking CLAUDE.md -> $source_worktree/CLAUDE.md"
+        ln -s "$source_worktree/CLAUDE.md" CLAUDE.md
+    elif [[ -e CLAUDE.md ]]; then
+        log "CLAUDE.md already exists."
+    fi
+
+    if [[ ! -e .claude && -d "$source_worktree/.claude" ]]; then
+        log "Linking .claude -> $source_worktree/.claude"
+        ln -s "$source_worktree/.claude" .claude
+    elif [[ -e .claude ]]; then
+        log ".claude already exists."
+    fi
 else
     [[ -f .env ]] && log ".env already exists." || warn "No .env found."
 fi


### PR DESCRIPTION
## Summary
- `CLAUDE.md` and everything under `.claude/` (skills, rules, commands, settings) are gitignored in this repo (strict allowlist, never un-ignored), so `git worktree add` never materializes them into a new worktree.
- `setup-worktree.sh` already copies `.env` and `configs/` from the source worktree but had no equivalent step for project instructions/skills — confirmed empirically that existing worktrees are missing both `CLAUDE.md` and `.claude/skills` entirely.
- Adds two symlink steps (not copies, to avoid drift) so a new worktree's `CLAUDE.md` and `.claude/` point back at the source worktree's copies and stay in sync automatically.

## Test plan
- [x] Reviewed diff against existing `.env`/`configs/` copy logic for style consistency
- [ ] Run `./setup-worktree.sh` in a freshly created worktree and confirm `CLAUDE.md` and `.claude/` resolve as symlinks to the source worktree